### PR TITLE
Gracefully exit instead of crashing when a file is not found.

### DIFF
--- a/Autoencoder/main.swift
+++ b/Autoencoder/main.swift
@@ -57,8 +57,8 @@ func readFile(_ filename: String) -> [UInt8] {
         let d = Python.open(filePath, "rb").read()
         return Array(numpy: np.frombuffer(d, dtype: np.uint8))!
     }
-    fatalError(
-        "Failed to find file with name \(filename) in the following folders: \(possibleFolders).")
+    print("Failed to find file with name \(filename) in the following folders: \(possibleFolders).")
+    exit(-1)
 }
 
 /// Reads MNIST images and labels from specified file paths.

--- a/MNIST/main.swift
+++ b/MNIST/main.swift
@@ -28,7 +28,7 @@ func readFile(_ path: String) -> [UInt8] {
         return [UInt8](data)
     }
     print("File not found: \(path)")
-    exit(-1);
+    exit(-1)
 }
 
 /// Reads MNIST images and labels from specified file paths.

--- a/MNIST/main.swift
+++ b/MNIST/main.swift
@@ -27,7 +27,8 @@ func readFile(_ path: String) -> [UInt8] {
         let data = try! Data(contentsOf: filePath, options: [])
         return [UInt8](data)
     }
-    fatalError("Filename not found: \(path)")
+    print("File not found: \(path)")
+    exit(-1);
 }
 
 /// Reads MNIST images and labels from specified file paths.

--- a/MiniGo/main.swift
+++ b/MiniGo/main.swift
@@ -30,7 +30,10 @@ let modelConfig = ModelConfiguration(boardSize: boardSize)
 var model = GoModel(configuration: modelConfig)
 
 guard FileManager.default.fileExists(atPath: "./MiniGoCheckpoint/000939-heron.data-00000-of-00001")
-    else { fatalError("Please download the MiniGo checkpoint according to the README.md.") }
+else {
+    print("Please download the MiniGo checkpoint according to the README.md.")
+    exit(-1)
+}
 let reader = PythonCheckpointReader(path: "./MiniGoCheckpoint/000939-heron")
 model.load(from: reader)
 


### PR DESCRIPTION
Use `print(_:)` and `exit(_:)` instead of a `fatalError(_:file:line:)` so that the program won't crash when a file doesn't exist.