### PR TITLE
A few fixes to the MNIST model:

### DIFF
--- a/MNIST/MNIST.swift
+++ b/MNIST/MNIST.swift
@@ -18,7 +18,7 @@ import TensorFlow
 /// Returns the images tensor and labels tensor.
 public func readMnist(
     imagesFile: String, labelsFile: String
-) -> (Tensor<Float>, Tensor<Int32>, Tensor<Float>) {
+) -> (Tensor<Float>, Tensor<Int32>) {
     print("Reading data.")
     let imageData =
         try! Data(contentsOf: URL(fileURLWithPath: imagesFile)).dropFirst(16)
@@ -32,9 +32,7 @@ public func readMnist(
     print("Constructing data tensors.")
     let imagesTensor = Tensor(shape: [rowCount, columnCount], scalars: images)
     let labelsTensor = Tensor(labels)
-    return (imagesTensor.toDevice(),
-            labelsTensor.toDevice(),
-            Tensor<Float>(Float(rowCount)).toDevice())
+    return (imagesTensor.toDevice(), labelsTensor.toDevice())
 }
 
 func main() {
@@ -51,8 +49,8 @@ func main() {
         scriptDirectory.appendingPathComponent("train-images-idx3-ubyte").path
     let labelsFile =
         scriptDirectory.appendingPathComponent("train-labels-idx1-ubyte").path
-    let (images, numericLabels, batchSize) = readMnist(imagesFile: imagesFile,
-                                                       labelsFile: labelsFile)
+    let (images, numericLabels) = readMnist(imagesFile: imagesFile,
+                                            labelsFile: labelsFile)
     let labels = Tensor<Float>(oneHotAtIndices: numericLabels, depth: 10)
     // FIXME: Defining batchSize tensor as follows instead of returning it from
     // readMnist() crashes the compiler: https://bugs.swift.org/browse/SR-7706


### PR DESCRIPTION
1. Normalized a few gradient values by the bach size.
2. Changed the loss function from MSE to cross entropy, which works with the
hard-coded gradients.

The change of loss values across training iterations before this CL:

Begin training for 20 iterations.
0.9
0.1
0.1
0.1
0.1
0.1
0.1
0.1
0.1
0.177527
0.25868
0.581863
0.18193
0.1
0.1
0.1
0.1
0.1
0.177527
0.1
0.1

After this CL:

Begin training for 20 iterations.
nan
113.156
88.0401
62.9524
38.1512
16.3276
5.25584
3.61207
3.37472
3.30145
3.2731
3.26038
3.2549
3.25211
3.25062
3.2499
3.24947
3.2495
3.24934
3.24926
3.24926

There might be further tuning opportunities with learning rate, etc, but is beyond the scope of this CL.

Working on this CL exposed a few compiler bugs. Left FIXME comments accordingly,
and will file bugs.