### PR TITLE
Convert MNIST to Swift Manager

### DIFF
--- a/MNIST/README.md
+++ b/MNIST/README.md
@@ -1,6 +1,6 @@
 # MNIST
 
-This directory builds a simple convolutional neural network to classify the 
+This directory builds a simple convolutional neural network to classify the
 [MNIST dataset](http://yann.lecun.com/exdb/mnist/).
 
 ## Setup
@@ -12,5 +12,6 @@ installed. Make sure you've added the correct version of `swift` to your path.
 To train the model, run:
 
 ```
-swift -O MNIST.swift
+cd swift-models
+swift run -c release MNIST
 ```

--- a/MNIST/main.swift
+++ b/MNIST/main.swift
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import Foundation
 import TensorFlow
 import Python
 
@@ -19,8 +20,19 @@ let np = Python.import("numpy")
 
 /// Reads a file into an array of bytes.
 func readFile(_ filename: String) -> [UInt8] {
-    let d = Python.open(filename, "rb").read()
-    return Array(numpy: np.frombuffer(d, dtype: np.uint8))!
+    let possibleFolders = [".", "MNIST"]
+    for folder in possibleFolders {
+        let parent = URL(fileURLWithPath: folder)
+        let filePath = parent.appendingPathComponent(filename).path
+
+        guard FileManager.default.fileExists(atPath: filePath) else {
+            continue
+        }
+
+        let d = Python.open(filePath, "rb").read()
+        return Array(numpy: np.frombuffer(d, dtype: np.uint8))!
+    }
+    fatalError("Failed to find file with name \(filename) in following folders: \(possibleFolders)")
 }
 
 /// Reads MNIST images and labels from specified file paths.

--- a/MNIST/main.swift
+++ b/MNIST/main.swift
@@ -24,11 +24,9 @@ func readFile(_ filename: String) -> [UInt8] {
     for folder in possibleFolders {
         let parent = URL(fileURLWithPath: folder)
         let filePath = parent.appendingPathComponent(filename).path
-
         guard FileManager.default.fileExists(atPath: filePath) else {
             continue
         }
-
         let d = Python.open(filePath, "rb").read()
         return Array(numpy: np.frombuffer(d, dtype: np.uint8))!
     }

--- a/Package.swift
+++ b/Package.swift
@@ -4,7 +4,7 @@
 import PackageDescription
 
 let package = Package(
-    name: "Swift-Models",
+    name: "TensorFlowModels",
     targets: [
         .target(
             name: "MNIST",

--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,14 @@
+// swift-tools-version:4.2
+// The swift-tools-version declares the minimum version of Swift required to build this package.
+
+import PackageDescription
+
+let package = Package(
+    name: "Swift-Models",
+    targets: [
+        .target(
+            name: "MNIST",
+            dependencies: [],
+            path: "MNIST"),
+    ]
+)

--- a/Package.swift
+++ b/Package.swift
@@ -5,6 +5,9 @@ import PackageDescription
 
 let package = Package(
     name: "TensorFlowModels",
+    products: [
+        .executable(name: "MNIST", targets: ["MNIST"]),
+    ],
     targets: [
         .target(
             name: "MNIST",


### PR DESCRIPTION
1. Rename the mnist.swift to main.swift so swiftpm can find it.
2. Improve the readFile method to search folders. This is required as we are changing the folder to run it. 
3. Give a better error message when file cannot be found.