### PR TITLE
Update Dockerfile to install Python libraries

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -29,6 +29,9 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         libxml2 \
         libblocksruntime-dev
 
+# Install Python libraries
+RUN pip3 install numpy matplotlib gym
+
 # Configure cuda
 RUN echo "/usr/local/cuda-9.2/targets/x86_64-linux/lib/stubs" > /etc/ld.so.conf.d/cuda-9.2-stubs.conf && \
     ldconfig


### PR DESCRIPTION
Current Dockerfile doesn't install Python requirements.

```sh
$ docker build -t s4tf docker
$ docekr run --rm -v $PWD:/swift-models s4tf swift run Autoencoder
...
Fatal error: 'try!' expression unexpectedly raised an error: Python exception: No module named 'matplotlib': file /swift-base/swift/stdlib/public/Python/Python.swift, line 683
```

Added  `numpy`, `matplotlib`, and `gym` installation.