### PR TITLE
Gets rid of Python in MNIST example

### DIFF
--- a/MNIST/MNIST.swift
+++ b/MNIST/MNIST.swift
@@ -26,8 +26,8 @@ func readFile(_ pathname: String) -> [UInt8] {
 func readMNIST(imagesFile: String, labelsFile: String) -> (images: Tensor<Float>,
                                                            labels: Tensor<Int32>) {
     print("Reading data.")
-    let images = readFile(imagesFile).dropFirst(16).map { Float($0) }
-    let labels = readFile(labelsFile).dropFirst(8).map { Int32($0) }
+    let images = readFile(imagesFile).dropFirst(16).map(Float.init)
+    let labels = readFile(labelsFile).dropFirst(8).map(Int32.init)
     let rowCount = Int32(labels.count)
     let imageHeight: Int32 = 28, imageWidth: Int32 = 28
 

--- a/MNIST/MNIST.swift
+++ b/MNIST/MNIST.swift
@@ -12,15 +12,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import Foundation
 import TensorFlow
-import Python
-
-let np = Python.import("numpy")
 
 /// Reads a file into an array of bytes.
-func readFile(_ filename: String) -> [UInt8] {
-    let d = Python.open(filename, "rb").read()
-    return Array(numpy: np.frombuffer(d, dtype: np.uint8))!
+func readFile(_ pathname: String) -> [UInt8] {
+    let url = URL(fileURLWithPath: pathname)
+    let data = try! Data(contentsOf: url, options: [])
+    return [UInt8](data)
 }
 
 /// Reads MNIST images and labels from specified file paths.


### PR DESCRIPTION
We don't need numpy to read files in Swift.