### PR TITLE
[MNIST] Implement minibatch gradient descent and print accuracy.

### DIFF
--- a/MNIST/MNIST.swift
+++ b/MNIST/MNIST.swift
@@ -105,9 +105,10 @@ func train(_ parameters: inout MNISTParameters, epochCount: Int32) {
             // unnecessary for single-label classification tasks like MNIST.
             // Sigmoid cross-entropy formula from:
             // https://www.tensorflow.org/api_docs/python/tf/nn/sigmoid_cross_entropy_with_logits
-            let part1 = max(predictions, 0) - predictions * labels
-            let part2 = log(1 + exp(-abs(predictions)))
-            loss = ((part1 + part2).sum(squeezingAxes: 0, 1) / batchSize).scalarized()
+
+            // let part1 = max(predictions, 0) - predictions * labels
+            // let part2 = log(1 + exp(-abs(predictions)))
+            // loss = ((part1 + part2).sum(squeezingAxes: 0, 1) / batchSize).scalarized()
 
             // Update number of correct/total guesses.
             let correctPredictions = predictions.argmax(squeezingAxis: 1).elementsEqual(numericLabels)

--- a/MNIST/MNIST.swift
+++ b/MNIST/MNIST.swift
@@ -33,8 +33,8 @@ func readMNIST(imagesFile: String, labelsFile: String) -> (images: Tensor<Float>
 
 /// Parameters of an MNIST classifier.
 struct MNISTParameters : ParameterAggregate {
-    var w1 = Tensor<Float>(randomUniform: [784, 30]) * 0.1
-    var w2 = Tensor<Float>(randomUniform: [30, 10]) * 0.1
+    var w1 = Tensor<Float>(randomNormal: [784, 30])
+    var w2 = Tensor<Float>(randomNormal: [30, 10])
     var b1 = Tensor<Float>(zeros: [1, 30])
     var b2 = Tensor<Float>(zeros: [1, 10])
 }
@@ -62,7 +62,8 @@ func train(_ parameters: inout MNISTParameters, epochCount: Int32) {
     print("Begin training for \(epochCount) epochs.")
 
     func minibatch<Scalar>(_ x: Tensor<Scalar>, index: Int32) -> Tensor<Scalar> {
-      return x[index*minibatchSize..<(index+1)*minibatchSize]
+      let start = index * minibatchSize
+      return x[start..<start+minibatchSize]
     }
 
     for _ in 0...epochCount {

--- a/MNIST/MNIST.swift
+++ b/MNIST/MNIST.swift
@@ -72,7 +72,8 @@ func train(_ parameters: inout MNISTParameters, epochCount: Int32) {
         var totalGuesses = 0
 
         // TODO: Randomly sample minibatches using TensorFlow dataset APIs.
-        for i in 0..<(Int32(batchSize)/minibatchSize) {
+        let iterationCount = Int32(batchSize) / minibatchSize
+        for i in 0..<iterationCount {
             let images = minibatch(images, index: i)
             let numericLabels = minibatch(numericLabels, index: i)
             let labels = minibatch(labels, index: i)

--- a/MNIST/MNIST.swift
+++ b/MNIST/MNIST.swift
@@ -33,14 +33,14 @@ func readMNIST(imagesFile: String, labelsFile: String) -> (images: Tensor<Float>
 
 /// Parameters of an MNIST classifier.
 struct MNISTParameters : ParameterAggregate {
-    var w1 = Tensor<Float>(randomUniform: [784, 30])
-    var w2 = Tensor<Float>(randomUniform: [30, 10])
+    var w1 = Tensor<Float>(randomUniform: [784, 30]) * 0.1
+    var w2 = Tensor<Float>(randomUniform: [30, 10]) * 0.1
     var b1 = Tensor<Float>(zeros: [1, 30])
     var b2 = Tensor<Float>(zeros: [1, 10])
 }
 
 /// Train a MNIST classifier for the specified number of epochs.
-func train(_ parameters: inout MNISTParameters, epochCount: Int) {
+func train(_ parameters: inout MNISTParameters, epochCount: Int32) {
     // Get script path. This is necessary for MNIST.swift to work when invoked
     // from any directory.
     let currentScriptPath = URL(fileURLWithPath: #file)
@@ -54,45 +54,68 @@ func train(_ parameters: inout MNISTParameters, epochCount: Int) {
     let batchSize = Float(images.shape[0])
 
     // Hyper-parameters.
+    let minibatchSize: Int32 = 10
     let learningRate: Float = 0.2
     var loss = Float.infinity
 
     // Training loop.
     print("Begin training for \(epochCount) epochs.")
 
+    func minibatch<Scalar>(_ x: Tensor<Scalar>, index: Int32) -> Tensor<Scalar> {
+      return x[index*minibatchSize..<(index+1)*minibatchSize]
+    }
+
     for _ in 0...epochCount {
-        // Forward pass.
-        let z1 = images • parameters.w1 + parameters.b1
-        let h1 = sigmoid(z1)
-        let z2 = h1 • parameters.w2 + parameters.b2
-        let predictions = sigmoid(z2)
+        // Store number of correct/total guesses, used to print accuracy.
+        var correctGuesses = 0
+        var totalGuesses = 0
 
-        // Backward pass. This will soon be replaced by automatic
-        // differentiation.
-        let dz2 = (predictions - labels) / batchSize
-        let dw2 = h1.transposed() • dz2
-        let db2 = dz2.sum(squeezingAxes: 0)
-        let dz1 = matmul(dz2, parameters.w2.transposed()) * h1 * (1 - h1)
-        let dw1 = images.transposed() • dz1
-        let db1 = dz1.sum(squeezingAxes: 0)
-        let gradients = MNISTParameters(w1: dw1, w2: dw2, b1: db1, b2: db2)
+        // TODO: Randomly sample minibatches using TensorFlow dataset APIs.
+        for i in 0..<(Int32(batchSize)/minibatchSize) {
+            let images = minibatch(images, index: i)
+            let numericLabels = minibatch(numericLabels, index: i)
+            let labels = minibatch(labels, index: i)
 
-        // Update parameters.
-        parameters.update(withGradients: gradients) { param, grad in
-            param -= grad * learningRate
+            // Forward pass.
+            let z1 = images • parameters.w1 + parameters.b1
+            let h1 = sigmoid(z1)
+            let z2 = h1 • parameters.w2 + parameters.b2
+            let predictions = sigmoid(z2)
+
+            // Backward pass. This will soon be replaced by automatic
+            // differentiation.
+            let dz2 = predictions - labels
+            let dw2 = h1.transposed() • dz2
+            let db2 = dz2.sum(squeezingAxes: 0)
+            let dz1 = matmul(dz2, parameters.w2.transposed()) * h1 * (1 - h1)
+            let dw1 = images.transposed() • dz1
+            let db1 = dz1.sum(squeezingAxes: 0)
+            let gradients = MNISTParameters(w1: dw1, w2: dw2, b1: db1, b2: db2)
+
+            // Update parameters.
+            parameters.update(withGradients: gradients) { param, grad in
+                param -= grad * learningRate
+            }
+
+            // Calculate the sigmoid-based cross-entropy loss.
+            // TODO: Use softmax-based cross-entropy loss instead. Sigmoid
+            // cross-entropy loss treats class labels as independent, which is
+            // unnecessary for single-label classification tasks like MNIST.
+            // Sigmoid cross-entropy formula from:
+            // https://www.tensorflow.org/api_docs/python/tf/nn/sigmoid_cross_entropy_with_logits
+            let part1 = max(predictions, 0) - predictions * labels
+            let part2 = log(1 + exp(-abs(predictions)))
+            loss = ((part1 + part2).sum(squeezingAxes: 0, 1) / batchSize).scalarized()
+
+            // Update number of correct/total guesses.
+            let correctPredictions = predictions.argmax(squeezingAxis: 1).elementsEqual(numericLabels)
+            correctGuesses += Int(Tensor<Int32>(correctPredictions).sum())
+            totalGuesses += Int(minibatchSize)
         }
-
-        // Calculate the sigmoid-based cross-entropy loss.
-        // TODO: Use softmax-based cross-entropy loss instead. Sigmoid
-        // cross-entropy loss treats class labels as independent, which is
-        // unnecessary for single-label classification tasks like MNIST.
-        // Sigmoid cross-entropy formula from:
-        // https://www.tensorflow.org/api_docs/python/tf/nn/sigmoid_cross_entropy_with_logits
-        let part1 = max(predictions, 0) - predictions * labels
-        let part2 = log(1 + exp(-abs(predictions)))
-        loss = ((part1 + part2).sum(squeezingAxes: 0, 1) / batchSize).scalarized()
-
-        print("Loss:", loss)
+        print("""
+              Accuracy: \(correctGuesses)/\(totalGuesses) \
+              (\(Float(correctGuesses) / Float(totalGuesses)))
+              """)
     }
 }
 


### PR DESCRIPTION
* Implement minibatch gradient descent.
  * TODO: Randomly sample minibatches using TensorFlow dataset APIs.
* Print accuracy (rather than loss) to clearly show that the model is improving.

Example output:
```
Reading data.
Constructing data tensors.
Begin training for 20 epochs.
Accuracy: 53172/60000 (0.8862)
Accuracy: 55651/60000 (0.92751664)
Accuracy: 56104/60000 (0.93506664)
Accuracy: 56390/60000 (0.93983334)
Accuracy: 56576/60000 (0.9429333)
Accuracy: 56810/60000 (0.9468333)
Accuracy: 56968/60000 (0.94946665)
Accuracy: 57105/60000 (0.95175)
Accuracy: 57228/60000 (0.9538)
Accuracy: 57358/60000 (0.95596665)
Accuracy: 57347/60000 (0.9557833)
Accuracy: 57357/60000 (0.95595)
Accuracy: 57367/60000 (0.9561167)
Accuracy: 57540/60000 (0.959)
Accuracy: 57545/60000 (0.9590833)
Accuracy: 57610/60000 (0.9601667)
Accuracy: 57657/60000 (0.96095)
Accuracy: 57632/60000 (0.9605333)
Accuracy: 57694/60000 (0.9615667)
Accuracy: 57722/60000 (0.96203333)
Accuracy: 57816/60000 (0.9636)
```