### PR TITLE
Remove deprecated allDifferentiableVariables

### DIFF
--- a/Autoencoder/main.swift
+++ b/Autoencoder/main.swift
@@ -93,6 +93,6 @@ for epoch in 1...epochCount {
             return meanSquaredError(predicted: image, expected: x)
         }
 
-        optimizer.update(&autoencoder.allDifferentiableVariables, along: 𝛁model)
+        optimizer.update(&autoencoder, along: 𝛁model)
     }
 }

--- a/Catch/main.swift
+++ b/Catch/main.swift
@@ -85,7 +85,7 @@ extension CatchAgent {
 
         let 𝛁loss = -log(Tensor<Float>(ŷ.max())).broadcasted(like: ŷ) * previousReward
         let (𝛁model, _) = backprop(𝛁loss)
-        optimizer.update(&model.allDifferentiableVariables, along: 𝛁model)
+        optimizer.update(&model, along: 𝛁model)
 
         return CatchAction(rawValue: Int(maxIndex))!
     }

--- a/Examples/Custom-CIFAR10/main.swift
+++ b/Examples/Custom-CIFAR10/main.swift
@@ -39,7 +39,7 @@ for epoch in 1...100 {
         }
         trainingLossSum += loss.scalarized()
         trainingBatchCount += 1
-        optimizer.update(&model.allDifferentiableVariables, along: gradients)
+        optimizer.update(&model, along: gradients)
     }
 
     var testLossSum: Float = 0

--- a/Examples/LeNet-MNIST/main.swift
+++ b/Examples/LeNet-MNIST/main.swift
@@ -52,7 +52,7 @@ for epoch in 1...epochCount {
             return loss
         }
         // Update the model's differentiable variables along the gradient vector.
-        optimizer.update(&classifier.allDifferentiableVariables, along: 𝛁model)
+        optimizer.update(&classifier, along: 𝛁model)
     }
 
     Context.local.learningPhase = .inference

--- a/Examples/ResNet-CIFAR10/main.swift
+++ b/Examples/ResNet-CIFAR10/main.swift
@@ -44,7 +44,7 @@ for epoch in 1...10 {
         }
         trainingLossSum += loss.scalarized()
         trainingBatchCount += 1
-        optimizer.update(&model.allDifferentiableVariables, along: gradients)
+        optimizer.update(&model, along: gradients)
     }
     var testLossSum: Float = 0
     var testBatchCount = 0

--- a/GAN/main.swift
+++ b/GAN/main.swift
@@ -154,7 +154,7 @@ for epoch in 1...epochCount {
             let loss = generatorLoss(fakeLogits: fakeLogits)
             return loss
         }
-        optG.update(&generator.allDifferentiableVariables, along: 𝛁generator)
+        optG.update(&generator, along: 𝛁generator)
         
         // Update discriminator.
         let realImages = dataset.trainingImages.minibatch(at: i, batchSize: batchSize)
@@ -167,7 +167,7 @@ for epoch in 1...epochCount {
             let loss = discriminatorLoss(realLogits: realLogits, fakeLogits: fakeLogits)
             return loss
         }
-        optD.update(&discriminator.allDifferentiableVariables, along: 𝛁discriminator)
+        optD.update(&discriminator, along: 𝛁discriminator)
     }
     
     // Start inference phase.

--- a/Gym/CartPole/main.swift
+++ b/Gym/CartPole/main.swift
@@ -184,7 +184,7 @@ while true {
             return loss
         }
     }
-    optimizer.update(&net.allDifferentiableVariables, along: gradients)
+    optimizer.update(&net, along: gradients)
 
     print("It has episode count \(episodeCount) and mean reward \(meanReward)")
 


### PR DESCRIPTION
This removes the now-deprecated allDifferentiableVariables from the various training loops. This is a follow-on from this change in swift-apis: https://github.com/tensorflow/swift-apis/pull/419 .