### PR TITLE
Add a pair of convolutional models for CIFAR10 image classification

### DIFF
--- a/CIFAR/data.swift
+++ b/CIFAR/data.swift
@@ -5,11 +5,11 @@ func maybeDownload(to directory: String = ".") {
     let subprocess = Python.import("subprocess")
     let path = Python.import("os.path")
     let filepath = "\(directory)/cifar-10-batches-py"
-    let isfile = Bool(path.isfile(filepath))!
-    if isfile {
+    let isdir = Bool(path.isdir(filepath))!
+    if !isdir {
         print("Downloading CIFAR data...")
         let command = "wget -nv -O- https://www.cs.toronto.edu/~kriz/cifar-10-python.tar.gz | tar xzf - -C \(directory)"
-        subprocess.call(command)
+        subprocess.call(command, shell: true)
     }
 }
 

--- a/CIFAR/data.swift
+++ b/CIFAR/data.swift
@@ -1,11 +1,15 @@
-import Glibc
 import Python
 import TensorFlow
 
 func maybeDownload(to directory: String = ".") {
-    if (access("\(directory)/cifar-10-batches-py", F_OK) == -1) {
-        print("downloading data...")
-        system("wget -nv -O- https://www.cs.toronto.edu/~kriz/cifar-10-python.tar.gz | tar xzf - -C \(directory)")
+    let subprocess = Python.import("subprocess")
+    let path = Python.import("os.path")
+    let filepath = "\(directory)/cifar-10-batches-py"
+    let isfile = Bool(path.isfile(filepath))!
+    if isfile {
+        print("Downloading CIFAR data...")
+        let command = "wget -nv -O- https://www.cs.toronto.edu/~kriz/cifar-10-python.tar.gz | tar xzf - -C \(directory)"
+        subprocess.call(command)
     }
 }
 

--- a/CIFAR/data.swift
+++ b/CIFAR/data.swift
@@ -1,0 +1,61 @@
+import Glibc
+import Python
+import TensorFlow
+
+func maybeDownload(to directory: String = ".") {
+    if (access("\(directory)/cifar-10-batches-py", F_OK) == -1) {
+        print("downloading data...")
+        system("wget -nv -O- https://www.cs.toronto.edu/~kriz/cifar-10-python.tar.gz | tar xzf - -C \(directory)")
+    }
+}
+
+func loadBatches(from file: String, in directory: String = ".")
+    -> (Tensor<Int32>, Tensor<Float>) {
+    maybeDownload(to: directory)
+    let np = Python.import("numpy")
+    let pickle = Python.import("pickle")
+    let path = "\(directory)/cifar-10-batches-py/\(file)"
+    let f = Python.open(path, "rb")
+    let res = pickle.load(f, encoding: "bytes")
+
+    let bytes = res[Python.bytes("data", encoding: "utf8")]
+    let labels = res[Python.bytes("labels", encoding: "utf8")]
+
+    let labelTensor = Tensor<Int64>(numpy: np.array(labels))!
+    let images = Tensor<UInt8>(numpy: bytes)!
+    let imageCount = images.shape[0]
+
+    // reshape and transpose from the provided N(CHW) to TF default NHWC
+    let imageTensor = Tensor<Float>(images
+        .reshaped(to: [imageCount, 3, 32, 32])
+        .transposed(withPermutations: [0, 2, 3, 1]))
+
+    return (Tensor<Int32>(labelTensor), imageTensor / Float(255.0))
+}
+
+func loadTrainingBatches() -> (Tensor<Int32>, Tensor<Float>) {
+  let data = (1..<6).map { loadBatches(from: "data_batch_\($0)") }
+  return (Raw.concat(concatDim: Tensor<Int32>(0), data.map { $0.0 }),
+  Raw.concat(concatDim: Tensor<Int32>(0), data.map { $0.1 }))
+}
+
+func loadTestBatches() -> (Tensor<Int32>, Tensor<Float>) {
+  return loadBatches(from: "test_batch")
+}
+
+extension Dataset where Element == TensorPair<Tensor<Int32>, Tensor<Float>> {
+  init(fromTuple: (Tensor<Int32>, Tensor<Float>)) {
+    self = zip(Dataset<Tensor<Int32>>(elements: fromTuple.0),
+               Dataset<Tensor<Float>>(elements: fromTuple.1))
+  }
+}
+
+public func loadCIFAR10() -> (
+    Dataset<TensorPair<Tensor<Int32>, Tensor<Float>>>,
+    Dataset<TensorPair<Tensor<Int32>, Tensor<Float>>>) {
+    let trainingDataset = Dataset<TensorPair<Tensor<Int32>, Tensor<Float>>>(
+        fromTuple: loadTrainingBatches())
+    let testDataset = Dataset<TensorPair<Tensor<Int32>, Tensor<Float>>>(
+        fromTuple: loadTestBatches())
+    return (trainingDataset, testDataset)
+}

--- a/CIFAR/main.swift
+++ b/CIFAR/main.swift
@@ -6,8 +6,8 @@ let (trainingDataset, testDataset) = loadCIFAR10()
 let trainingBatches = trainingDataset.batched(Int64(batchSize))
 let testBatches = testDataset.batched(Int64(batchSize))
 
-let modeRef = ModeRef()
-var net = CIFARNet() // modeRef: modeRef)
+let learningPhaseIndicator = LearningPhaseIndicator()
+var model = CIFARModel() // learningPhaseIndicator: LearningPhaseIndicator)
 
 // optimizer used in the PyTorch code
 let optimizer = SGD<CIFARNet, Float>(learningRate: 0.001, momentum: 0.9)
@@ -16,11 +16,11 @@ let optimizer = SGD<CIFARNet, Float>(learningRate: 0.001, momentum: 0.9)
 
 for epoch in 1...10 {
     print("Epoch \(epoch), training...")
-    modeRef.training = true
+    learningPhaseIndicator.training = true
     var trainingLossSum: Float = 0
     var trainingBatchCount = 0
     for batch in trainingBatches {
-        let gradients = gradient(at: net) {
+        let gradients = gradient(at: model) {
             (model: CIFARNet) -> Tensor<Float> in
             let thisLoss = loss(
                 model: model, images: batch.second, labels: batch.first)
@@ -28,16 +28,16 @@ for epoch in 1...10 {
             trainingBatchCount += 1
             return thisLoss
         }
-        optimizer.update(&net.allDifferentiableVariables, along: gradients)
+        optimizer.update(&model.allDifferentiableVariables, along: gradients)
     }
     print("  average loss: \(trainingLossSum / Float(trainingBatchCount))")
     print("Epoch \(epoch), evaluating on test set...")
-    modeRef.training = false
+    learningPhaseIndicator.training = false
     var testLossSum: Float = 0
     var testBatchCount = 0
     for batch in testBatches {
         testLossSum += loss(
-            model: net, images: batch.second, labels: batch.first).scalarized()
+        model: model, images: batch.second, labels: batch.first).scalarized()
         testBatchCount += 1
     }
     print("  average loss: \(testLossSum / Float(testBatchCount))")

--- a/CIFAR/main.swift
+++ b/CIFAR/main.swift
@@ -1,0 +1,44 @@
+import TensorFlow
+
+let batchSize: Int32 = 4
+
+let (trainingDataset, testDataset) = loadCIFAR10()
+let trainingBatches = trainingDataset.batched(Int64(batchSize))
+let testBatches = testDataset.batched(Int64(batchSize))
+
+let modeRef = ModeRef()
+var net = CIFARNet() // modeRef: modeRef)
+
+// optimizer used in the PyTorch code
+let optimizer = SGD<CIFARNet, Float>(learningRate: 0.001, momentum: 0.9)
+// optimizer used in the Keras code
+// let optimizer = RMSProp<CIFARNet, Float>(learningRate: 0.0001, decay: 1e-6)
+
+for epoch in 1...10 {
+    print("Epoch \(epoch), training...")
+    modeRef.training = true
+    var trainingLossSum: Float = 0
+    var trainingBatchCount = 0
+    for batch in trainingBatches {
+        let gradients = gradient(at: net) {
+            (model: CIFARNet) -> Tensor<Float> in
+            let thisLoss = loss(
+                model: model, images: batch.second, labels: batch.first)
+            trainingLossSum += thisLoss.scalarized()
+            trainingBatchCount += 1
+            return thisLoss
+        }
+        optimizer.update(&net.allDifferentiableVariables, along: gradients)
+    }
+    print("  average loss: \(trainingLossSum / Float(trainingBatchCount))")
+    print("Epoch \(epoch), evaluating on test set...")
+    modeRef.training = false
+    var testLossSum: Float = 0
+    var testBatchCount = 0
+    for batch in testBatches {
+        testLossSum += loss(
+            model: net, images: batch.second, labels: batch.first).scalarized()
+        testBatchCount += 1
+    }
+    print("  average loss: \(testLossSum / Float(testBatchCount))")
+}

--- a/CIFAR/main.swift
+++ b/CIFAR/main.swift
@@ -10,9 +10,9 @@ let learningPhaseIndicator = LearningPhaseIndicator()
 var model = CIFARModel() // learningPhaseIndicator: LearningPhaseIndicator)
 
 // optimizer used in the PyTorch code
-let optimizer = SGD<CIFARNet, Float>(learningRate: 0.001, momentum: 0.9)
+let optimizer = SGD<CIFARModel, Float>(learningRate: 0.001, momentum: 0.9)
 // optimizer used in the Keras code
-// let optimizer = RMSProp<CIFARNet, Float>(learningRate: 0.0001, decay: 1e-6)
+// let optimizer = RMSProp<CIFARModel, Float>(learningRate: 0.0001, decay: 1e-6)
 
 for epoch in 1...10 {
     print("Epoch \(epoch), training...")
@@ -21,7 +21,7 @@ for epoch in 1...10 {
     var trainingBatchCount = 0
     for batch in trainingBatches {
         let gradients = gradient(at: model) {
-            (model: CIFARNet) -> Tensor<Float> in
+            (model: CIFARModel) -> Tensor<Float> in
             let thisLoss = loss(
                 model: model, images: batch.second, labels: batch.first)
             trainingLossSum += thisLoss.scalarized()

--- a/CIFAR/models.swift
+++ b/CIFAR/models.swift
@@ -1,7 +1,7 @@
 import TensorFlow
 
 // Ported from pytorch.org/tutorials/beginner/blitz/cifar10_tutorial.html
-public struct PyTorchNet : Layer {
+public struct PyTorchModel : Layer {
     var conv1: Conv2D<Float>
     var pool: MaxPool2D<Float>
     var conv2: Conv2D<Float>
@@ -34,7 +34,7 @@ public struct PyTorchNet : Layer {
 }
 
 // Ported from github.com/keras-team/keras/blob/master/examples/cifar10_cnn.py
-public struct KerasNet : Layer {
+public struct KerasModel : Layer {
     var conv1a: Conv2D<Float>
     var conv1b: Conv2D<Float>
     var pool1: MaxPool2D<Float>
@@ -46,20 +46,23 @@ public struct KerasNet : Layer {
     var dense1: Dense<Float>
     var dropout3: Dropout<Float>
     var dense2: Dense<Float>
-    public init(modeRef: ModeRef) {
+    public init(learningPhaseIndicator: LearningPhaseIndicator) {
         conv1a = Conv2D<Float>(filterShape: (3, 3, 3, 32), padding: .same)
         conv1b = Conv2D<Float>(filterShape: (3, 3, 32, 32), padding: .valid)
         pool1 = MaxPool2D<Float>(
             poolSize: (2, 2), strides: (2, 2), padding: .valid)
-        dropout1 = Dropout<Float>(dropProbability: 0.25, modeRef: modeRef)
+        dropout1 = Dropout<Float>(
+            probability: 0.25, learningPhaseIndicator: learningPhaseIndicator)
         conv2a = Conv2D<Float>(filterShape: (3, 3, 32, 64), padding: .same)
         conv2b = Conv2D<Float>(filterShape: (3, 3, 64, 64), padding: .same)
         pool2 = MaxPool2D<Float>(
             poolSize: (2, 2), strides: (2, 2), padding: .valid)
-        dropout2 = Dropout<Float>(dropProbability: 0.25, modeRef: modeRef)
+        dropout2 = Dropout<Float>(
+            probability: 0.25, learningPhaseIndicator: learningPhaseIndicator)
         dense1 = Dense<Float>(
             inputSize: 64 * 7 * 7, outputSize: 512, activation: relu)
-        dropout3 = Dropout<Float>(dropProbability: 0.5, modeRef: modeRef)
+        dropout3 = Dropout<Float>(
+            probability: 0.5, learningPhaseIndicator: learningPhaseIndicator)
         dense2 = Dense<Float>(
             inputSize: 512, outputSize: 10, activation: { $0 })
     }
@@ -79,10 +82,10 @@ public struct KerasNet : Layer {
     }
 }
 
-public typealias CIFARNet = PyTorchNet
+public typealias CIFARModel = PyTorchModel
 
 @differentiable(wrt: model)
-public func loss(model: CIFARNet, images: Tensor<Float>, labels: Tensor<Int32>)
+public func loss(model: CIFARModel, images: Tensor<Float>, labels: Tensor<Int32>)
     -> Tensor<Float> {
     let logits = model.applied(to: images)
     let oneHotLabels = Tensor<Float>(

--- a/CIFAR/models.swift
+++ b/CIFAR/models.swift
@@ -1,0 +1,91 @@
+import TensorFlow
+
+// Ported from pytorch.org/tutorials/beginner/blitz/cifar10_tutorial.html
+public struct PyTorchNet : Layer {
+    var conv1: Conv2D<Float>
+    var pool: MaxPool2D<Float>
+    var conv2: Conv2D<Float>
+    var dense1: Dense<Float>
+    var dense2: Dense<Float>
+    var dense3: Dense<Float>
+    public init() {
+        conv1 = Conv2D<Float>(filterShape: (5, 5, 3, 6), padding: .valid)
+        pool = MaxPool2D<Float>(
+            poolSize: (2, 2), strides: (2, 2), padding: .valid)
+        conv2 = Conv2D<Float>(filterShape: (5, 5, 6, 16), padding: .valid)
+        dense1 = Dense<Float>(
+            inputSize: 16 * 5 * 5, outputSize: 120, activation: relu)
+        dense2 = Dense<Float>(inputSize: 120, outputSize: 84, activation: relu)
+        dense3 = Dense<Float>(inputSize: 84, outputSize: 10, activation: { $0 })
+    }
+    @differentiable(wrt: (self, input))
+    public func applied(to input: Tensor<Float>) -> Tensor<Float> {
+        var tmp = input
+        tmp = pool.applied(to: relu(conv1.applied(to: tmp)))
+        tmp = pool.applied(to: relu(conv2.applied(to: tmp)))
+        let batchSize = tmp.shape[0]
+        tmp = tmp.reshaped(
+            toShape: Tensor<Int32>([batchSize, Int32(16 * 5 * 5)]))
+        tmp = dense1.applied(to: tmp)
+        tmp = dense2.applied(to: tmp)
+        tmp = dense3.applied(to: tmp)
+        return tmp
+    }
+}
+
+// Ported from github.com/keras-team/keras/blob/master/examples/cifar10_cnn.py
+public struct KerasNet : Layer {
+    var conv1a: Conv2D<Float>
+    var conv1b: Conv2D<Float>
+    var pool1: MaxPool2D<Float>
+    var dropout1: Dropout<Float>
+    var conv2a: Conv2D<Float>
+    var conv2b: Conv2D<Float>
+    var pool2: MaxPool2D<Float>
+    var dropout2: Dropout<Float>
+    var dense1: Dense<Float>
+    var dropout3: Dropout<Float>
+    var dense2: Dense<Float>
+    public init(modeRef: ModeRef) {
+        conv1a = Conv2D<Float>(filterShape: (3, 3, 3, 32), padding: .same)
+        conv1b = Conv2D<Float>(filterShape: (3, 3, 32, 32), padding: .valid)
+        pool1 = MaxPool2D<Float>(
+            poolSize: (2, 2), strides: (2, 2), padding: .valid)
+        dropout1 = Dropout<Float>(dropProbability: 0.25, modeRef: modeRef)
+        conv2a = Conv2D<Float>(filterShape: (3, 3, 32, 64), padding: .same)
+        conv2b = Conv2D<Float>(filterShape: (3, 3, 64, 64), padding: .same)
+        pool2 = MaxPool2D<Float>(
+            poolSize: (2, 2), strides: (2, 2), padding: .valid)
+        dropout2 = Dropout<Float>(dropProbability: 0.25, modeRef: modeRef)
+        dense1 = Dense<Float>(
+            inputSize: 64 * 7 * 7, outputSize: 512, activation: relu)
+        dropout3 = Dropout<Float>(dropProbability: 0.5, modeRef: modeRef)
+        dense2 = Dense<Float>(
+            inputSize: 512, outputSize: 10, activation: { $0 })
+    }
+    @differentiable(wrt: (self, input))
+    public func applied(to input: Tensor<Float>) -> Tensor<Float> {
+        var tmp = input
+        tmp = relu(conv1b.applied(to: relu(conv1a.applied(to: tmp))))
+        tmp = dropout1.applied(to: pool1.applied(to: tmp))
+        tmp = relu(conv2b.applied(to: relu(conv2a.applied(to: tmp))))
+        tmp = dropout2.applied(to: pool2.applied(to: tmp))
+        let batchSize = tmp.shape[0]
+        tmp = tmp.reshaped(
+            toShape: Tensor<Int32>([batchSize, Int32(64 * 7 * 7)]))
+        tmp = dropout3.applied(to: dense1.applied(to: tmp))
+        tmp = dense2.applied(to: tmp)
+        return tmp
+    }
+}
+
+public typealias CIFARNet = PyTorchNet
+
+@differentiable(wrt: model)
+public func loss(model: CIFARNet, images: Tensor<Float>, labels: Tensor<Int32>)
+    -> Tensor<Float> {
+    let logits = model.applied(to: images)
+    let oneHotLabels = Tensor<Float>(
+        oneHotAtIndices: labels, depth: logits.shape[1])
+    return softmaxCrossEntropy(logits: logits, labels: oneHotLabels)
+}


### PR DESCRIPTION
These are intended to match the networks used in the canonical PyTorch 
and Keras CIFAR10 examples, but they don't currently converge to the 
correct loss. Requires https://github.com/rxwei/DeepLearning/pull/4 but no
compiler changes.