### PR TITLE
MiniGo style pass and and minor logic enhancements.

### DIFF
--- a/MiniGo/GameLib/Board.swift
+++ b/MiniGo/GameLib/Board.swift
@@ -46,7 +46,6 @@ struct Board: Hashable {
 }
 
 extension Board: CustomStringConvertible {
-
     var description: String {
         var output = ""
 
@@ -103,4 +102,3 @@ extension Board: CustomStringConvertible {
         return output
     }
 }
-

--- a/MiniGo/GameLib/BoardState.swift
+++ b/MiniGo/GameLib/BoardState.swift
@@ -276,8 +276,7 @@ extension Board {
 
         for neighbor in position.neighbors(boardSize: self.size) {
             guard let group = libertyTracker.group(at: neighbor) else {
-                // If the neighbor is not occupied, no liberty group, the position is
-                // OK.
+                // If the neighbor is not occupied, no liberty group, the position is OK.
                 return false
             }
             if group.color == nextPlayerColor {
@@ -288,14 +287,14 @@ extension Board {
             }
         }
 
-        // After removing the new postion from liberties, if there is no liberties
-        // left, this move is suicide.
+        // After removing the new postion from liberties, if there is no liberties left, this move
+        // is suicide.
         possibleLiberties.remove(position)
         return possibleLiberties.isEmpty
     }
 
-    /// Checks whether the position is a potential ko, i.e., whether the position is surrounded by all
-    /// sides belonging to the opponent.
+    /// Checks whether the position is a potential ko, i.e., whether the position is surrounded by
+    /// all sides belonging to the opponent.
     ///
     /// This is an approximated algorithm to find `ko`. See https://en.wikipedia.org/wiki/Ko_fight
     /// for details.
@@ -334,8 +333,9 @@ extension Board {
             }
         }
 
-        // Second pass: Calculates the territory and borders for each empty position, if there is any.
-        // If territory is surrounded by the stones in same color, fills that color in territory.
+        // Second pass: Calculates the territory and borders for each empty position, if there is
+        // any. If territory is surrounded by the stones in same color, fills that color in
+        // territory.
         while !emptyPositions.isEmpty {
             let emptyPosition = emptyPositions.removeFirst()
 
@@ -401,7 +401,8 @@ extension Board {
             for neighbor in currentPosition.neighbors(boardSize: self.size) {
                 if self.color(at: neighbor) == nil {
                     if !territory.contains(neighbor) {
-                        // We have not explored this (empty) position, so queue it up for processing.
+                        // We have not explored this (empty) position, so queue it up for
+                        // processing.
                         candidates.insert(neighbor)
                     }
                 } else {
@@ -411,12 +412,10 @@ extension Board {
             }
         } while !candidates.isEmpty
 
-        precondition(
-            territory.allSatisfy { self.color(at: $0) == nil },
-            "territory must be all empty (no stones).")
-        precondition(
-            borders.allSatisfy { self.color(at: $0) != nil },
-            "borders cannot have empty positions.")
+        precondition(territory.allSatisfy { self.color(at: $0) == nil },
+                     "territory must be all empty (no stones).")
+        precondition(borders.allSatisfy { self.color(at: $0) != nil },
+                     "borders cannot have empty positions.")
         return (territory, borders)
     }
 }

--- a/MiniGo/GameLib/BoardState.swift
+++ b/MiniGo/GameLib/BoardState.swift
@@ -38,8 +38,9 @@ private enum PositionStatus: Equatable {
 /// `BoardState` checks whether a new placed stone is legal or not. If so,
 /// creates a new snapshot.
 public struct BoardState {
-
+    /// The game configuration.
     let gameConfiguration: GameConfiguration
+    /// The color of the next player.
     let nextPlayerColor: Color
 
     /// The position of potential `ko`. See `IllegalMove.ko` for details.
@@ -218,7 +219,6 @@ extension BoardState: Equatable {
 }
 
 extension Board {
-
     /// Calculates all legal moves on board.
     fileprivate func allLegalMoves(
         ko: Position?,
@@ -320,7 +320,6 @@ extension Board {
     /// `komi` is the points added to the score of the player with the white stones as compensation
     /// for playing second.
     fileprivate func scoreForBlackPlayer(komi: Float) -> Float {
-
         // Makes a copy as we will modify it over time.
         var scoreBoard = self
 

--- a/MiniGo/GameLib/Color.swift
+++ b/MiniGo/GameLib/Color.swift
@@ -28,4 +28,3 @@ extension Color: CustomStringConvertible {
         }
     }
 }
-

--- a/MiniGo/GameLib/GameConfiguration.swift
+++ b/MiniGo/GameLib/GameConfiguration.swift
@@ -15,19 +15,19 @@
 /// Represents an (immutable) configuration of a Go game.
 public struct GameConfiguration {
     /// The board size of the game.
-    let size: Int
+    public let size: Int
 
     /// The points added to the score of the player with the white stones as compensation for playing
     /// second.
-    let komi: Float
+    public let komi: Float
 
     /// The maximum number of board states to track.
     ///
     /// This does not include the the current board.
-    let maxHistoryCount: Int
+    public let maxHistoryCount: Int
 
     /// If true, enables debugging information.
-    let isVerboseDebuggingEnabled: Bool
+    public let isVerboseDebuggingEnabled: Bool
 
     public init(
         size: Int,
@@ -41,4 +41,3 @@ public struct GameConfiguration {
         self.isVerboseDebuggingEnabled = isVerboseDebuggingEnabled
     }
 }
-

--- a/MiniGo/GameLib/LibertyTracker.swift
+++ b/MiniGo/GameLib/LibertyTracker.swift
@@ -183,11 +183,9 @@ extension LibertyTracker {
 
     /// Assigns a new unique group ID.
     mutating private func assignNewGroupID() -> Int {
-        let newID = nextGroupIDToAssign
-        precondition(groups[newID] == nil)
-
-        nextGroupIDToAssign += 1
-        return newID
+        defer { nextGroupIDToAssign += 1 }
+        precondition(!groups.keys.contains(nextGroupIDToAssign))
+        return nextGroupIDToAssign
     }
 
     /// Creates a new group for the single stone with liberties.

--- a/MiniGo/GameLib/LibertyTracker.swift
+++ b/MiniGo/GameLib/LibertyTracker.swift
@@ -36,11 +36,10 @@ struct LibertyTracker {
     /// The game configuration.
     private let gameConfiguration: GameConfiguration
 
-    // Tracks the liberty groups. For a position (stone) having no group,
-    // groupIndex[stone] should be nil. Otherwise, the group ID should be
-    // groupIndex[stone] and its group is groups[groupIndex[stone]].
-    // The invariance check can be done via checkLibertyGroupsInvariance helper
-    // method.
+    // Tracks the liberty groups. For a position (stone) having no group, `groupIndex[stone]` should
+    // be `nil`. Otherwise, the group ID should be `groupIndex[stone]` and its group is
+    // `groups[groupIndex[stone]]`. The invariance check can be done via the
+    // `checkLibertyGroupsInvariance()` helper method.
     private var nextGroupIDToAssign = 0
     private var groupIndex: [[Int?]]
     private var groups: [Int: LibertyGroup] = [:]
@@ -64,7 +63,7 @@ struct LibertyTracker {
     }
 }
 
-/// Extend `LibertyTracker` to have a mutating method by placing a new stone.
+// Extend `LibertyTracker` to have a mutating method by placing a new stone.
 extension LibertyTracker {
     /// Adds a new stone to the board and returns all captured stones.
     mutating func addStone(at position: Position, withColor color: Color) throws -> Set<Position> {
@@ -80,7 +79,6 @@ extension LibertyTracker {
         var friendlyNeighboringGroupIDs = Set<Int>()
 
         for neighbor in position.neighbors(boardSize: gameConfiguration.size) {
-
             // First, handle the case neighbor has no group.
             guard let neighborGroupID = groupIndex(for: neighbor) else {
                 emptyNeighbors.insert(neighbor)
@@ -295,5 +293,3 @@ extension LibertyTracker {
         }
     }
 }
-
-

--- a/MiniGo/GameLib/LibertyTracker.swift
+++ b/MiniGo/GameLib/LibertyTracker.swift
@@ -260,9 +260,6 @@ extension LibertyTracker {
                 guard let index = groups.index(forKey: neighborGroupID) else {
                     fatalErrorForGroupsInvariance(groupID: neighborGroupID)
                 }
-                // This force unwrap is safe as we checked the key existence above. As
-                // the value in the groups is struct. We need the force unwrap to do
-                // mutation in place.
                 groups.values[index].liberties.insert(capturedStone)
             }
         }
@@ -277,7 +274,7 @@ extension LibertyTracker {
 
         print(message)
 
-        /// Prints the group index for the board.
+        // Prints the group index for the board.
         let size = gameConfiguration.size
         for x in 0..<size {
             for y in 0..<size {

--- a/MiniGo/GameLib/LibertyTracker.swift
+++ b/MiniGo/GameLib/LibertyTracker.swift
@@ -258,16 +258,14 @@ extension LibertyTracker {
     ) {
         let size = gameConfiguration.size
         for capturedStone in capturedStones {
-            for neighbor in capturedStone.neighbors(boardSize: size) {
-                if let neighborGroupdID = groupIndex(for: neighbor) {
-                    guard let index = groups.index(forKey: neighborGroupdID) else {
-                        fatalErrorForGroupsInvariance(groupID: neighborGroupdID)
-                    }
-                    // This force unwrap is safe as we checked the key existence above. As
-                    // the value in the groups is struct. We need the force unwrap to do
-                    // mutation in place.
-                    groups.values[index].liberties.insert(capturedStone)
+            for neighborGroupID in capturedStone.neighbors(boardSize: size).compactMap(groupIndex) {
+                guard let index = groups.index(forKey: neighborGroupID) else {
+                    fatalErrorForGroupsInvariance(groupID: neighborGroupID)
                 }
+                // This force unwrap is safe as we checked the key existence above. As
+                // the value in the groups is struct. We need the force unwrap to do
+                // mutation in place.
+                groups.values[index].liberties.insert(capturedStone)
             }
         }
         assert(checkLibertyGroupsInvariance())

--- a/MiniGo/GameLib/Position.swift
+++ b/MiniGo/GameLib/Position.swift
@@ -14,13 +14,17 @@
 
 /// Represents a position in a Go game.
 public struct Position: Hashable, Equatable {
-    var x: Int
-    var y: Int
+    public var x: Int
+    public var y: Int
+    
+    public init(x: Int, y: Int) {
+        self.x = x
+        self.y = y
+    }
 }
 
 /// Returns all valid neighbors for the given position on board.
 extension Position {
-
     func neighbors(boardSize size: Int) -> [Position] {
         let neighbors = [
             Position(x: x+1, y: y),
@@ -28,7 +32,6 @@ extension Position {
             Position(x: x, y: y+1),
             Position(x: x, y: y-1),
         ]
-
         return neighbors.filter { 0..<size ~= $0.x && 0..<size ~= $0.y }
     }
 }

--- a/MiniGo/Models/PythonCheckpointReader.swift
+++ b/MiniGo/Models/PythonCheckpointReader.swift
@@ -22,8 +22,8 @@ public class PythonCheckpointReader {
         self.path = path
     }
 
-    // Currently returns Optional in order to support the case where the variable might not exist, but
-    // this is not implemented (see b/124126672)
+    // Currently returns an `Optional` in order to support the case where the variable might not
+    // exist, but this is not implemented (see b/124126672).
     func readTensor(layerName: String, weightName: String) -> Tensor<Float>? {
         let countSuffix = layerCounts[layerName] == nil ? "" : "_\(layerCounts[layerName]!)"
         let tensorName = layerName + countSuffix + "/" + weightName
@@ -102,14 +102,16 @@ extension BatchNorm: LoadableFromPythonCheckpoint where Scalar == Float {
         if let newRunningMean = reader.readTensor(
             layerName: "batch_normalization",
             weightName: "moving_mean") {
-            // do not check shapes, because Swift running mean/variance are initialized to scalar tensors
+            // Do not check shapes, because Swift running mean/variance are initialized to scalar
+            // tensors.
             runningMean.value = newRunningMean
         }
 
         if let newRunningVariance = reader.readTensor(
             layerName: "batch_normalization",
             weightName: "moving_variance") {
-            // do not check shapes, because Swift running mean/variance are initialized to scalar tensors
+            // Do not check shapes, because Swift running mean/variance are initialized to scalar
+            // tensors.
             runningVariance.value = newRunningVariance
         }
 

--- a/MiniGo/Models/PythonCheckpointReader.swift
+++ b/MiniGo/Models/PythonCheckpointReader.swift
@@ -36,7 +36,7 @@ public class PythonCheckpointReader {
             dtypes$dtype: [Float.tensorFlowDataType]))
     }
 
-    /// Increment a per-layer counter for variable names in the checkpoint file.
+    /// Increments a per-layer counter for variable names in the checkpoint file.
     /// As the Python model code uses low-level TensorFlow APIs, variables are namespaced only by
     /// layer name and this per-layer counter (e.g., conv2d_5/bias).
     func increment(layerName: String) {

--- a/MiniGo/Play/PlayOneGame.swift
+++ b/MiniGo/Play/PlayOneGame.swift
@@ -14,13 +14,10 @@
 
 /// Plays one game with participants. The game ends with two passes.
 public func playOneGame(gameConfiguration: GameConfiguration, participants: [Policy]) throws {
-
     var boardState = BoardState(gameConfiguration: gameConfiguration)
     precondition(participants.count == 2, "Must provide two participants.")
-    precondition(
-        participants[0].participantName !=  participants[1].participantName,
-        "Participants' names should not be same.")
-
+    precondition(participants[0].participantName !=  participants[1].participantName,
+                 "Participants' names should not be same.")
     // Choose a random participant to play black.
     let shuffled = participants.shuffled()
     let blackPlayer = shuffled.first! // precondition makes safe force unwrap

--- a/MiniGo/Strategies/MCTS/MCTSPredictor.swift
+++ b/MiniGo/Strategies/MCTS/MCTSPredictor.swift
@@ -44,4 +44,3 @@ public struct MCTSPrediction {
 public protocol MCTSPredictor: class {
     func prediction(for boardState: BoardState) -> MCTSPrediction
 }
-

--- a/MiniGo/main.swift
+++ b/MiniGo/main.swift
@@ -53,4 +53,3 @@ try playOneGame(
         MCTSPolicy(participantName: "white", predictor: predictor,
                    configuration: mctsConfiguration),
     ])
-

--- a/MiniGo/main.swift
+++ b/MiniGo/main.swift
@@ -29,11 +29,8 @@ print("Loading checkpoint into GoModel. Might take a while.")
 let modelConfig = ModelConfiguration(boardSize: boardSize)
 var model = GoModel(configuration: modelConfig)
 
-guard FileManager.default.fileExists(
-    atPath: "./MiniGoCheckpoint/000939-heron.data-00000-of-00001"
-) else {
-    fatalError("Please download the MiniGo checkpoint according to the README.md.")
-}
+guard FileManager.default.fileExists(atPath: "./MiniGoCheckpoint/000939-heron.data-00000-of-00001")
+    else { fatalError("Please download the MiniGo checkpoint according to the README.md.") }
 let reader = PythonCheckpointReader(path: "./MiniGoCheckpoint/000939-heron")
 model.load(from: reader)
 
@@ -51,7 +48,9 @@ let mctsConfiguration = MCTSConfiguration(
 try playOneGame(
     gameConfiguration: gameConfiguration,
     participants: [
-        MCTSPolicy(participantName: "black", predictor: predictor, configuration: mctsConfiguration),
-        MCTSPolicy(participantName: "white", predictor: predictor, configuration: mctsConfiguration),
+        MCTSPolicy(participantName: "black", predictor: predictor,
+                   configuration: mctsConfiguration),
+        MCTSPolicy(participantName: "white", predictor: predictor,
+                   configuration: mctsConfiguration),
     ])
 

--- a/Tests/MiniGoTests/Models/GoModelTests.swift
+++ b/Tests/MiniGoTests/Models/GoModelTests.swift
@@ -9,7 +9,7 @@ final class GoModelTests: XCTestCase {
         let model = GoModel(configuration: modelConfiguration)
 
         let sampleInput = Tensor<Float>(randomUniform: [2, 19, 19, 17])
-        let inference = model.prediction(input: sampleInput)
+        let inference = model.prediction(for: sampleInput)
         let (policy, value) = (inference.policy, inference.value)
         XCTAssertEqual(TensorShape([2, 19 * 19 + 1]), policy.shape)
         XCTAssertEqual(TensorShape([2]), value.shape)

--- a/Tests/MiniGoTests/Strategies/MCTS/MCTSModelBasedPredictorTests.swift
+++ b/Tests/MiniGoTests/Strategies/MCTS/MCTSModelBasedPredictorTests.swift
@@ -6,7 +6,7 @@ import XCTest
 final class MCTSModelBasedPredictorTests: XCTestCase {
 
     struct MockModel: InferenceModel {
-        func prediction(input: Tensor<Float>) -> GoModelOutput {
+        func prediction(for: Tensor<Float>) -> GoModelOutput {
             return GoModelOutput(
                 policy: Tensor<Float>(rangeFrom: 0, to: 19 * 19 + 1, stride:1),
                 value: Tensor<Float>(shape: [1], scalars: [0.9]),


### PR DESCRIPTION
Logic changes:
* In LibertyTracker.swift, use dictionary indices to avoid force unwrapping. Removed a lot of bangs!
* Make `ModelConfiguration.boardSize` public since the initializer takes a `boardSize` for better transparency. It's a little weird for an initializer to take a constant, store it and make it private.
* Reduce nesting in `LibertyTracker.updateLibertiesAfterRemovingCapturedStones(_:)` with `compactMap(_:)`.
* Simplify `assignNewGroupID()` with a `defer` block.

Formatting changes:
* Make every file end with exactly 1 empty line.
* Add some minor comments.
* Remove empty lines between the start of a type declaration or extension and the first declaration for consistency.
* Make `GoModel` code fit within 100 columns.