### PR TITLE
match api change: call --> callAsFunction

### DIFF
--- a/Autoencoder/main.swift
+++ b/Autoencoder/main.swift
@@ -94,7 +94,7 @@ struct Autoencoder: Layer {
         activation: tanh)
 
     @differentiable
-    func call(_ input: Input) -> Output {
+    func callAsFunction(_ input: Input) -> Output {
         let encoder = input.sequenced(through: encoder1, encoder2, encoder3, encoder4)
         return encoder.sequenced(through: decoder1, decoder2, decoder3, decoder4)
     }

--- a/Gym/CartPole/main.swift
+++ b/Gym/CartPole/main.swift
@@ -48,7 +48,7 @@ struct Net: Layer {
     }
 
     @differentiable
-    func call(_ input: Input) -> Output {
+    func callAsFunction(_ input: Input) -> Output {
         return input.sequenced(through: l1, l2)
     }
 }

--- a/MNIST/main.swift
+++ b/MNIST/main.swift
@@ -64,7 +64,7 @@ struct Classifier: Layer {
     var layer1b = Dense<Float>(inputSize: 128, outputSize: 10, activation: softmax)
 
     @differentiable
-    func call(_ input: Input) -> Output {
+    func callAsFunction(_ input: Input) -> Output {
         let convolved = input.sequenced(through: conv1a, conv1b, pool1)
         return convolved.sequenced(through: dropout1a, flatten, layer1a, dropout1b, layer1b)
     }

--- a/MiniGo/Models/GoModel.swift
+++ b/MiniGo/Models/GoModel.swift
@@ -61,7 +61,7 @@ struct ConvBN: Layer {
     }
 
     @differentiable
-    func call(_ input: Tensor<Float>) -> Tensor<Float> {
+    func callAsFunction(_ input: Tensor<Float>) -> Tensor<Float> {
         return norm(conv(input))
     }
 }
@@ -90,7 +90,7 @@ struct ResidualIdentityBlock: Layer {
     }
 
     @differentiable
-    func call(_ input: Tensor<Float>) -> Tensor<Float> {
+    func callAsFunction(_ input: Tensor<Float>) -> Tensor<Float> {
         var tmp = relu(layer1(input))
         tmp = layer2(tmp)
         return relu(tmp + input)
@@ -158,7 +158,7 @@ public struct GoModel: Layer {
     }
   
     @differentiable(wrt: (self, input), vjp: _vjpCall)
-    public func call(_ input: Tensor<Float>) -> GoModelOutput {
+    public func callAsFunction(_ input: Tensor<Float>) -> GoModelOutput {
         let batchSize = input.shape[0]
         var output = relu(initialConv(input))
 


### PR DESCRIPTION
see also #165.

rest work with this pr, following are broken:

    - Catch (needs love)
    - CIFAR (tensorhandles)
    - ResNet (tensorhandles)
    - Transformer (_vjpGathering)