### PR TITLE
Minor cleanup for MiniGo.

### DIFF
--- a/MiniGo/Strategies/MCTS/MCTSPredictor.swift
+++ b/MiniGo/Strategies/MCTS/MCTSPredictor.swift
@@ -44,4 +44,3 @@ public struct MCTSPrediction {
 public protocol MCTSPredictor: class {
     func prediction(for boardState: BoardState) -> MCTSPrediction
 }
-

--- a/Tests/MiniGoTests/Models/GoModelTests.swift
+++ b/Tests/MiniGoTests/Models/GoModelTests.swift
@@ -9,7 +9,7 @@ final class GoModelTests: XCTestCase {
         let model = GoModel(configuration: modelConfiguration)
 
         let sampleInput = Tensor<Float>(randomUniform: [2, 19, 19, 17])
-        let inference = model.prediction(input: sampleInput)
+        let inference = model.prediction(for: sampleInput)
         let (policy, value) = (inference.policy, inference.value)
         XCTAssertEqual(TensorShape([2, 19 * 19 + 1]), policy.shape)
         XCTAssertEqual(TensorShape([2]), value.shape)

--- a/Tests/MiniGoTests/Strategies/MCTS/MCTSModelBasedPredictorTests.swift
+++ b/Tests/MiniGoTests/Strategies/MCTS/MCTSModelBasedPredictorTests.swift
@@ -6,7 +6,7 @@ import XCTest
 final class MCTSModelBasedPredictorTests: XCTestCase {
 
     struct MockModel: InferenceModel {
-        func prediction(input: Tensor<Float>) -> GoModelOutput {
+        func prediction(for: Tensor<Float>) -> GoModelOutput {
             return GoModelOutput(
                 policy: Tensor<Float>(rangeFrom: 0, to: 19 * 19 + 1, stride:1),
                 value: Tensor<Float>(shape: [1], scalars: [0.9]),


### PR DESCRIPTION
- Rename `InferenceModel`'s `prediction(input:)` to `prediction(for:)`.
- Rename `GoModel._vjpApplied(to:)` to `GoModel._vjpCall(_:)`.
- Minor formatting changes.
- Remove outdated comments about `Int32` indices.