### PR TITLE
Convert ResNet to SwiftPM and add notes how to run it with Py3.

### DIFF
--- a/CIFAR/README.md
+++ b/CIFAR/README.md
@@ -5,9 +5,12 @@ classification on the [CIFAR-10](https://www.cs.toronto.edu/~kriz/cifar.html) da
 
 ## Setup
 
-You'll need the [latest version of Swift for TensorFlow](https://github.com/tensorflow/swift/blob/master/Installation.md)
+You'll need the latest version of [Swift for TensorFlow][SwiftForTensorFlow]
 installed and added to your path. Additionally, the data loader requires Python
-3.x (rather than Python 2.7), `wget`, and numpy.
+3.x (rather than Python 2.7), `wget`, and `numpy`.
+
+> Note: For MacOS, you need to set up the `PYTHON_LIBRARY` to help the Swift for
+> TensorFlow find the `libpython3.<minor-value>.dylib` file, e.g., in `homebrew`.
 
 To train the default model, run:
 
@@ -15,3 +18,5 @@ To train the default model, run:
 cd swift-models
 swift run -c release CIFAR
 ```
+
+[SwiftForTensorFlow]: (https://github.com/tensorflow/swift/blob/master/Installation.md)

--- a/CIFAR/README.md
+++ b/CIFAR/README.md
@@ -5,12 +5,13 @@ classification on the [CIFAR-10](https://www.cs.toronto.edu/~kriz/cifar.html) da
 
 ## Setup
 
-You'll need the latest version of [Swift for TensorFlow][SwiftForTensorFlow]
+You'll need [the latest version][INSTALL] of Swift for TensorFlow
 installed and added to your path. Additionally, the data loader requires Python
 3.x (rather than Python 2.7), `wget`, and `numpy`.
 
-> Note: For MacOS, you need to set up the `PYTHON_LIBRARY` to help the Swift for
-> TensorFlow find the `libpython3.<minor-value>.dylib` file, e.g., in `homebrew`.
+> Note: For macOS, you need to set up the `PYTHON_LIBRARY` to help the Swift for
+> TensorFlow find the `libpython3.<minor-version>.dylib` file, e.g., in
+> `homebrew`.
 
 To train the default model, run:
 
@@ -19,4 +20,4 @@ cd swift-models
 swift run -c release CIFAR
 ```
 
-[SwiftForTensorFlow]: (https://github.com/tensorflow/swift/blob/master/Installation.md)
+[INSTALL]: (https://github.com/tensorflow/swift/blob/master/Installation.md)

--- a/CIFAR/main.swift
+++ b/CIFAR/main.swift
@@ -1,4 +1,6 @@
 import TensorFlow
+import Python
+PythonLibrary.useVersion(3)
 
 let batchSize: Int32 = 100
 

--- a/Package.swift
+++ b/Package.swift
@@ -8,6 +8,7 @@ let package = Package(
     products: [
         .executable(name: "MNIST", targets: ["MNIST"]),
         .executable(name: "CIFAR", targets: ["CIFAR"]),
+        .executable(name: "ResNet", targets: ["ResNet"]),
         .executable(name: "MiniGo", targets: ["MiniGo", "MiniGoMain"]),
     ],
     targets: [
@@ -19,6 +20,10 @@ let package = Package(
             name: "CIFAR",
             dependencies: [],
             path: "CIFAR"),
+        .target(
+            name: "ResNet",
+            dependencies: [],
+            path: "ResNet"),
         .target(
             name: "MiniGoMain",
             dependencies: ["MiniGo"],

--- a/ResNet/README.md
+++ b/ResNet/README.md
@@ -6,13 +6,18 @@ dataset.
 
 ## Setup
 
-You'll need the [latest version of Swift for TensorFlow]
-(https://github.com/tensorflow/swift/blob/master/Installation.md)
-installed and added to your path. Additionally, the data loader requires Python 3.x (rather than
-Python 2.7), `wget`, and numpy.
+You'll need the latest version of [Swift for TensorFlow][SwiftForTensorFlow]
+installed and added to your path. Additionally, the data loader requires Python
+3.x (rather than Python 2.7), `wget`, and `numpy`.
+
+> Note: For MacOS, you need to set up the `PYTHON_LIBRARY` to help the Swift for
+> TensorFlow find the `libpython3.<minor-value>.dylib` file, e.g., in `homebrew`.
 
 To train the model on CIFAR-10, run:
 
 ```
-swift -O ResNet50.swift data.swift main.swift
+cd swift-models
+swift run ResNet
 ```
+
+[SwiftForTensorFlow]: (https://github.com/tensorflow/swift/blob/master/Installation.md)

--- a/ResNet/README.md
+++ b/ResNet/README.md
@@ -6,12 +6,13 @@ dataset.
 
 ## Setup
 
-You'll need the latest version of [Swift for TensorFlow][SwiftForTensorFlow]
+You'll need [the latest version][INSTALL] of Swift for TensorFlow
 installed and added to your path. Additionally, the data loader requires Python
 3.x (rather than Python 2.7), `wget`, and `numpy`.
 
-> Note: For MacOS, you need to set up the `PYTHON_LIBRARY` to help the Swift for
-> TensorFlow find the `libpython3.<minor-value>.dylib` file, e.g., in `homebrew`.
+> Note: For macOS, you need to set up the `PYTHON_LIBRARY` to help the Swift for
+> TensorFlow find the `libpython3.<minor-version>.dylib` file, e.g., in
+> `homebrew`.
 
 To train the model on CIFAR-10, run:
 
@@ -20,4 +21,4 @@ cd swift-models
 swift run ResNet
 ```
 
-[SwiftForTensorFlow]: (https://github.com/tensorflow/swift/blob/master/Installation.md)
+[INSTALL]: (https://github.com/tensorflow/swift/blob/master/Installation.md)

--- a/ResNet/main.swift
+++ b/ResNet/main.swift
@@ -1,4 +1,6 @@
 import TensorFlow
+import Python
+PythonLibrary.useVersion(3)
 
 let batchSize = 128
 


### PR DESCRIPTION
In addition to the changes mentioned in the title, I did the same change for CIFAR regarding the py3 issue. 

