### PR TITLE
Added .swift-format and updated .gitignore for Xcode 11's SwiftPM support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,4 +5,5 @@
 *.xcodeproj
 *.png
 .DS_Store
+.swiftpm
 cifar-10-batches-py/

--- a/.swift-format
+++ b/.swift-format
@@ -1,0 +1,14 @@
+{
+    "version": 1,
+    "lineLength": 100,
+    "indentation": {
+        "spaces": 4
+    },
+    "maximumBlankLines": 1,
+    "respectsExistingLineBreaks": true,
+    "blankLineBetweenMembers": {
+        "ignoreSingleLineProperties": true
+    },
+    "lineBreakBeforeControlFlowKeywords": false,
+    "lineBreakBeforeEachArgument": false
+}


### PR DESCRIPTION
This replicates the following pull request on swift-apis: https://github.com/tensorflow/swift-apis/pull/374 , adding a `swift-format` configuration file. Note the cautions indicated in that pull request around use of `swift-format` at present.

This also adds a .gitignore line to prevent Xcode 11's new SwiftPM support from adding supporting files to the repository.