### PR TITLE
Replace Autoencoder's tanh activation with sigmoid

### DIFF
--- a/Autoencoder/main.swift
+++ b/Autoencoder/main.swift
@@ -91,7 +91,7 @@ struct Autoencoder: Layer {
     var decoder2 = Dense<Float>(inputSize: 12, outputSize: 64, activation: relu)
     var decoder3 = Dense<Float>(inputSize: 64, outputSize: 128, activation: relu)
     var decoder4 = Dense<Float>(inputSize: 128, outputSize: imageHeight * imageWidth,
-        activation: tanh)
+        activation: sigmoid)
 
     @differentiable
     func callAsFunction(_ input: Input) -> Output {


### PR DESCRIPTION
This PR resolves #179 

In v0.4.0-rc2 `sigmoid` has a bug in its gradient. So the model doesn't learn correctly.
It'll be fixed in future release.

close #179