### PR TITLE
Remove uses of the obsolete TensorPair struct from models.

### DIFF
--- a/CIFAR/data.swift
+++ b/CIFAR/data.swift
@@ -15,7 +15,7 @@ func downloadCIFAR10IfNotPresent(to directory: String = ".") {
     }
 }
 
-public struct Example: TensorGroup {
+struct Example: TensorGroup {
     var label: Tensor<Int32>
     var data: Tensor<Float>
 }
@@ -60,7 +60,7 @@ func loadCIFARTestFile() -> Example {
     return loadCIFARFile(named: "test_batch")
 }
 
-public func loadCIFAR10() -> (
+func loadCIFAR10() -> (
   training: Dataset<Example>, test: Dataset<Example>) {
     let trainingDataset = Dataset<Example>(elements: loadCIFARTrainingFiles())
     let testDataset = Dataset<Example>(elements: loadCIFARTestFile())

--- a/CIFAR/data.swift
+++ b/CIFAR/data.swift
@@ -55,7 +55,9 @@ func loadCIFARTestFile() -> (Tensor<Int32>, Tensor<Float>) {
     return loadCIFARFile(named: "test_batch")
 }
 
-extension Dataset where Element == Zip2TensorGroup<Tensor<Int32>, Tensor<Float>> {
+public typealias Example = Zip2TensorGroup<Tensor<Int32>, Tensor<Float>>
+
+extension Dataset where Element == Example {
     init(_ tuple: (Tensor<Int32>, Tensor<Float>)) {
         self = zip(
             Dataset<Tensor<Int32>>(elements: tuple.0),
@@ -63,11 +65,8 @@ extension Dataset where Element == Zip2TensorGroup<Tensor<Int32>, Tensor<Float>>
     }
 }
 
-public func loadCIFAR10() -> (
-    Dataset<Zip2TensorGroup<Tensor<Int32>, Tensor<Float>>>,
-    Dataset<Zip2TensorGroup<Tensor<Int32>, Tensor<Float>>>) {
-    let trainingDataset = Dataset<Zip2TensorGroup<Tensor<Int32>, Tensor<Float>>>(
-        loadCIFARTrainingFiles())
-    let testDataset = Dataset<Zip2TensorGroup<Tensor<Int32>, Tensor<Float>>>(loadCIFARTestFile())
+public func loadCIFAR10() -> (Dataset<Example>, Dataset<Example>) {
+    let trainingDataset = Dataset<Example>(loadCIFARTrainingFiles())
+    let testDataset = Dataset<Example>(loadCIFARTestFile())
     return (trainingDataset, testDataset)
 }

--- a/CIFAR/data.swift
+++ b/CIFAR/data.swift
@@ -60,8 +60,9 @@ func loadCIFARTestFile() -> Example {
     return loadCIFARFile(named: "test_batch")
 }
 
-public func loadCIFAR10() -> (Dataset<Example>, Dataset<Example>) {
+public func loadCIFAR10() -> (
+  training: Dataset<Example>, test: Dataset<Example>) {
     let trainingDataset = Dataset<Example>(elements: loadCIFARTrainingFiles())
     let testDataset = Dataset<Example>(elements: loadCIFARTestFile())
-    return (trainingDataset, testDataset)
+    return (training: trainingDataset, test: testDataset)
 }

--- a/CIFAR/data.swift
+++ b/CIFAR/data.swift
@@ -55,7 +55,7 @@ func loadCIFARTestFile() -> (Tensor<Int32>, Tensor<Float>) {
     return loadCIFARFile(named: "test_batch")
 }
 
-extension Dataset where Element == TensorPair<Tensor<Int32>, Tensor<Float>> {
+extension Dataset where Element == Zip2TensorGroup<Tensor<Int32>, Tensor<Float>> {
     init(_ tuple: (Tensor<Int32>, Tensor<Float>)) {
         self = zip(
             Dataset<Tensor<Int32>>(elements: tuple.0),
@@ -64,10 +64,10 @@ extension Dataset where Element == TensorPair<Tensor<Int32>, Tensor<Float>> {
 }
 
 public func loadCIFAR10() -> (
-    Dataset<TensorPair<Tensor<Int32>, Tensor<Float>>>,
-    Dataset<TensorPair<Tensor<Int32>, Tensor<Float>>>) {
-    let trainingDataset = Dataset<TensorPair<Tensor<Int32>, Tensor<Float>>>(
+    Dataset<Zip2TensorGroup<Tensor<Int32>, Tensor<Float>>>,
+    Dataset<Zip2TensorGroup<Tensor<Int32>, Tensor<Float>>>) {
+    let trainingDataset = Dataset<Zip2TensorGroup<Tensor<Int32>, Tensor<Float>>>(
         loadCIFARTrainingFiles())
-    let testDataset = Dataset<TensorPair<Tensor<Int32>, Tensor<Float>>>(loadCIFARTestFile())
+    let testDataset = Dataset<Zip2TensorGroup<Tensor<Int32>, Tensor<Float>>>(loadCIFARTestFile())
     return (trainingDataset, testDataset)
 }

--- a/CIFAR/main.swift
+++ b/CIFAR/main.swift
@@ -20,7 +20,7 @@ for epoch in 1...100 {
     var trainingBatchCount = 0
     let trainingShuffled = trainingDataset.shuffled(sampleCount: 50000, randomSeed: Int64(epoch))
     for batch in trainingShuffled.batched(Int64(batchSize)) {
-        let (labels, images) = (batch.first, batch.second)
+        let (labels, images) = (batch.label, batch.data)
         let (loss, gradients) = valueWithGradient(at: model) { model -> Tensor<Float> in
             let logits = model.applied(to: images, in: Context(learningPhase: .training))
             return softmaxCrossEntropy(logits: logits, labels: labels)
@@ -35,7 +35,7 @@ for epoch in 1...100 {
     var correctGuessCount = 0
     var totalGuessCount: Int32 = 0
     for batch in testBatches {
-        let (labels, images) = (batch.first, batch.second)
+        let (labels, images) = (batch.label, batch.data)
         let logits = model.inferring(from: images)
         testLossSum += softmaxCrossEntropy(logits: logits, labels: labels).scalarized()
         testBatchCount += 1

--- a/CIFAR/main.swift
+++ b/CIFAR/main.swift
@@ -2,8 +2,8 @@ import TensorFlow
 
 let batchSize: Int32 = 100
 
-let (trainingDataset, testDataset) = loadCIFAR10()
-let testBatches = testDataset.batched(Int64(batchSize))
+let cifarDataset = loadCIFAR10()
+let testBatches = cifarDataset.test.batched(Int64(batchSize))
 
 //var model = ResNet20()
 //var model = PyTorchModel()
@@ -18,7 +18,8 @@ print("Starting training...")
 for epoch in 1...100 {
     var trainingLossSum: Float = 0
     var trainingBatchCount = 0
-    let trainingShuffled = trainingDataset.shuffled(sampleCount: 50000, randomSeed: Int64(epoch))
+    let trainingShuffled = cifarDataset.training.shuffled(
+        sampleCount: 50000, randomSeed: Int64(epoch))
     for batch in trainingShuffled.batched(Int64(batchSize)) {
         let (labels, images) = (batch.label, batch.data)
         let (loss, gradients) = valueWithGradient(at: model) { model -> Tensor<Float> in

--- a/ResNet/data.swift
+++ b/ResNet/data.swift
@@ -57,8 +57,9 @@ func loadCIFARTestFile() -> Example {
     return loadCIFARFile(named: "test_batch")
 }
 
-public func loadCIFAR10() -> (Dataset<Example>, Dataset<Example>) {
+public func loadCIFAR10() -> (
+    training: Dataset<Example>, test: Dataset<Example>) {
     let trainingDataset = Dataset<Example>(elements: loadCIFARTrainingFiles())
     let testDataset = Dataset<Example>(elements: loadCIFARTestFile())
-    return (trainingDataset, testDataset)
+    return (training: trainingDataset, test: testDataset)
 }

--- a/ResNet/data.swift
+++ b/ResNet/data.swift
@@ -51,7 +51,9 @@ func loadCIFARTestFile() -> (Tensor<Int32>, Tensor<Float>) {
     return loadCIFARFile(named: "test_batch")
 }
 
-extension Dataset where Element == Zip2TensorGroup<Tensor<Int32>, Tensor<Float>> {
+public typealias Example = Zip2TensorGroup<Tensor<Int32>, Tensor<Float>>
+
+extension Dataset where Element == Example {
     init(_ tuple: (Tensor<Int32>, Tensor<Float>)) {
         self = zip(
             Dataset<Tensor<Int32>>(elements: tuple.0),
@@ -59,11 +61,8 @@ extension Dataset where Element == Zip2TensorGroup<Tensor<Int32>, Tensor<Float>>
     }
 }
 
-public func loadCIFAR10() -> (
-    Dataset<Zip2TensorGroup<Tensor<Int32>, Tensor<Float>>>,
-    Dataset<Zip2TensorGroup<Tensor<Int32>, Tensor<Float>>>) {
-    let trainingDataset = Dataset<Zip2TensorGroup<Tensor<Int32>, Tensor<Float>>>(
-        loadCIFARTrainingFiles())
-    let testDataset = Dataset<Zip2TensorGroup<Tensor<Int32>, Tensor<Float>>>(loadCIFARTestFile())
+public func loadCIFAR10() -> (Dataset<Example>, Dataset<Example>) {
+    let trainingDataset = Dataset<Example>(loadCIFARTrainingFiles())
+    let testDataset = Dataset<Example>(loadCIFARTestFile())
     return (trainingDataset, testDataset)
 }

--- a/ResNet/data.swift
+++ b/ResNet/data.swift
@@ -15,7 +15,7 @@ func downloadCIFAR10IfNotPresent(to directory: String = ".") {
     }
 }
 
-public struct Example: TensorGroup {
+struct Example: TensorGroup {
     var label: Tensor<Int32>
     var data: Tensor<Float>
 }
@@ -57,7 +57,7 @@ func loadCIFARTestFile() -> Example {
     return loadCIFARFile(named: "test_batch")
 }
 
-public func loadCIFAR10() -> (
+func loadCIFAR10() -> (
     training: Dataset<Example>, test: Dataset<Example>) {
     let trainingDataset = Dataset<Example>(elements: loadCIFARTrainingFiles())
     let testDataset = Dataset<Example>(elements: loadCIFARTestFile())

--- a/ResNet/data.swift
+++ b/ResNet/data.swift
@@ -15,8 +15,13 @@ func downloadCIFAR10IfNotPresent(to directory: String = ".") {
     }
 }
 
+public struct Example: TensorGroup {
+    var label: Tensor<Int32>
+    var data: Tensor<Float>
+}
+
 // Each CIFAR data file is provided as a Python pickle of NumPy arrays
-func loadCIFARFile(named name: String, in directory: String = ".") -> (Tensor<Int32>, Tensor<Float>) {
+func loadCIFARFile(named name: String, in directory: String = ".") -> Example {
     downloadCIFAR10IfNotPresent(to: directory)
     let np = Python.import("numpy")
     let pickle = Python.import("pickle")
@@ -36,33 +41,24 @@ func loadCIFARFile(named name: String, in directory: String = ".") -> (Tensor<In
         .reshaped(to: [imageCount, 3, 32, 32])
         .transposed(withPermutations: [0, 2, 3, 1]))
 
-    return (Tensor<Int32>(labelTensor), imageTensor / Float(255.0))
+    return Example(
+        label: Tensor<Int32>(labelTensor), data: imageTensor / Float(255.0))
 }
 
-func loadCIFARTrainingFiles() -> (Tensor<Int32>, Tensor<Float>) {
+func loadCIFARTrainingFiles() -> Example {
     let data = (1..<6).map { loadCIFARFile(named: "data_batch_\($0)") }
-    return (
-        Raw.concat(concatDim: Tensor<Int32>(0), data.map { $0.0 }),
-        Raw.concat(concatDim: Tensor<Int32>(0), data.map { $0.1 })
+    return Example(
+        label: Raw.concat(concatDim: Tensor<Int32>(0), data.map { $0.label }),
+        data: Raw.concat(concatDim: Tensor<Int32>(0), data.map { $0.data })
     )
 }
 
-func loadCIFARTestFile() -> (Tensor<Int32>, Tensor<Float>) {
+func loadCIFARTestFile() -> Example {
     return loadCIFARFile(named: "test_batch")
 }
 
-public typealias Example = Zip2TensorGroup<Tensor<Int32>, Tensor<Float>>
-
-extension Dataset where Element == Example {
-    init(_ tuple: (Tensor<Int32>, Tensor<Float>)) {
-        self = zip(
-            Dataset<Tensor<Int32>>(elements: tuple.0),
-            Dataset<Tensor<Float>>(elements: tuple.1))
-    }
-}
-
 public func loadCIFAR10() -> (Dataset<Example>, Dataset<Example>) {
-    let trainingDataset = Dataset<Example>(loadCIFARTrainingFiles())
-    let testDataset = Dataset<Example>(loadCIFARTestFile())
+    let trainingDataset = Dataset<Example>(elements: loadCIFARTrainingFiles())
+    let testDataset = Dataset<Example>(elements: loadCIFARTestFile())
     return (trainingDataset, testDataset)
 }

--- a/ResNet/data.swift
+++ b/ResNet/data.swift
@@ -51,7 +51,7 @@ func loadCIFARTestFile() -> (Tensor<Int32>, Tensor<Float>) {
     return loadCIFARFile(named: "test_batch")
 }
 
-extension Dataset where Element == TensorPair<Tensor<Int32>, Tensor<Float>> {
+extension Dataset where Element == Zip2TensorGroup<Tensor<Int32>, Tensor<Float>> {
     init(_ tuple: (Tensor<Int32>, Tensor<Float>)) {
         self = zip(
             Dataset<Tensor<Int32>>(elements: tuple.0),
@@ -60,10 +60,10 @@ extension Dataset where Element == TensorPair<Tensor<Int32>, Tensor<Float>> {
 }
 
 public func loadCIFAR10() -> (
-    Dataset<TensorPair<Tensor<Int32>, Tensor<Float>>>,
-    Dataset<TensorPair<Tensor<Int32>, Tensor<Float>>>) {
-    let trainingDataset = Dataset<TensorPair<Tensor<Int32>, Tensor<Float>>>(
+    Dataset<Zip2TensorGroup<Tensor<Int32>, Tensor<Float>>>,
+    Dataset<Zip2TensorGroup<Tensor<Int32>, Tensor<Float>>>) {
+    let trainingDataset = Dataset<Zip2TensorGroup<Tensor<Int32>, Tensor<Float>>>(
         loadCIFARTrainingFiles())
-    let testDataset = Dataset<TensorPair<Tensor<Int32>, Tensor<Float>>>(loadCIFARTestFile())
+    let testDataset = Dataset<Zip2TensorGroup<Tensor<Int32>, Tensor<Float>>>(loadCIFARTestFile())
     return (trainingDataset, testDataset)
 }

--- a/ResNet/main.swift
+++ b/ResNet/main.swift
@@ -17,7 +17,7 @@ for epoch in 1...10 {
     var trainingBatchCount = 0
     let trainingShuffled = trainingDataset.shuffled(sampleCount: 50000, randomSeed: Int64(epoch))
     for batch in trainingShuffled.batched(Int64(batchSize)) {
-        let (labels, images) = (batch.first, batch.second)
+        let (labels, images) = (batch.label, batch.data)
         let (loss, gradients) = valueWithGradient(at: model) { model -> Tensor<Float> in
             let logits = model.applied(to: images, in: Context(learningPhase: .training))
             return softmaxCrossEntropy(logits: logits, labels: labels)
@@ -31,7 +31,7 @@ for epoch in 1...10 {
     var testLossSum: Float = 0
     var testBatchCount = 0
     for batch in testBatches {
-        let (labels, images) = (batch.first, batch.second)
+        let (labels, images) = (batch.label, batch.data)
         let logits = model.inferring(from: images)
         testLossSum += softmaxCrossEntropy(logits: logits, labels: labels).scalarized()
         testBatchCount += 1

--- a/ResNet/main.swift
+++ b/ResNet/main.swift
@@ -2,8 +2,8 @@ import TensorFlow
 
 let batchSize = 128
 
-let (trainingDataset, testDataset) = loadCIFAR10()
-let testBatches = testDataset.batched(Int64(batchSize))
+let cifarDataset = loadCIFAR10()
+let testBatches = cifarDataset.test.batched(Int64(batchSize))
 
 var model = ResNet50(imageSize: 32, classCount: 10) // Use the network sized for CIFAR-10
 
@@ -15,7 +15,8 @@ for epoch in 1...10 {
     print("Epoch \(epoch), training...")
     var trainingLossSum: Float = 0
     var trainingBatchCount = 0
-    let trainingShuffled = trainingDataset.shuffled(sampleCount: 50000, randomSeed: Int64(epoch))
+    let trainingShuffled = cifarDataset.training.shuffled(
+        sampleCount: 50000, randomSeed: Int64(epoch))
     for batch in trainingShuffled.batched(Int64(batchSize)) {
         let (labels, images) = (batch.label, batch.data)
         let (loss, gradients) = valueWithGradient(at: model) { model -> Tensor<Float> in


### PR DESCRIPTION
https://github.com/apple/swift/commit/bcb73a17770da5b891fb8cfbc647c6425bf30e53 remoted the TensorPair struct.