### PR TITLE
Replaced Python with Swift in CIFAR10 dataset loading

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@
 .DS_Store
 .swiftpm
 cifar-10-batches-py/
+cifar-10-batches-bin/

--- a/CIFAR/Data.swift
+++ b/CIFAR/Data.swift
@@ -69,12 +69,6 @@ func downloadCIFAR10IfNotPresent(to directory: String = ".") {
     print("Unarchiving completed")
 }
 
-extension Tensor where Scalar: _TensorFlowDataTypeCompatible {
-    public var _tfeTensorHandle: _AnyTensorHandle {
-        TFETensorHandle(_owning: handle._cTensorHandle)
-    }
-}
-
 struct Example: TensorGroup {
     var label: Tensor<Int32>
     var data: Tensor<Float>
@@ -92,10 +86,6 @@ struct Example: TensorGroup {
         let dataIndex = _handles.index(labelIndex, offsetBy: 1)
         label = Tensor<Int32>(handle: TensorHandle<Int32>(handle: _handles[labelIndex]))
         data = Tensor<Float>(handle: TensorHandle<Float>(handle: _handles[dataIndex]))
-    }
-
-    public var _tensorHandles: [_AnyTensorHandle] {
-        [label._tfeTensorHandle, data._tfeTensorHandle]
     }
 }
 

--- a/CIFAR/Data.swift
+++ b/CIFAR/Data.swift
@@ -1,4 +1,4 @@
-// Copyright 2018 The TensorFlow Authors. All Rights Reserved.
+// Copyright 2019 The TensorFlow Authors. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,24 +12,62 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import Python
+import Foundation
 import TensorFlow
 
-/// Use Python and shell calls to download and extract the CIFAR-10 tarball if not already done
-/// This can fail for many reasons (e.g. lack of `wget`, `tar`, or an Internet connection)
 func downloadCIFAR10IfNotPresent(to directory: String = ".") {
-    let subprocess = Python.import("subprocess")
-    let path = Python.import("os.path")
-    let filepath = "\(directory)/cifar-10-batches-py"
-    let isdir = Bool(path.isdir(filepath))!
-    if !isdir {
-        print("Downloading CIFAR data...")
-        let command = "wget -nv -O- https://www.cs.toronto.edu/~kriz/cifar-10-python.tar.gz | tar xzf - -C \(directory)"
-        subprocess.call(command, shell: true)
+    let downloadPath = "\(directory)/cifar-10-batches-bin"
+    let directoryExists = FileManager.default.fileExists(atPath: downloadPath)
+
+    if !directoryExists {
+        print("Downloading CIFAR dataset...")
+        let archivePath = "\(directory)/cifar-10-binary.tar.gz"
+        let archiveExists = FileManager.default.fileExists(atPath: archivePath)
+        if !archiveExists {
+            print("Archive missing, downloading...")
+            do {
+                let downloadedFile = try Data(
+                    contentsOf: URL(
+                        string: "https://www.cs.toronto.edu/~kriz/cifar-10-binary.tar.gz")!)
+                try downloadedFile.write(to: URL(fileURLWithPath: archivePath))
+            } catch {
+                fatalError("Could not download CIFAR dataset, error: \(error)")
+            }
+        }
+
+        print("Archive downloaded, processing...")
+
+        #if os(macOS)
+            let tarLocation = "/usr/bin/tar"
+        #else
+            let tarLocation = "/bin/tar"
+        #endif
+
+        if #available(macOS 10.13, *) {
+            let task = Process()
+            task.executableURL = URL(fileURLWithPath: tarLocation)
+            task.arguments = ["xzf", archivePath]
+            do {
+                try task.run()
+                task.waitUntilExit()
+            } catch {
+                print("CIFAR extraction failed with error: \(error)")
+            }
+        } else {
+            fatalError("Process() is missing from this platform")
+        }
+
+        do {
+            try FileManager.default.removeItem(atPath: archivePath)
+        } catch {
+            fatalError("Could not remove archive, error: \(error)")
+        }
+
+        print("Unarchiving completed")
     }
 }
 
-extension Tensor where Scalar : _TensorFlowDataTypeCompatible {
+extension Tensor where Scalar: _TensorFlowDataTypeCompatible {
     public var _tfeTensorHandle: _AnyTensorHandle {
         TFETensorHandle(_owning: handle._cTensorHandle)
     }
@@ -54,39 +92,51 @@ struct Example: TensorGroup {
         data = Tensor<Float>(handle: TensorHandle<Float>(handle: _handles[dataIndex]))
     }
 
-    public var _tensorHandles: [_AnyTensorHandle] { [label._tfeTensorHandle, data._tfeTensorHandle] }
+    public var _tensorHandles: [_AnyTensorHandle] {
+        [label._tfeTensorHandle, data._tfeTensorHandle]
+    }
 }
 
-// Each CIFAR data file is provided as a Python pickle of NumPy arrays
 func loadCIFARFile(named name: String, in directory: String = ".") -> Example {
     downloadCIFAR10IfNotPresent(to: directory)
-    let np = Python.import("numpy")
-    let pickle = Python.import("pickle")
-    let path = "\(directory)/cifar-10-batches-py/\(name)"
-    let f = Python.open(path, "rb")
-    let res = pickle.load(f, encoding: "bytes")
+    let path = "\(directory)/cifar-10-batches-bin/\(name)"
 
-    let bytes = res[Python.bytes("data", encoding: "utf8")]
-    let labels = res[Python.bytes("labels", encoding: "utf8")]
+    let imageCount = 10000
+    guard let fileContents = try? Data(contentsOf: URL(fileURLWithPath: path)) else {
+        fatalError("Could not read dataset file: \(name)")
+    }
+    guard fileContents.count == 30_730_000 else {
+        fatalError(
+            "Dataset file \(name) should have 30730000 bytes, instead had \(fileContents.count)")
+    }
 
-    let labelTensor = Tensor<Int64>(numpy: np.array(labels))!
-    let images = Tensor<UInt8>(numpy: bytes)!
-    let imageCount = images.shape[0]
+    var bytes: [UInt8] = []
+    var labels: [Int64] = []
 
-    // reshape and transpose from the provided N(CHW) to TF default NHWC
-    let imageTensor = Tensor<Float>(images
-        .reshaped(to: [imageCount, 3, 32, 32])
-        .transposed(withPermutations: [0, 2, 3, 1]))
+    let imageByteSize = 3073
+    for imageIndex in 0..<imageCount {
+        let baseAddress = imageIndex * imageByteSize
+        labels.append(Int64(fileContents[baseAddress]))
+
+        bytes.append(contentsOf: fileContents[(baseAddress + 1)..<(baseAddress + 3073)])
+    }
+
+    let labelTensor = Tensor<Int64>(shape: [imageCount], scalars: labels)
+    let images = Tensor<UInt8>(shape: [imageCount, 3, 32, 32], scalars: bytes)
+
+    // transpose from the provided N(CHW) to TF default NHWC
+    let imageTensor = Tensor<Float>(
+        images.transposed(withPermutations: [0, 2, 3, 1]))
 
     let mean = Tensor<Float>([0.485, 0.456, 0.406])
-    let std  = Tensor<Float>([0.229, 0.224, 0.225])
+    let std = Tensor<Float>([0.229, 0.224, 0.225])
     let imagesNormalized = ((imageTensor / 255.0) - mean) / std
 
     return Example(label: Tensor<Int32>(labelTensor), data: imagesNormalized)
 }
 
 func loadCIFARTrainingFiles() -> Example {
-    let data = (1..<6).map { loadCIFARFile(named: "data_batch_\($0)") }
+    let data = (1..<6).map { loadCIFARFile(named: "data_batch_\($0).bin") }
     return Example(
         label: Raw.concat(concatDim: Tensor<Int32>(0), data.map { $0.label }),
         data: Raw.concat(concatDim: Tensor<Int32>(0), data.map { $0.data })
@@ -94,11 +144,12 @@ func loadCIFARTrainingFiles() -> Example {
 }
 
 func loadCIFARTestFile() -> Example {
-    return loadCIFARFile(named: "test_batch")
+    return loadCIFARFile(named: "test_batch.bin")
 }
 
 func loadCIFAR10() -> (
-  training: Dataset<Example>, test: Dataset<Example>) {
+    training: Dataset<Example>, test: Dataset<Example>
+) {
     let trainingDataset = Dataset<Example>(elements: loadCIFARTrainingFiles())
     let testDataset = Dataset<Example>(elements: loadCIFARTestFile())
     return (training: trainingDataset, test: testDataset)

--- a/CIFAR/Data.swift
+++ b/CIFAR/Data.swift
@@ -36,7 +36,8 @@ func downloadCIFAR10IfNotPresent(to directory: String = ".") {
                     string: "https://www.cs.toronto.edu/~kriz/cifar-10-binary.tar.gz")!)
             try downloadedFile.write(to: URL(fileURLWithPath: archivePath))
         } catch {
-            fatalError("Could not download CIFAR dataset, error: \(error)")
+            print("Could not download CIFAR dataset, error: \(error)")
+            exit(-1)
         }
     }
 
@@ -48,18 +49,14 @@ func downloadCIFAR10IfNotPresent(to directory: String = ".") {
         let tarLocation = "/bin/tar"
     #endif
 
-    if #available(macOS 10.13, *) {
-        let task = Process()
-        task.executableURL = URL(fileURLWithPath: tarLocation)
-        task.arguments = ["xzf", archivePath]
-        do {
-            try task.run()
-            task.waitUntilExit()
-        } catch {
-            print("CIFAR extraction failed with error: \(error)")
-        }
-    } else {
-        fatalError("Process() is missing from this platform")
+    let task = Process()
+    task.executableURL = URL(fileURLWithPath: tarLocation)
+    task.arguments = ["xzf", archivePath]
+    do {
+        try task.run()
+        task.waitUntilExit()
+    } catch {
+        print("CIFAR extraction failed with error: \(error)")
     }
 
     do {
@@ -108,11 +105,13 @@ func loadCIFARFile(named name: String, in directory: String = ".") -> Example {
 
     let imageCount = 10000
     guard let fileContents = try? Data(contentsOf: URL(fileURLWithPath: path)) else {
-        fatalError("Could not read dataset file: \(name)")
+        print("Could not read dataset file: \(name)")
+        exit(-1)
     }
     guard fileContents.count == 30_730_000 else {
-        fatalError(
+        print(
             "Dataset file \(name) should have 30730000 bytes, instead had \(fileContents.count)")
+        exit(-1)
     }
 
     var bytes: [UInt8] = []

--- a/CIFAR/Data.swift
+++ b/CIFAR/Data.swift
@@ -121,16 +121,14 @@ func loadCIFARFile(named name: String, in directory: String = ".") -> Example {
     for imageIndex in 0..<imageCount {
         let baseAddress = imageIndex * imageByteSize
         labels.append(Int64(fileContents[baseAddress]))
-
         bytes.append(contentsOf: fileContents[(baseAddress + 1)..<(baseAddress + 3073)])
     }
 
     let labelTensor = Tensor<Int64>(shape: [imageCount], scalars: labels)
     let images = Tensor<UInt8>(shape: [imageCount, 3, 32, 32], scalars: bytes)
 
-    // transpose from the provided N(CHW) to TF default NHWC
-    let imageTensor = Tensor<Float>(
-        images.transposed(withPermutations: [0, 2, 3, 1]))
+    // Transpose from the CIFAR-provided N(CHW) to TF's default NHWC.
+    let imageTensor = Tensor<Float>(images.transposed(withPermutations: [0, 2, 3, 1]))
 
     let mean = Tensor<Float>([0.485, 0.456, 0.406])
     let std = Tensor<Float>([0.229, 0.224, 0.225])

--- a/CIFAR/Data.swift
+++ b/CIFAR/Data.swift
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 import Foundation
+import FoundationNetworking
 import TensorFlow
 
 func downloadCIFAR10IfNotPresent(to directory: String = ".") {

--- a/CIFAR/README.md
+++ b/CIFAR/README.md
@@ -6,12 +6,7 @@ classification on the [CIFAR-10](https://www.cs.toronto.edu/~kriz/cifar.html) da
 ## Setup
 
 You'll need [the latest version][INSTALL] of Swift for TensorFlow
-installed and added to your path. Additionally, the data loader requires Python
-3.x (rather than Python 2.7), `wget`, and `numpy`.
-
-> Note: For macOS, you need to set up the `PYTHON_LIBRARY` to help the Swift for
-> TensorFlow find the `libpython3.<minor-version>.dylib` file, e.g., in
-> `homebrew`.
+installed and added to your path.
 
 To train the default model, run:
 

--- a/CIFAR/main.swift
+++ b/CIFAR/main.swift
@@ -13,8 +13,6 @@
 // limitations under the License.
 
 import TensorFlow
-import Python
-PythonLibrary.useVersion(3)
 
 let batchSize = 100
 

--- a/Package.swift
+++ b/Package.swift
@@ -1,10 +1,13 @@
-// swift-tools-version:4.2
+// swift-tools-version:5.0
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription
 
 let package = Package(
     name: "TensorFlowModels",
+    platforms: [
+        .macOS(.v10_13)
+    ],
     products: [
         .executable(name: "MNIST", targets: ["MNIST"]),
         .executable(name: "CIFAR", targets: ["CIFAR"]),

--- a/ResNet/Data.swift
+++ b/ResNet/Data.swift
@@ -69,12 +69,6 @@ func downloadCIFAR10IfNotPresent(to directory: String = ".") {
     print("Unarchiving completed")
 }
 
-extension Tensor where Scalar: _TensorFlowDataTypeCompatible {
-    public var _tfeTensorHandle: _AnyTensorHandle {
-        TFETensorHandle(_owning: handle._cTensorHandle)
-    }
-}
-
 struct Example: TensorGroup {
     var label: Tensor<Int32>
     var data: Tensor<Float>
@@ -92,10 +86,6 @@ struct Example: TensorGroup {
         let dataIndex = _handles.index(labelIndex, offsetBy: 1)
         label = Tensor<Int32>(handle: TensorHandle<Int32>(handle: _handles[labelIndex]))
         data = Tensor<Float>(handle: TensorHandle<Float>(handle: _handles[dataIndex]))
-    }
-
-    public var _tensorHandles: [_AnyTensorHandle] {
-        [label._tfeTensorHandle, data._tfeTensorHandle]
     }
 }
 

--- a/ResNet/Data.swift
+++ b/ResNet/Data.swift
@@ -12,27 +12,62 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import Python
+import Foundation
 import TensorFlow
 
-/// Use Python and shell calls to download and extract the CIFAR-10 tarball if not already done
-/// This can fail for many reasons (e.g. lack of `wget`, `tar`, or an Internet connection)
 func downloadCIFAR10IfNotPresent(to directory: String = ".") {
-    let subprocess = Python.import("subprocess")
-    let path = Python.import("os.path")
-    let filepath = "\(directory)/cifar-10-batches-py"
-    let isdir = Bool(path.isdir(filepath))!
-    if !isdir {
-        print("Downloading CIFAR data...")
-        let command = """
-            wget -nv -O- https://www.cs.toronto.edu/~kriz/cifar-10-python.tar.gz | tar xzf - \
-            -C \(directory)
-            """
-        subprocess.call(command, shell: true)
+    let downloadPath = "\(directory)/cifar-10-batches-bin"
+    let directoryExists = FileManager.default.fileExists(atPath: downloadPath)
+
+    if !directoryExists {
+        print("Downloading CIFAR dataset...")
+        let archivePath = "\(directory)/cifar-10-binary.tar.gz"
+        let archiveExists = FileManager.default.fileExists(atPath: archivePath)
+        if !archiveExists {
+            print("Archive missing, downloading...")
+            do {
+                let downloadedFile = try Data(
+                    contentsOf: URL(
+                        string: "https://www.cs.toronto.edu/~kriz/cifar-10-binary.tar.gz")!)
+                try downloadedFile.write(to: URL(fileURLWithPath: archivePath))
+            } catch {
+                fatalError("Could not download CIFAR dataset, error: \(error)")
+            }
+        }
+
+        print("Archive downloaded, processing...")
+
+        #if os(macOS)
+            let tarLocation = "/usr/bin/tar"
+        #else
+            let tarLocation = "/bin/tar"
+        #endif
+
+        if #available(macOS 10.13, *) {
+            let task = Process()
+            task.executableURL = URL(fileURLWithPath: tarLocation)
+            task.arguments = ["xzf", archivePath]
+            do {
+                try task.run()
+                task.waitUntilExit()
+            } catch {
+                print("CIFAR extraction failed with error: \(error)")
+            }
+        } else {
+            fatalError("Process() is missing from this platform")
+        }
+
+        do {
+            try FileManager.default.removeItem(atPath: archivePath)
+        } catch {
+            fatalError("Could not remove archive, error: \(error)")
+        }
+
+        print("Unarchiving completed")
     }
 }
 
-extension Tensor where Scalar : _TensorFlowDataTypeCompatible {
+extension Tensor where Scalar: _TensorFlowDataTypeCompatible {
     public var _tfeTensorHandle: _AnyTensorHandle {
         TFETensorHandle(_owning: handle._cTensorHandle)
     }
@@ -57,39 +92,51 @@ struct Example: TensorGroup {
         data = Tensor<Float>(handle: TensorHandle<Float>(handle: _handles[dataIndex]))
     }
 
-    public var _tensorHandles: [_AnyTensorHandle] { [label._tfeTensorHandle, data._tfeTensorHandle] }
+    public var _tensorHandles: [_AnyTensorHandle] {
+        [label._tfeTensorHandle, data._tfeTensorHandle]
+    }
 }
 
-// Each CIFAR data file is provided as a Python pickle of NumPy arrays
 func loadCIFARFile(named name: String, in directory: String = ".") -> Example {
     downloadCIFAR10IfNotPresent(to: directory)
-    let np = Python.import("numpy")
-    let pickle = Python.import("pickle")
-    let path = "\(directory)/cifar-10-batches-py/\(name)"
-    let f = Python.open(path, "rb")
-    let res = pickle.load(f, encoding: "bytes")
+    let path = "\(directory)/cifar-10-batches-bin/\(name)"
 
-    let bytes = res[Python.bytes("data", encoding: "utf8")]
-    let labels = res[Python.bytes("labels", encoding: "utf8")]
+    let imageCount = 10000
+    guard let fileContents = try? Data(contentsOf: URL(fileURLWithPath: path)) else {
+        fatalError("Could not read dataset file: \(name)")
+    }
+    guard fileContents.count == 30_730_000 else {
+        fatalError(
+            "Dataset file \(name) should have 30730000 bytes, instead had \(fileContents.count)")
+    }
 
-    let labelTensor = Tensor<Int64>(numpy: np.array(labels))!
-    let images = Tensor<UInt8>(numpy: bytes)!
-    let imageCount = images.shape[0]
+    var bytes: [UInt8] = []
+    var labels: [Int64] = []
 
-    // reshape and transpose from the provided N(CHW) to TF default NHWC
-    let imageTensor = Tensor<Float>(images
-        .reshaped(to: [imageCount, 3, 32, 32])
-        .transposed(withPermutations: [0, 2, 3, 1]))
+    let imageByteSize = 3073
+    for imageIndex in 0..<imageCount {
+        let baseAddress = imageIndex * imageByteSize
+        labels.append(Int64(fileContents[baseAddress]))
+
+        bytes.append(contentsOf: fileContents[(baseAddress + 1)..<(baseAddress + 3073)])
+    }
+
+    let labelTensor = Tensor<Int64>(shape: [imageCount], scalars: labels)
+    let images = Tensor<UInt8>(shape: [imageCount, 3, 32, 32], scalars: bytes)
+
+    // transpose from the provided N(CHW) to TF default NHWC
+    let imageTensor = Tensor<Float>(
+        images.transposed(withPermutations: [0, 2, 3, 1]))
 
     let mean = Tensor<Float>([0.485, 0.456, 0.406])
-    let std  = Tensor<Float>([0.229, 0.224, 0.225])
+    let std = Tensor<Float>([0.229, 0.224, 0.225])
     let imagesNormalized = ((imageTensor / 255.0) - mean) / std
 
     return Example(label: Tensor<Int32>(labelTensor), data: imagesNormalized)
 }
 
 func loadCIFARTrainingFiles() -> Example {
-    let data = (1..<6).map { loadCIFARFile(named: "data_batch_\($0)") }
+    let data = (1..<6).map { loadCIFARFile(named: "data_batch_\($0).bin") }
     return Example(
         label: Raw.concat(concatDim: Tensor<Int32>(0), data.map { $0.label }),
         data: Raw.concat(concatDim: Tensor<Int32>(0), data.map { $0.data })
@@ -97,10 +144,12 @@ func loadCIFARTrainingFiles() -> Example {
 }
 
 func loadCIFARTestFile() -> Example {
-    return loadCIFARFile(named: "test_batch")
+    return loadCIFARFile(named: "test_batch.bin")
 }
 
-func loadCIFAR10() -> (training: Dataset<Example>, test: Dataset<Example>) {
+func loadCIFAR10() -> (
+    training: Dataset<Example>, test: Dataset<Example>
+) {
     let trainingDataset = Dataset<Example>(elements: loadCIFARTrainingFiles())
     let testDataset = Dataset<Example>(elements: loadCIFARTestFile())
     return (training: trainingDataset, test: testDataset)

--- a/ResNet/Data.swift
+++ b/ResNet/Data.swift
@@ -36,7 +36,8 @@ func downloadCIFAR10IfNotPresent(to directory: String = ".") {
                     string: "https://www.cs.toronto.edu/~kriz/cifar-10-binary.tar.gz")!)
             try downloadedFile.write(to: URL(fileURLWithPath: archivePath))
         } catch {
-            fatalError("Could not download CIFAR dataset, error: \(error)")
+            print("Could not download CIFAR dataset, error: \(error)")
+            exit(-1)
         }
     }
 
@@ -48,18 +49,14 @@ func downloadCIFAR10IfNotPresent(to directory: String = ".") {
         let tarLocation = "/bin/tar"
     #endif
 
-    if #available(macOS 10.13, *) {
-        let task = Process()
-        task.executableURL = URL(fileURLWithPath: tarLocation)
-        task.arguments = ["xzf", archivePath]
-        do {
-            try task.run()
-            task.waitUntilExit()
-        } catch {
-            print("CIFAR extraction failed with error: \(error)")
-        }
-    } else {
-        fatalError("Process() is missing from this platform")
+    let task = Process()
+    task.executableURL = URL(fileURLWithPath: tarLocation)
+    task.arguments = ["xzf", archivePath]
+    do {
+        try task.run()
+        task.waitUntilExit()
+    } catch {
+        print("CIFAR extraction failed with error: \(error)")
     }
 
     do {
@@ -108,11 +105,13 @@ func loadCIFARFile(named name: String, in directory: String = ".") -> Example {
 
     let imageCount = 10000
     guard let fileContents = try? Data(contentsOf: URL(fileURLWithPath: path)) else {
-        fatalError("Could not read dataset file: \(name)")
+        print("Could not read dataset file: \(name)")
+        exit(-1)
     }
     guard fileContents.count == 30_730_000 else {
-        fatalError(
+        print(
             "Dataset file \(name) should have 30730000 bytes, instead had \(fileContents.count)")
+        exit(-1)
     }
 
     var bytes: [UInt8] = []

--- a/ResNet/Data.swift
+++ b/ResNet/Data.swift
@@ -121,16 +121,14 @@ func loadCIFARFile(named name: String, in directory: String = ".") -> Example {
     for imageIndex in 0..<imageCount {
         let baseAddress = imageIndex * imageByteSize
         labels.append(Int64(fileContents[baseAddress]))
-
         bytes.append(contentsOf: fileContents[(baseAddress + 1)..<(baseAddress + 3073)])
     }
 
     let labelTensor = Tensor<Int64>(shape: [imageCount], scalars: labels)
     let images = Tensor<UInt8>(shape: [imageCount, 3, 32, 32], scalars: bytes)
 
-    // transpose from the provided N(CHW) to TF default NHWC
-    let imageTensor = Tensor<Float>(
-        images.transposed(withPermutations: [0, 2, 3, 1]))
+    // Transpose from the CIFAR-provided N(CHW) to TF's default NHWC.
+    let imageTensor = Tensor<Float>(images.transposed(withPermutations: [0, 2, 3, 1]))
 
     let mean = Tensor<Float>([0.485, 0.456, 0.406])
     let std = Tensor<Float>([0.229, 0.224, 0.225])

--- a/ResNet/Data.swift
+++ b/ResNet/Data.swift
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 import Foundation
+import FoundationNetworking
 import TensorFlow
 
 func downloadCIFAR10IfNotPresent(to directory: String = ".") {

--- a/ResNet/README.md
+++ b/ResNet/README.md
@@ -7,18 +7,13 @@ dataset.
 ## Setup
 
 You'll need [the latest version][INSTALL] of Swift for TensorFlow
-installed and added to your path. Additionally, the data loader requires Python
-3.x (rather than Python 2.7), `wget`, and `numpy`.
-
-> Note: For macOS, you need to set up the `PYTHON_LIBRARY` to help the Swift for
-> TensorFlow find the `libpython3.<minor-version>.dylib` file, e.g., in
-> `homebrew`.
+installed and added to your path.
 
 To train the model on CIFAR-10, run:
 
 ```
 cd swift-models
-swift run ResNet
+swift run -c release ResNet
 ```
 
 [INSTALL]: (https://github.com/tensorflow/swift/blob/master/Installation.md)

--- a/ResNet/main.swift
+++ b/ResNet/main.swift
@@ -13,8 +13,6 @@
 // limitations under the License.
 
 import TensorFlow
-import Python
-PythonLibrary.useVersion(3)
 
 let batchSize = 100
 


### PR DESCRIPTION
The CIFAR10 dataset download and loading mechanism in the CIFAR and ResNet models was dependent on Python for downloading and parsing the dataset. In particular, this was dependent on Python 3 for the pickle archives of the CIFAR10 dataset, which created a slight barrier for macOS systems that had Python 2 by default.

This replaces the dataset downloading and parsing with a Swift-only implementation, removing the need for Python. It downloads the binary CIFAR10 dataset via FoundationNetworking, and then parses the image and label bytes from that.

As a result, Python 3 is no longer required to train these models, nor is wget.