### PR TITLE
Fix up models so they can run.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@
 .build
 *.xcodeproj
 .DS_Store
+output
+cifar-10-batches-py/

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,6 @@
 
 .build
 *.xcodeproj
+*.png
 .DS_Store
-output
 cifar-10-batches-py/

--- a/Autoencoder/main.swift
+++ b/Autoencoder/main.swift
@@ -47,7 +47,7 @@ func plot(image: [Float], name: String) {
 
 /// Reads a file into an array of bytes.
 func readFile(_ filename: String) -> [UInt8] {
-    let possibleFolders = [".", "Resources"]
+    let possibleFolders = [".", "Resources", "Autoencoder/Resources"]
     for folder in possibleFolders {
         let parent = URL(fileURLWithPath: folder)
         let filePath = parent.appendingPathComponent(filename).path

--- a/MNIST/main.swift
+++ b/MNIST/main.swift
@@ -15,12 +15,8 @@
 import Foundation
 import TensorFlow
 
-struct FileNotFound: Error {
-    let filename: String
-}
-
 /// Reads a file into an array of bytes.
-func readFile(_ path: String) throws -> [UInt8] {
+func readFile(_ path: String) -> [UInt8] {
     let possibleFolders  = [".", "MNIST"]
     for folder in possibleFolders {
         let parent = URL(fileURLWithPath: folder)
@@ -28,18 +24,18 @@ func readFile(_ path: String) throws -> [UInt8] {
         guard FileManager.default.fileExists(atPath: filePath.path) else {
             continue
         }
-        let data = try Data(contentsOf: filePath, options: [])
+        let data = try! Data(contentsOf: filePath, options: [])
         return [UInt8](data)
     }
-    throw FileNotFound(filename: path)
+    fatalError("Filename not found: \(path)")
 }
 
 /// Reads MNIST images and labels from specified file paths.
 func readMNIST(imagesFile: String, labelsFile: String) -> (images: Tensor<Float>,
                                                            labels: Tensor<Int32>) {
     print("Reading data.")
-    let images = try! readFile(imagesFile).dropFirst(16).map(Float.init)
-    let labels = try! readFile(labelsFile).dropFirst(8).map(Int32.init)
+    let images = readFile(imagesFile).dropFirst(16).map(Float.init)
+    let labels = readFile(labelsFile).dropFirst(8).map(Int32.init)
     let rowCount = labels.count
     let imageHeight = 28, imageWidth = 28
 

--- a/MNIST/main.swift
+++ b/MNIST/main.swift
@@ -15,19 +15,31 @@
 import Foundation
 import TensorFlow
 
+struct FileNotFound: Error {
+    let filename: String
+}
+
 /// Reads a file into an array of bytes.
-func readFile(_ path: String) -> [UInt8] {
-    let url = URL(fileURLWithPath: path)
-    let data = try! Data(contentsOf: url, options: [])
-    return [UInt8](data)
+func readFile(_ path: String) throws -> [UInt8] {
+    let possibleFolders  = [".", "MNIST"]
+    for folder in possibleFolders {
+        let parent = URL(fileURLWithPath: folder)
+        let filePath = parent.appendingPathComponent(path)
+        guard FileManager.default.fileExists(atPath: filePath.path) else {
+            continue
+        }
+        let data = try Data(contentsOf: filePath, options: [])
+        return [UInt8](data)
+    }
+    throw FileNotFound(filename: path)
 }
 
 /// Reads MNIST images and labels from specified file paths.
 func readMNIST(imagesFile: String, labelsFile: String) -> (images: Tensor<Float>,
                                                            labels: Tensor<Int32>) {
     print("Reading data.")
-    let images = readFile(imagesFile).dropFirst(16).map(Float.init)
-    let labels = readFile(labelsFile).dropFirst(8).map(Int32.init)
+    let images = try! readFile(imagesFile).dropFirst(16).map(Float.init)
+    let labels = try! readFile(labelsFile).dropFirst(8).map(Int32.init)
     let rowCount = labels.count
     let imageHeight = 28, imageWidth = 28
 
@@ -75,6 +87,8 @@ let labels = Tensor<Float>(oneHotAtIndices: numericLabels, depth: 10)
 
 var classifier = Classifier()
 let optimizer = RMSProp(for: classifier)
+
+print("Beginning training...")
 
 // The training loop.
 for epoch in 1...epochCount {


### PR DESCRIPTION
As part of the migration to a single SwiftPM-based package for the models
repository, the working directory where people run `swift run` has changed.
As a result, a number of relative-path lookups were broken when actually
running models. This commit fixes them up so they all properly run.