### PR TITLE
tweak checkpoint directory to match README?

### DIFF
--- a/MiniGo/README.md
+++ b/MiniGo/README.md
@@ -27,9 +27,10 @@ To get a toolchain, you can:
 
 Currently, inference uses a pre-trained checkpoint. To download it, please
 install [`gsutil`](https://cloud.google.com/storage/docs/gsutil_install) and run
-the following:
+the following in the parent directory:
 
 ```sh
+cd swift-models
 mkdir -p MiniGoCheckpoint
 gsutil cp 'gs://minigo-pub/v15-19x19/models/000939-heron.*' MiniGoCheckpoint/
 ```


### PR DESCRIPTION
Doing 

    swift run -Xlinker -ltensorflow -c release MiniGo

like the README suggests in the parent directory is currently failing because the logic assumes it is in the MiniGo directory.  On the flip side doing a ```swift run``` inside the MiniGo directory will fail if this get merged.  Not sure what the correct/desired behavior is.  Can also write logic to check both locations but figured I would ask first.