### PR TITLE
Fixed the MiniGo Tests due to recent changes.

### DIFF
--- a/MiniGo/Strategies/MCTS/MCTSNode.swift
+++ b/MiniGo/Strategies/MCTS/MCTSNode.swift
@@ -171,8 +171,8 @@ extension MCTSNode {
         }
 
         // Breaks the tie randomly.
-        assert(!elements.isEmpty)
-        return elements.randomElement()!
+        assert(!candidateIndexes.isEmpty)
+        return elements[candidateIndexes.randomElement()!]
     }
 
     /// Samples an element according to the PMF.

--- a/Tests/MiniGoTests/Models/GoModelTests.swift
+++ b/Tests/MiniGoTests/Models/GoModelTests.swift
@@ -11,7 +11,7 @@ final class GoModelTests: XCTestCase {
         let sampleInput = Tensor<Float>(randomUniform: [2, 19, 19, 17])
         let inference = model.prediction(input: sampleInput)
         let (policy, value) = (inference.policy, inference.value)
-        XCTAssertEqual(TensorShape([2, Int32(19 * 19 + 1)]), policy.shape)
+        XCTAssertEqual(TensorShape([2, 19 * 19 + 1]), policy.shape)
         XCTAssertEqual(TensorShape([2]), value.shape)
     }
 }

--- a/Tests/MiniGoTests/Strategies/MCTS/MCTSModelBasedPredictorTests.swift
+++ b/Tests/MiniGoTests/Strategies/MCTS/MCTSModelBasedPredictorTests.swift
@@ -10,7 +10,7 @@ final class MCTSModelBasedPredictorTests: XCTestCase {
             return GoModelOutput(
                 policy: Tensor<Float>(rangeFrom: 0, to: 19 * 19 + 1, stride:1),
                 value: Tensor<Float>(shape: [1], scalars: [0.9]),
-                logits: Tensor<Float>(randomUniform: [1, Int32(19 * 19 + 1)]))  // Not used.
+                logits: Tensor<Float>(randomUniform: [1, 19 * 19 + 1]))  // Not used.
         }
     }
 


### PR DESCRIPTION
- Two are due to the the compiler/stdlib changes.
- one is due to https://github.com/tensorflow/swift-models/pull/119/