### PR TITLE
update cifar models for 0.3

### DIFF
--- a/CIFAR/main.swift
+++ b/CIFAR/main.swift
@@ -25,7 +25,7 @@ for epoch in 1...100 {
     for batch in trainingShuffled.batched(Int64(batchSize)) {
         let (labels, images) = (batch.label, batch.data)
         let (loss, gradients) = valueWithGradient(at: model) { model -> Tensor<Float> in
-            let logits = model.applied(to: images, in: Context(learningPhase: .training))
+            let logits = model.applied(to: images)
             return softmaxCrossEntropy(logits: logits, labels: labels)
         }
         trainingLossSum += loss.scalarized()

--- a/CIFAR/main.swift
+++ b/CIFAR/main.swift
@@ -1,16 +1,16 @@
 import TensorFlow
 import Python
 PythonLibrary.useVersion(3)
+//needed to use batch norm in ResNet model layers
+Context.local.learningPhase = .training
 
 let batchSize: Int32 = 100
 
 let cifarDataset = loadCIFAR10()
 let testBatches = cifarDataset.test.batched(Int64(batchSize))
 
-//needed to use batch norm in ResNet model layers
-//Context.local.learningPhase = .training
-//var model = ResNet20()
 
+//var model = ResNet20()
 //var model = PyTorchModel()
 var model = KerasModel()
 

--- a/CIFAR/main.swift
+++ b/CIFAR/main.swift
@@ -1,8 +1,6 @@
 import TensorFlow
 import Python
 PythonLibrary.useVersion(3)
-//needed to use batch norm in ResNet model layers
-Context.local.learningPhase = .training
 
 let batchSize: Int32 = 100
 
@@ -20,6 +18,8 @@ var model = KerasModel()
 let optimizer = RMSProp(for: model, learningRate: 0.0001, decay: 1e-6, scalarType: Float.self)
 
 print("Starting training...")
+Context.local.learningPhase = .training
+
 for epoch in 1...100 {
     var trainingLossSum: Float = 0
     var trainingBatchCount = 0

--- a/CIFAR/main.swift
+++ b/CIFAR/main.swift
@@ -7,7 +7,10 @@ let batchSize: Int32 = 100
 let cifarDataset = loadCIFAR10()
 let testBatches = cifarDataset.test.batched(Int64(batchSize))
 
+//needed to use batch norm in ResNet model layers
+//Context.local.learningPhase = .training
 //var model = ResNet20()
+
 //var model = PyTorchModel()
 var model = KerasModel()
 

--- a/CIFAR/resnet.swift
+++ b/CIFAR/resnet.swift
@@ -21,11 +21,8 @@ struct Conv2DBatchNorm: Layer {
     }
 
     @differentiable
-    func applied(to input: Tensor<Float>, in context: Context) -> Tensor<Float> {
-        var tmp = input
-        tmp = conv.applied(to: tmp, in: context)
-        tmp = norm.applied(to: tmp, in: context)
-        return tmp
+    func applied(to input: Tensor<Float>) -> Tensor<Float> {
+        return input.sequenced(through: conv, norm)
     }
 }
 
@@ -53,10 +50,10 @@ struct BasicBlock20: Layer {
     }
 
     @differentiable
-    func applied(to input: Tensor<Float>, in context: Context) -> Tensor<Float> {
-        var tmp = relu(layer1.applied(to: input, in: context))
-        tmp = relu(layer2.applied(to: tmp, in: context))
-        return relu(tmp + shortcut.applied(to: input, in: context))
+    func applied(to input: Tensor<Float>) -> Tensor<Float> {
+        var tmp = relu(layer1.applied(to: input))
+        tmp = relu(layer2.applied(to: tmp))
+        return relu(tmp + shortcut.applied(to: input))
     }
 }
 
@@ -72,16 +69,10 @@ struct ResNet20: Layer {
     var classifier = Dense<Float>(inputSize: 64, outputSize: 10, activation: softmax)
 
     @differentiable
-    func applied(to input: Tensor<Float>, in context: Context) -> Tensor<Float> {
-        var tmp = relu(inputLayer.applied(to: input, in: context))
-
-        tmp = basicBlock1.applied(to: tmp, in: context)
-        tmp = basicBlock2.applied(to: tmp, in: context)
-        tmp = basicBlock3.applied(to: tmp, in: context)
-
-        tmp = averagePool.applied(to: tmp, in: context)
-        tmp = flatten.applied(to: tmp, in: context)
-        return classifier.applied(to: tmp, in: context)
+    func applied(to input: Tensor<Float>) -> Tensor<Float> {
+        let tmp = relu(inputLayer.applied(to: input))
+        let convolved = tmp.sequenced(through: basicBlock1, basicBlock2, basicBlock3)
+        return convolved.sequenced(through: averagePool, flatten, classifier)
     }
 }
 
@@ -117,12 +108,12 @@ struct BasicBlock32: Layer {
     }
 
     @differentiable
-    func applied(to input: Tensor<Float>, in context: Context) -> Tensor<Float> {
-        var tmp = relu(layer1.applied(to: input, in: context))
-        tmp = relu(layer2.applied(to: tmp, in: context))
-        tmp = relu(layer3.applied(to: tmp, in: context))
-        tmp = relu(layer4.applied(to: tmp, in: context))
-        return relu(tmp + shortcut.applied(to: input, in: context))
+    func applied(to input: Tensor<Float>) -> Tensor<Float> {
+        var tmp = relu(layer1.applied(to: input))
+        tmp = relu(layer2.applied(to: tmp))
+        tmp = relu(layer3.applied(to: tmp))
+        tmp = relu(layer4.applied(to: tmp))
+        return relu(tmp + shortcut.applied(to: input))
     }
 }
 
@@ -138,16 +129,10 @@ struct ResNet32: Layer {
     var classifier = Dense<Float>(inputSize: 64, outputSize: 10, activation: softmax)
 
     @differentiable
-    func applied(to input: Tensor<Float>, in context: Context) -> Tensor<Float> {
-        var tmp = relu(inputLayer.applied(to: input, in: context))
-
-        tmp = basicBlock1.applied(to: tmp, in: context)
-        tmp = basicBlock2.applied(to: tmp, in: context)
-        tmp = basicBlock3.applied(to: tmp, in: context)
-
-        tmp = averagePool.applied(to: tmp, in: context)
-        tmp = flatten.applied(to: tmp, in: context)
-        return classifier.applied(to: tmp, in: context)
+    func applied(to input: Tensor<Float>) -> Tensor<Float> {
+        let tmp = relu(inputLayer.applied(to: input))
+        let convolved = tmp.sequenced(through: basicBlock1, basicBlock2, basicBlock3)
+        return convolved.sequenced(through: averagePool, flatten, classifier)
     }
 }
 
@@ -191,14 +176,14 @@ struct BasicBlock44: Layer {
     }
 
     @differentiable
-    func applied(to input: Tensor<Float>, in context: Context) -> Tensor<Float> {
-        var tmp = relu(layer1.applied(to: input, in: context))
-        tmp = relu(layer2.applied(to: tmp, in: context))
-        tmp = relu(layer3.applied(to: tmp, in: context))
-        tmp = relu(layer4.applied(to: tmp, in: context))
-        tmp = relu(layer5.applied(to: tmp, in: context))
-        tmp = relu(layer6.applied(to: tmp, in: context))
-        return relu(tmp + shortcut.applied(to: input, in: context))
+    func applied(to input: Tensor<Float>) -> Tensor<Float> {
+        var tmp = relu(layer1.applied(to: input))
+        tmp = relu(layer2.applied(to: tmp))
+        tmp = relu(layer3.applied(to: tmp))
+        tmp = relu(layer4.applied(to: tmp))
+        tmp = relu(layer5.applied(to: tmp))
+        tmp = relu(layer6.applied(to: tmp))
+        return relu(tmp + shortcut.applied(to: input))
     }
 }
 
@@ -214,16 +199,10 @@ struct ResNet44: Layer {
     var classifier = Dense<Float>(inputSize: 64, outputSize: 10, activation: softmax)
 
     @differentiable
-    func applied(to input: Tensor<Float>, in context: Context) -> Tensor<Float> {
-        var tmp = relu(inputLayer.applied(to: input, in: context))
-
-        tmp = basicBlock1.applied(to: tmp, in: context)
-        tmp = basicBlock2.applied(to: tmp, in: context)
-        tmp = basicBlock3.applied(to: tmp, in: context)
-
-        tmp = averagePool.applied(to: tmp, in: context)
-        tmp = flatten.applied(to: tmp, in: context)
-        return classifier.applied(to: tmp, in: context)
+    func applied(to input: Tensor<Float>) -> Tensor<Float> {
+        let tmp = relu(inputLayer.applied(to: input))
+        let convolved = tmp.sequenced(through: basicBlock1, basicBlock2, basicBlock3)
+        return convolved.sequenced(through: averagePool, flatten, classifier)
     }
 }
 
@@ -275,16 +254,16 @@ struct BasicBlock56: Layer {
     }
 
     @differentiable
-    func applied(to input: Tensor<Float>, in context: Context) -> Tensor<Float> {
-        var tmp = relu(layer1.applied(to: input, in: context))
-        tmp = relu(layer2.applied(to: tmp, in: context))
-        tmp = relu(layer3.applied(to: tmp, in: context))
-        tmp = relu(layer4.applied(to: tmp, in: context))
-        tmp = relu(layer5.applied(to: tmp, in: context))
-        tmp = relu(layer6.applied(to: tmp, in: context))
-        tmp = relu(layer7.applied(to: tmp, in: context))
-        tmp = relu(layer8.applied(to: tmp, in: context))
-        return relu(tmp + shortcut.applied(to: input, in: context))
+    func applied(to input: Tensor<Float>) -> Tensor<Float> {
+        var tmp = relu(layer1.applied(to: input))
+        tmp = relu(layer2.applied(to: tmp))
+        tmp = relu(layer3.applied(to: tmp))
+        tmp = relu(layer4.applied(to: tmp))
+        tmp = relu(layer5.applied(to: tmp))
+        tmp = relu(layer6.applied(to: tmp))
+        tmp = relu(layer7.applied(to: tmp))
+        tmp = relu(layer8.applied(to: tmp))
+        return relu(tmp + shortcut.applied(to: input))
     }
 }
 
@@ -300,15 +279,9 @@ struct ResNet56: Layer {
     var classifier = Dense<Float>(inputSize: 64, outputSize: 10, activation: softmax)
 
     @differentiable
-    func applied(to input: Tensor<Float>, in context: Context) -> Tensor<Float> {
-        var tmp = relu(inputLayer.applied(to: input, in: context))
-
-        tmp = basicBlock1.applied(to: tmp, in: context)
-        tmp = basicBlock2.applied(to: tmp, in: context)
-        tmp = basicBlock3.applied(to: tmp, in: context)
-
-        tmp = averagePool.applied(to: tmp, in: context)
-        tmp = flatten.applied(to: tmp, in: context)
-        return classifier.applied(to: tmp, in: context)
+    func applied(to input: Tensor<Float>) -> Tensor<Float> {
+        let tmp = relu(inputLayer.applied(to: input))
+        let convolved = tmp.sequenced(through: basicBlock1, basicBlock2, basicBlock3)
+        return convolved.sequenced(through: averagePool, flatten, classifier)
     }
 }


### PR DESCRIPTION
@rxwei this all works, but could be refactored down more.

I am getting this error when I try to use through on my Conv2DBatchNorm Layer, should I be doing something differently?

```
resnet.swift:133:26: error: cannot invoke 'sequenced' with an argument list of type '(through: Conv2DBatchNorm
)'                                                                                                            
        let test = input.sequenced(through: inputLayer)                                                       
                         ^                                                                                    
resnet.swift:133:26: note: overloads for 'sequenced' exist with these partially matching parameter lists: (thr
ough: L1, L2), (through: L1, L2, L3), (through: L1, L2, L3, L4), (through: L1, L2, L3, L4, L5), (through: L1, 
L2, L3, L4, L5, L6)                                                                                           
        let test = input.sequenced(through: inputLayer)                                                       
                         ^                                                                                    

```