### PR TITLE
WIP: Enabling function-level XLA compilation

### DIFF
--- a/XLABatchNorm/bnorm.swift
+++ b/XLABatchNorm/bnorm.swift
@@ -1,0 +1,226 @@
+import TensorFlow
+
+struct PullbackArgs<T : TensorGroup, U : TensorGroup> : TensorGroup {
+  let input: T
+  let cotangent: U
+}
+
+func xlaCompiled<T : Differentiable & TensorGroup, U : Differentiable & TensorGroup>(
+  _ fn: @escaping @differentiable (T) -> U) -> @differentiable (T) -> U
+where T.CotangentVector : TensorGroup, U.CotangentVector : TensorGroup
+{
+  let xlaCompiledFn: (T) -> U = _graph(fn, useXla: true)
+  let xlaCompiledPullback = _graph(
+    { (pbArgs: PullbackArgs<T, U.CotangentVector>) in
+      pullback(at: pbArgs.input, in: fn)(pbArgs.cotangent)
+    },
+    useXla: true)
+  return  differentiableFunction { x in
+      (value: xlaCompiledFn(x),
+      pullback: {
+        v in
+        xlaCompiledPullback(PullbackArgs(input: x, cotangent: v))}
+      )
+  }
+}
+
+
+@_fixed_layout
+public struct XLABatchNorm<Scalar: TensorFlowFloatingPoint>: Layer {
+    /// The batch dimension.
+    @noDerivative public let axis: Int32
+    /// The momentum for the running mean and running variance.
+    @noDerivative public let momentum: Tensor<Scalar>
+    /// The offset value, also known as beta.
+    public var offset: Tensor<Scalar>
+    /// The scale value, also known as gamma.
+    public var scale: Tensor<Scalar>
+    /// The variance epsilon value.
+    @noDerivative public let epsilon: Tensor<Scalar>
+    /// The running mean.
+    @noDerivative public let runningMean: Parameter<Scalar>
+    /// The running variance.
+    @noDerivative public let runningVariance: Parameter<Scalar>
+    /// compiled batch norm
+    @noDerivative
+    public let compiledBatchNormTraining: @differentiable (BatchNormInput) -> BatchNormResult
+  
+    /// Creates a batch normalization layer.
+    ///
+    /// - Parameters:
+    ///   - axis: The axis that should be normalized (typically the features axis).
+    ///   - momentum: The momentum for the moving average.
+    ///   - offset: The offset to be added to the normalized tensor.
+    ///   - scale: The scale to multiply the normalized tensor by.
+    ///   - epsilon: A small scalar added to the denominator to improve numerical stability.
+    ///   - runningMean: The running mean.
+    ///   - runningVariance: The running variance.
+    public init(
+        axis: Int,
+        momentum: Tensor<Scalar>,
+        offset: Tensor<Scalar>,
+        scale: Tensor<Scalar>,
+        epsilon: Tensor<Scalar>,
+        runningMean: Tensor<Scalar>,
+        runningVariance: Tensor<Scalar>
+    ) {
+        self.axis = Int32(axis)
+        self.momentum = momentum
+        self.offset = offset
+        self.scale = scale
+        self.epsilon = epsilon
+        self.runningMean = Parameter(runningMean)
+        self.runningVariance = Parameter(runningVariance)
+        self.compiledBatchNormTraining = xlaCompiled({ [axis=self.axis, momentum=self.momentum, epsilon=self.epsilon]
+        (arg: BatchNormInput)  in
+             XLABatchNorm.batchNormTraining(
+                 axis, momentum, arg.offset, arg.scale,
+                 epsilon, arg.runningMeanValue,
+                 arg.runningVarianceValue, arg.input)})
+    }
+
+    @differentiable
+    private func applyingTraining(to input: Tensor<Scalar>) -> Tensor<Scalar> {
+        // let positiveAxis = (input.rank + axis) % input.rank
+        // let mean = input.mean(alongAxes: [0, positiveAxis])
+        // let variance = input.variance(alongAxes: [0, positiveAxis])
+        // runningMean.value += (mean - runningMean.value) * (1 - momentum)
+        // runningVariance.value += (
+        //     variance - runningVariance.value) * (1 - momentum)
+        // let inv = rsqrt(variance + epsilon) * scale
+        // return (input - mean) * inv + offset
+
+        let result = compiledBatchNormTraining(
+            BatchNormInput(  
+                scale: scale, offset: offset, runningMeanValue: runningMean.value,
+                runningVarianceValue: runningVariance.value, input:  input))
+        runningMean.value = result.runningMeanValue
+        runningVariance.value = result.runningVarianceValue
+        return result.output
+    }
+
+    public struct BatchNormInput: Differentiable & TensorGroup & AdditiveArithmetic {
+        let scale: Tensor<Scalar>
+        let offset: Tensor<Scalar>
+        let runningMeanValue: Tensor<Scalar>
+        let runningVarianceValue: Tensor<Scalar>
+        let input: Tensor<Scalar>
+    }
+
+    public struct BatchNormResult: Differentiable & TensorGroup & AdditiveArithmetic {
+        let runningMeanValue: Tensor<Scalar>
+        let runningVarianceValue: Tensor<Scalar>
+        let output: Tensor<Scalar>
+    }
+
+    private static func batchNormTraining(
+        _ axis: Int32,
+        _ momentum: Tensor<Scalar>,
+        _ offset: Tensor<Scalar>,
+        _ scale: Tensor<Scalar>,
+        _ epsilon: Tensor<Scalar>,
+        _ runningMeanValue: Tensor<Scalar>,
+        _ runningVarianceValue: Tensor<Scalar>,
+        _ input: Tensor<Scalar>
+     ) -> BatchNormResult {
+        let positiveAxis = (input.rank + axis) % input.rank
+        let mean = input.mean(alongAxes: [0, positiveAxis])
+        let variance = input.variance(alongAxes: [0, positiveAxis])
+        let newRunningMeanValue =
+            runningMeanValue + (mean - runningMeanValue) * (1 - momentum)
+        let newRunningVariance =
+            runningVarianceValue + (
+                 variance - runningVarianceValue) * (1 - momentum)
+        let inv = rsqrt(variance + epsilon) * scale
+        return BatchNormResult(
+            runningMeanValue: newRunningMeanValue.withoutDerivative(),
+            runningVarianceValue: newRunningVariance.withoutDerivative(),
+            output: (input - mean) * inv + offset
+        )
+    }
+
+    @differentiable
+    private func applyingInference(to input: Tensor<Scalar>) -> Tensor<Scalar> {
+        let inv = rsqrt(runningVariance.value + epsilon) * scale
+        return (input - runningMean.value) * inv + offset
+    }
+
+    /// Returns the output obtained from applying the layer to the given input.
+    ///
+    /// - Parameters:
+    ///   - input: The input to the layer.
+    ///   - context: The contextual information for the layer application, e.g. the current learning
+    ///     phase.
+    /// - Returns: The output.
+    @differentiable(vjp: _vjpApplied(to:in:))
+    public func applied(to input: Tensor<Scalar>, in context: Context) -> Tensor<Scalar> {
+        switch context.learningPhase {
+        case .training:
+            return applyingTraining(to: input)
+        case .inference:
+            return applyingInference(to: input)
+        }
+    }
+
+    @usableFromInline
+    func _vjpApplied(to input: Tensor<Scalar>, in context: Context) ->
+        (Tensor<Scalar>, (Tensor<Scalar>) ->
+            (XLABatchNorm<Scalar>.CotangentVector, Tensor<Scalar>)) {
+        switch context.learningPhase {
+        case .training:
+            return valueWithPullback(at: input) {
+                $0.applyingTraining(to: $1)
+            }
+        case .inference:
+            return valueWithPullback(at: input) {
+                $0.applyingInference(to: $1)
+            }
+        }
+    }
+
+    /// Creates a batch normalization layer.
+    ///
+    /// - Parameters:
+    ///   - featureCount: The number of features.
+    ///   - axis: The axis that should be normalized (typically the features axis).
+    ///   - momentum: The momentum for the moving average.
+    ///   - epsilon: A small scalar added to the denominator to improve numerical stability.
+    public init(featureCount: Int,
+                axis: Int = -1,
+                momentum: Tensor<Scalar> = Tensor(0.99),
+                epsilon: Tensor<Scalar> = Tensor(0.001)) {
+        self.axis = Int32(axis)
+        self.momentum = momentum
+        self.scale = Tensor<Scalar>(ones: [Int32(featureCount)])
+        self.offset = Tensor<Scalar>(zeros: [Int32(featureCount)])
+        self.epsilon = epsilon
+        self.runningMean = Parameter(Tensor(0))
+        self.runningVariance = Parameter(Tensor(1))
+        self.compiledBatchNormTraining = xlaCompiled({(arg: BatchNormInput)  in
+             XLABatchNorm.batchNormTraining(
+                 Int32(axis), momentum, arg.offset, arg.scale,
+                 epsilon, arg.runningMeanValue,
+                 arg.runningVarianceValue, arg.input)})
+
+    }
+}
+
+struct ConvBN: Layer {
+    var conv: Conv2D<Float>
+    var norm: XLABatchNorm<Float>
+
+    public init(
+        filterShape: (Int, Int, Int, Int),
+        strides: (Int, Int) = (1, 1),
+        padding: Padding = .valid
+    ) {
+        self.conv = Conv2D(filterShape: filterShape, strides: strides, padding: padding)
+        self.norm = XLABatchNorm(featureCount: filterShape.3)
+    }
+
+    @differentiable
+    public func applied(to input: Tensor<Float>, in context: Context) -> Tensor<Float> {
+        return norm.applied(to: conv.applied(to: input, in: context), in: context)
+    }
+}
+

--- a/XLABatchNorm/data.swift
+++ b/XLABatchNorm/data.swift
@@ -1,0 +1,65 @@
+import Python
+import TensorFlow
+
+/// Use Python and shell calls to download and extract the CIFAR-10 tarball if not already done
+/// This can fail for many reasons (e.g. lack of `wget`, `tar`, or an Internet connection)
+func downloadCIFAR10IfNotPresent(to directory: String = ".") {
+    let subprocess = Python.import("subprocess")
+    let path = Python.import("os.path")
+    let filepath = "\(directory)/cifar-10-batches-py"
+    let isdir = Bool(path.isdir(filepath))!
+    if !isdir {
+        print("Downloading CIFAR data...")
+        let command = "wget -nv -O- https://www.cs.toronto.edu/~kriz/cifar-10-python.tar.gz | tar xzf - -C \(directory)"
+        subprocess.call(command, shell: true)
+    }
+}
+
+struct Example: TensorGroup {
+    var label: Tensor<Int32>
+    var data: Tensor<Float>
+}
+
+// Each CIFAR data file is provided as a Python pickle of NumPy arrays
+func loadCIFARFile(named name: String, in directory: String = ".") -> Example {
+    downloadCIFAR10IfNotPresent(to: directory)
+    let np = Python.import("numpy")
+    let pickle = Python.import("pickle")
+    let path = "\(directory)/cifar-10-batches-py/\(name)"
+    let f = Python.open(path, "rb")
+    let res = pickle.load(f, encoding: "bytes")
+
+    let bytes = res[Python.bytes("data", encoding: "utf8")]
+    let labels = res[Python.bytes("labels", encoding: "utf8")]
+
+    let labelTensor = Tensor<Int64>(numpy: np.array(labels))!
+    let images = Tensor<UInt8>(numpy: bytes)!
+    let imageCount = images.shape[0]
+
+    // reshape and transpose from the provided N(CHW) to TF default NHWC
+    let imageTensor = Tensor<Float>(images
+        .reshaped(to: [imageCount, 3, 32, 32])
+        .transposed(withPermutations: [0, 2, 3, 1]))
+
+    return Example(
+        label: Tensor<Int32>(labelTensor), data: imageTensor / Float(255.0))
+}
+
+func loadCIFARTrainingFiles() -> Example {
+    let data = (1..<6).map { loadCIFARFile(named: "data_batch_\($0)") }
+    return Example(
+        label: Raw.concat(concatDim: Tensor<Int32>(0), data.map { $0.label }),
+        data: Raw.concat(concatDim: Tensor<Int32>(0), data.map { $0.data })
+    )
+}
+
+func loadCIFARTestFile() -> Example {
+    return loadCIFARFile(named: "test_batch")
+}
+
+func loadCIFAR10() -> (
+    training: Dataset<Example>, test: Dataset<Example>) {
+    let trainingDataset = Dataset<Example>(elements: loadCIFARTrainingFiles())
+    let testDataset = Dataset<Example>(elements: loadCIFARTestFile())
+    return (training: trainingDataset, test: testDataset)
+}

--- a/XLABatchNorm/main.swift
+++ b/XLABatchNorm/main.swift
@@ -5,40 +5,39 @@ let batchSize = 128
 let cifarDataset = loadCIFAR10()
 let testBatches = cifarDataset.test.batched(Int64(batchSize))
 
-// For imageSize = 32
-var model = ConvBN(filterShape: (3, 3, 3, 64), padding: .same)
-
-// the classic ImageNet optimizer setting diverges on CIFAR-10
-// let optimizer = SGD(for: model, learningRate: 0.1, momentum: 0.9, scalarType: Float.self)
-let optimizer = SGD(for: model, learningRate: 0.001, scalarType: Float.self)
-
-for epoch in 1...2 {
-    print("Epoch \(epoch), training...")
-    var trainingLossSum: Float = 0
-    var trainingBatchCount = 0
-    let trainingShuffled = cifarDataset.training.shuffled(
-        sampleCount: 50000, randomSeed: Int64(epoch))
-    for batch in trainingShuffled.batched(Int64(batchSize)) {
-       let (labels, images) = (batch.label, batch.data)
-       let _ =  model.applied(to: images, in: Context(learningPhase: .training))
-      //   let (loss, gradients) = valueWithGradient(at: model) { model -> Tensor<Float> in
-      //       // let logits = model.applied(to: images, in: Context(learningPhase: .training))
-      // // return softmaxCrossEntropy(logits: logits, labels: labels)
-      //      return  model.applied(to: images, in: Context(learningPhase: .training))
-      //   }
-      //   trainingLossSum += loss.scalarized()
-      //   trainingBatchCount += 1
-      //   optimizer.update(&model.allDifferentiableVariables, along: gradients)
+// Returns an empty Array if saveResults is false.
+func computeBnorm(useXLA: Bool, nResults: Int, epoch: Int64 = 1) -> Array<Tensor<Float>> {
+  let model = ConvBN(filterShape: (3, 3, 3, 64), padding: .same, useXLA: useXLA)
+  var results:Array<Tensor<Float>> = []
+  let trainingShuffled = cifarDataset.training.shuffled(
+    sampleCount: 50000, randomSeed: epoch)
+  for batch in trainingShuffled.batched(Int64(batchSize)) {
+    let images = batch.data
+    let res =  model.applied(to: images, in: Context(learningPhase: .training))
+    results.append(res);
+    if results.count > nResults {
+      break
     }
-    // print("  average loss: \(trainingLossSum / Float(trainingBatchCount))")
-    // print("Epoch \(epoch), evaluating on test set...")
-    // var testLossSum: Float = 0
-    // var testBatchCount = 0
-    // for batch in testBatches {
-    //     let (labels, images) = (batch.label, batch.data)
-    //     let logits = model.inferring(from: images)
-    //     testLossSum += softmaxCrossEntropy(logits: logits, labels: labels).scalarized()
-    //     testBatchCount += 1
-    // }
-    // print("  average loss: \(testLossSum / Float(testBatchCount))")
+  }
+  return results
 }
+
+func checkBnormResults() {
+  let nResultsToCheck = 100
+  let resultsNoXLA = computeBnorm(useXLA: false, nResults: nResultsToCheck)
+  let resultsXLA = computeBnorm(useXLA: true, nResults: nResultsToCheck)
+  let error: Float = 0.000001
+  var i = 0
+  print("Checking nearly equal with error: \(error)")
+  for (l, r) in zip(resultsNoXLA, resultsXLA) {
+    if (abs(l - r) > error) {
+      print("Mismatch at \(i):\n")// \(resultsNoXLA[i]) \n vs \(resultsXLA[i])\n")
+    }
+    i += 1
+  }
+}
+
+
+simpleTest()
+checkBnormResults()
+

--- a/XLABatchNorm/main.swift
+++ b/XLABatchNorm/main.swift
@@ -1,0 +1,44 @@
+import TensorFlow
+
+let batchSize = 128
+
+let cifarDataset = loadCIFAR10()
+let testBatches = cifarDataset.test.batched(Int64(batchSize))
+
+// For imageSize = 32
+var model = ConvBN(filterShape: (3, 3, 3, 64), padding: .same)
+
+// the classic ImageNet optimizer setting diverges on CIFAR-10
+// let optimizer = SGD(for: model, learningRate: 0.1, momentum: 0.9, scalarType: Float.self)
+let optimizer = SGD(for: model, learningRate: 0.001, scalarType: Float.self)
+
+for epoch in 1...2 {
+    print("Epoch \(epoch), training...")
+    var trainingLossSum: Float = 0
+    var trainingBatchCount = 0
+    let trainingShuffled = cifarDataset.training.shuffled(
+        sampleCount: 50000, randomSeed: Int64(epoch))
+    for batch in trainingShuffled.batched(Int64(batchSize)) {
+       let (labels, images) = (batch.label, batch.data)
+       let _ =  model.applied(to: images, in: Context(learningPhase: .training))
+      //   let (loss, gradients) = valueWithGradient(at: model) { model -> Tensor<Float> in
+      //       // let logits = model.applied(to: images, in: Context(learningPhase: .training))
+      // // return softmaxCrossEntropy(logits: logits, labels: labels)
+      //      return  model.applied(to: images, in: Context(learningPhase: .training))
+      //   }
+      //   trainingLossSum += loss.scalarized()
+      //   trainingBatchCount += 1
+      //   optimizer.update(&model.allDifferentiableVariables, along: gradients)
+    }
+    // print("  average loss: \(trainingLossSum / Float(trainingBatchCount))")
+    // print("Epoch \(epoch), evaluating on test set...")
+    // var testLossSum: Float = 0
+    // var testBatchCount = 0
+    // for batch in testBatches {
+    //     let (labels, images) = (batch.label, batch.data)
+    //     let logits = model.inferring(from: images)
+    //     testLossSum += softmaxCrossEntropy(logits: logits, labels: labels).scalarized()
+    //     testBatchCount += 1
+    // }
+    // print("  average loss: \(testLossSum / Float(testBatchCount))")
+}

--- a/XLABatchNorm/xla.compile.swift
+++ b/XLABatchNorm/xla.compile.swift
@@ -9,12 +9,12 @@ func xlaCompiled<T : Differentiable & TensorGroup, U : Differentiable & TensorGr
   _ fn: @escaping @differentiable (T) -> U) -> @differentiable (T) -> U
 where T.CotangentVector : TensorGroup, U.CotangentVector : TensorGroup
 {
-  let xlaCompiledFn: (T) -> U = _graph(fn, useXla: true)
+  let xlaCompiledFn: (T) -> U = _graph(fn, useXLA: true)
   let xlaCompiledPullback = _graph(
     { (pbArgs: PullbackArgs<T, U.CotangentVector>) in
       pullback(at: pbArgs.input, in: fn)(pbArgs.cotangent)
     },
-    useXla: true)
+    useXLA: true)
   return  differentiableFunction { x in
       (value: xlaCompiledFn(x),
       pullback: {
@@ -25,17 +25,12 @@ where T.CotangentVector : TensorGroup, U.CotangentVector : TensorGroup
 }
   
 
-
 @differentiable 
 func square(_ a: Tensor<Float>) -> Tensor<Float>{
   return a * a 
-}
+}  
 
-let blah = xlaCompiled(square)
-let b = blah(Tensor<Float>(5.0))
-print("b \(b)")
-
-withDevice(.cpu) {
+func simpleTest() {
   let input = Tensor<Float>(10.0)
   let computation = xlaCompiled(square)
   let res = computation(input)

--- a/XLABatchNorm/xla.compile.swift
+++ b/XLABatchNorm/xla.compile.swift
@@ -1,0 +1,44 @@
+import TensorFlow
+
+struct PullbackArgs<T : TensorGroup, U : TensorGroup> : TensorGroup {
+  let input: T
+  let cotangent: U
+}
+
+func xlaCompiled<T : Differentiable & TensorGroup, U : Differentiable & TensorGroup>(
+  _ fn: @escaping @differentiable (T) -> U) -> @differentiable (T) -> U
+where T.CotangentVector : TensorGroup, U.CotangentVector : TensorGroup
+{
+  let xlaCompiledFn: (T) -> U = _graph(fn, useXla: true)
+  let xlaCompiledPullback = _graph(
+    { (pbArgs: PullbackArgs<T, U.CotangentVector>) in
+      pullback(at: pbArgs.input, in: fn)(pbArgs.cotangent)
+    },
+    useXla: true)
+  return  differentiableFunction { x in
+      (value: xlaCompiledFn(x),
+      pullback: {
+        v in
+        xlaCompiledPullback(PullbackArgs(input: x, cotangent: v))}
+      )
+  }
+}
+  
+
+
+@differentiable 
+func square(_ a: Tensor<Float>) -> Tensor<Float>{
+  return a * a 
+}
+
+let blah = xlaCompiled(square)
+let b = blah(Tensor<Float>(5.0))
+print("b \(b)")
+
+withDevice(.cpu) {
+  let input = Tensor<Float>(10.0)
+  let computation = xlaCompiled(square)
+  let res = computation(input)
+  let diff = gradient(at: input, in: computation)
+  print("in: \(input), sq: \(res) grad: \(diff) ")
+}


### PR DESCRIPTION
This is a WIP and needs some changes in TensorFlow as well as the CompilerRuntime.

Please take a look at xla.compile.swift to get a sense for the API to invoke xla compilation. The API is based on tracing. 

This PR also has a version of batch norm that uses the API above. It is not working yet:  I have got it compiling, but I am encountering some runtime failures. (Including it in this PR, just as FYI.)