### PR TITLE
Use `#file` to get Swift script location.

### DIFF
--- a/Autoencoder/Autoencoder.swift
+++ b/Autoencoder/Autoencoder.swift
@@ -21,8 +21,7 @@ let outputFolder = "/tmp/mnist-test/"
 
 func readDataset() -> (images: Tensor<Float>, labels: Tensor<Int32>)? {
     print("Reading the data.")
-    guard let swiftFile = CommandLine.arguments.first else { return nil }
-    let swiftFileURL = URL(fileURLWithPath: swiftFile)
+    let swiftFileURL = URL(fileURLWithPath: #file)
     var imageFolderURL = swiftFileURL.deletingLastPathComponent()
     var labelFolderURL = swiftFileURL.deletingLastPathComponent()
     imageFolderURL.appendPathComponent("Resources/train-images-idx3-ubyte")

--- a/MNIST/MNIST.swift
+++ b/MNIST/MNIST.swift
@@ -41,11 +41,9 @@ struct MNISTParameters : ParameterAggregate {
 
 /// Train a MNIST classifier for the specified number of iterations.
 func train(_ parameters: inout MNISTParameters, iterationCount: Int) {
-    // Get script directory. This is necessary for MNIST.swift to work when
-    // invoked from any directory.
-    let currentDirectory = URL(fileURLWithPath: FileManager.default.currentDirectoryPath)
-    let currentScriptPath = URL(fileURLWithPath: CommandLine.arguments[0],
-                                relativeTo: currentDirectory)
+    // Get script path. This is necessary for MNIST.swift to work when invoked
+    // from any directory.
+    let currentScriptPath = URL(fileURLWithPath: #file)
     let scriptDirectory = currentScriptPath.deletingLastPathComponent()
 
     // Get training data.


### PR DESCRIPTION
Using `CommandLine.arguments[0]` to get the Swift script location is
unrobust. `arguments[0]` differs when running `swift` directly vs.
invoking `swiftc` then running the compiled binary.