### PR TITLE
Correct tensorflow/swift Installation readme link

### DIFF
--- a/MNIST/README.md
+++ b/MNIST/README.md
@@ -4,7 +4,7 @@ This directory builds a two-layer perceptron to classify the [MNIST dataset](htt
 
 ## Setup
 
-To begin, you'll need the [latest version of Swift for TensorFlow](https://github.com/tensorflow/swift/blob/master/INSTALLATION.md) installed.
+To begin, you'll need the [latest version of Swift for TensorFlow](https://github.com/tensorflow/swift/blob/master/Installation.md) installed.
 Make sure you've added the correct version of `swift` to your path.
 
 To train the model, run:


### PR DESCRIPTION
This fixes the link to the Swift for TensorFlow installation instructions, as github's links are case sensitive.