### PR TITLE
Fixes README for Transformer

### DIFF
--- a/Transformer/README.md
+++ b/Transformer/README.md
@@ -3,11 +3,16 @@
 This is an implementation of [OpenAI's GPT-2 Transformer language model](https://github.com/openai/gpt-2) using [Swift for TensorFlow](https://github.com/tensorflow/swift).
 
 In order to run this code, first download a pre-trained checkpoint from OpenAI
-using the included `download_model.sh` script. Then, compile using `swiftc`:
+using the included `download_model.sh` script. Script needs one parameter - model name.
 
 ```sh
-bash download_model.sh
-swiftc -O -ltensorflow Operators.swift Model.swift PythonCheckpointReader.swift main.swift
+bash download_model.sh 117M
+```
+
+Then, compile using `swiftc`:
+
+```sh
+swiftc -O -ltensorflow -o main Operators.swift Model.swift PythonCheckpointReader.swift main.swift
 ```
 
 You can now sample from the model either unconditionally:


### PR DESCRIPTION
* adds parameter for `download_model.sh`
* adds parameter `-o main` for `swiftc` to make following examples work