### PR TITLE
WideResNet - fix widenFactor and match model to citation

### DIFF
--- a/Models/ImageClassification/WideResNet.swift
+++ b/Models/ImageClassification/WideResNet.swift
@@ -61,16 +61,19 @@ public struct BatchNormConv2DBlock: Layer {
     @differentiable
     public func callAsFunction(_ input: Tensor<Float>) -> Tensor<Float> {
         let preact1 = relu(norm1(input))
+        var residual = conv1(preact1)
+        let preact2: Tensor<Float>
         let shortcutResult: Tensor<Float>
         switch shortcutType {
         case .expansion: 
             shortcutResult = shortcut(preact1)
+            preact2 = relu(norm2(residual))
         case .id: 
             shortcutResult = input
+            preact2 = dropout(relu(norm2(residual)))
         }
-        var tmp = conv1(preact1)
-        tmp = conv2(dropout(relu(norm2(tmp))))
-        return tmp + shortcutResult
+        residual = conv2(preact2)
+        return residual + shortcutResult
     }
 }
 

--- a/Models/ImageClassification/WideResNet.swift
+++ b/Models/ImageClassification/WideResNet.swift
@@ -19,85 +19,89 @@ import TensorFlow
 // Sergey Zagoruyko, Nikos Komodakis
 // https://arxiv.org/abs/1605.07146
 // https://github.com/szagoruyko/wide-residual-networks
+enum ShortcutType {
+    case id
+    case expansion
+}
 
 public struct BatchNormConv2DBlock: Layer {
     public var norm1: BatchNorm<Float>
     public var conv1: Conv2D<Float>
     public var norm2: BatchNorm<Float>
     public var conv2: Conv2D<Float>
+    public var shortcut: Conv2D<Float>
+    let shortcutType: ShortcutType
 
     public init(
-        filterShape: (Int, Int, Int, Int),
+        featureCounts: (Int, Int),
+        kernelSize: Int = 3,
         strides: (Int, Int) = (1, 1),
         padding: Padding = .same
     ) {
-        self.norm1 = BatchNorm(featureCount: filterShape.2)
-        self.conv1 = Conv2D(filterShape: filterShape, strides: strides, padding: padding)
-        self.norm2 = BatchNorm(featureCount: filterShape.3)
-        self.conv2 = Conv2D(filterShape: filterShape, strides: (1, 1), padding: padding)
+        self.norm1 = BatchNorm(featureCount: featureCounts.0)
+        self.conv1 = Conv2D(
+            filterShape: (kernelSize, kernelSize, featureCounts.0, featureCounts.1), 
+            strides: strides, 
+            padding: padding)
+        self.norm2 = BatchNorm(featureCount: featureCounts.1)
+        self.conv2 = Conv2D(filterShape: (kernelSize, kernelSize, featureCounts.1, featureCounts.1), 
+                            strides: (1, 1), 
+                            padding: padding)
+        self.shortcut = Conv2D(filterShape: (1, 1, featureCounts.0, featureCounts.1), 
+                               strides: strides, 
+                               padding: padding)
+        if featureCounts.1 != featureCounts.0 || strides != (1, 1) {
+            self.shortcutType = .expansion
+        } else {
+            self.shortcutType = .id
+        }
     }
 
     @differentiable
     public func callAsFunction(_ input: Tensor<Float>) -> Tensor<Float> {
-        let firstLayer = conv1(relu(norm1(input)))
-        return conv2(relu(norm2(firstLayer)))
+        var tmp = relu(norm1(input))
+        let shortcutResult: Tensor<Float>
+        switch shortcutType {
+        case .expansion: 
+            shortcutResult = shortcut(tmp)
+        case .id: 
+            shortcutResult = input
+        }
+        tmp = conv1(tmp)
+        tmp = conv2(relu(norm2(tmp)))
+        return relu(tmp + shortcutResult)
     }
 }
 
 public struct WideResNetBasicBlock: Layer {
     public var blocks: [BatchNormConv2DBlock]
-    public var shortcut: Conv2D<Float>
 
     public init(
         featureCounts: (Int, Int),
         kernelSize: Int = 3,
         depthFactor: Int = 2,
-        widenFactor: Int = 1,
         initialStride: (Int, Int) = (2, 2)
     ) {
-        if initialStride == (1, 1) {
-            self.blocks = [
-                BatchNormConv2DBlock(
-                    filterShape: (
-                        kernelSize, kernelSize,
-                        featureCounts.0, featureCounts.1 * widenFactor
-                    ),
-                    strides: initialStride)
-            ]
-            self.shortcut = Conv2D(
-                filterShape: (1, 1, featureCounts.0, featureCounts.1 * widenFactor),
+        self.blocks = [
+            BatchNormConv2DBlock(
+                featureCounts: featureCounts,
+                kernelSize: kernelSize,
                 strides: initialStride)
-        } else {
-            self.blocks = [
-                BatchNormConv2DBlock(
-                    filterShape: (
-                        kernelSize, kernelSize,
-                        featureCounts.0 * widenFactor, featureCounts.1 * widenFactor
-                    ),
-                    strides: initialStride)
-            ]
-            self.shortcut = Conv2D(
-                filterShape: (1, 1, featureCounts.0 * widenFactor, featureCounts.1 * widenFactor),
-                strides: initialStride)
-        }
+        ]
+        
         for _ in 1..<depthFactor {
             self.blocks += [
                 BatchNormConv2DBlock(
-                    filterShape: (
-                        kernelSize, kernelSize,
-                        featureCounts.1 * widenFactor, featureCounts.1 * widenFactor
-                    ),
-                    strides: (1, 1))
+                    featureCounts: (featureCounts.1, featureCounts.1),
+                    kernelSize: kernelSize)
             ]
         }
+        
     }
 
     @differentiable
     public func callAsFunction(_ input: Tensor<Float>) -> Tensor<Float> {
-        let blocksReduced = blocks.differentiableReduce(input) { last, layer in
-            relu(layer(last))
-        }
-        return relu(blocksReduced + shortcut(input))
+        return blocks.differentiableReduce(input) { $1($0) }
     }
 }
 
@@ -116,15 +120,12 @@ public struct WideResNet: Layer {
     public init(depthFactor: Int = 2, widenFactor: Int = 8) {
         self.l1 = Conv2D(filterShape: (3, 3, 3, 16), strides: (1, 1), padding: .same)
 
-        l2 = WideResNetBasicBlock(
-            featureCounts: (16, 16), depthFactor: depthFactor,
-            widenFactor: widenFactor, initialStride: (1, 1))
-        l3 = WideResNetBasicBlock(
-            featureCounts: (16, 32), depthFactor: depthFactor,
-            widenFactor: widenFactor)
-        l4 = WideResNetBasicBlock(
-            featureCounts: (32, 64), depthFactor: depthFactor,
-            widenFactor: widenFactor)
+        self.l2 = WideResNetBasicBlock(
+            featureCounts: (16, 16 * widenFactor), depthFactor: depthFactor, initialStride: (1, 1))
+        self.l3 = WideResNetBasicBlock(featureCounts: (16 * widenFactor, 32 * widenFactor), 
+                                       depthFactor: depthFactor)
+        self.l4 = WideResNetBasicBlock(featureCounts: (32 * widenFactor, 64 * widenFactor), 
+                                       depthFactor: depthFactor)
 
         self.norm = BatchNorm(featureCount: 64 * widenFactor)
         self.avgPool = AvgPool2D(poolSize: (8, 8), strides: (8, 8))

--- a/Models/ImageClassification/WideResNet.swift
+++ b/Models/ImageClassification/WideResNet.swift
@@ -59,15 +59,15 @@ public struct BatchNormConv2DBlock: Layer {
 
     @differentiable
     public func callAsFunction(_ input: Tensor<Float>) -> Tensor<Float> {
-        var tmp = relu(norm1(input))
+        var preact1 = relu(norm1(input))
         let shortcutResult: Tensor<Float>
         switch shortcutType {
         case .expansion: 
-            shortcutResult = shortcut(tmp)
+            shortcutResult = shortcut(preact1)
         case .id: 
             shortcutResult = input
         }
-        tmp = conv1(tmp)
+        tmp = conv1(preact1)
         tmp = conv2(relu(norm2(tmp)))
         return relu(tmp + shortcutResult)
     }

--- a/Models/ImageClassification/WideResNet.swift
+++ b/Models/ImageClassification/WideResNet.swift
@@ -31,6 +31,7 @@ public struct BatchNormConv2DBlock: Layer {
     public var conv2: Conv2D<Float>
     public var shortcut: Conv2D<Float>
     let shortcutType: ShortcutType
+    let dropout: Dropout<Float> = Dropout(probability: 0.3)
 
     public init(
         featureCounts: (Int, Int),
@@ -68,8 +69,8 @@ public struct BatchNormConv2DBlock: Layer {
             shortcutResult = input
         }
         tmp = conv1(preact1)
-        tmp = conv2(relu(norm2(tmp)))
-        return relu(tmp + shortcutResult)
+        tmp = conv2(dropout(relu(norm2(tmp))))
+        return tmp + shortcutResult
     }
 }
 

--- a/Models/ImageClassification/WideResNet.swift
+++ b/Models/ImageClassification/WideResNet.swift
@@ -60,7 +60,7 @@ public struct BatchNormConv2DBlock: Layer {
 
     @differentiable
     public func callAsFunction(_ input: Tensor<Float>) -> Tensor<Float> {
-        var preact1 = relu(norm1(input))
+        let preact1 = relu(norm1(input))
         let shortcutResult: Tensor<Float>
         switch shortcutType {
         case .expansion: 
@@ -68,7 +68,7 @@ public struct BatchNormConv2DBlock: Layer {
         case .id: 
             shortcutResult = input
         }
-        tmp = conv1(preact1)
+        var tmp = conv1(preact1)
         tmp = conv2(dropout(relu(norm2(tmp))))
         return tmp + shortcutResult
     }


### PR DESCRIPTION
replaces #158.  With the repo restructuring and availability of control flow autodiff it seemed simpler to make the changes from scratch.

The changes match the model to the citation by:

- fix widenFactor application so model can train
- use identity shortcuts when the feature size doesn't change
- use preactivation on the shortcut branch when features are expanded
- add dropout between convolutions when feature sizes don't change
- remove extra ReLU following the addition of shortcut and residual

There are other changes that could be made as well but they are across all the residual models.

- use He normal initialisation instead of Glorot uniform
- include L2 regularisation of the model weights in the loss

I tested the changes locally by using `WideResNet(depthFactor: 2, widenFactor: 2)` and `SGD(learningRate: 0.1, momentum: 0.9)` in Examples/ResNet-CIFAR10/main.swift.  This resulted in:

    [Epoch 1] Accuracy: 6165/10112 (0.60967165) Loss: 1.0804846

