### PR TITLE
Update squeezenet and add V1.1 version

### DIFF
--- a/Models/ImageClassification/SqueezeNet.swift
+++ b/Models/ImageClassification/SqueezeNet.swift
@@ -177,6 +177,7 @@ public struct SqueezeNetV1_1: Layer {
         let fired1 = convolved1.sequenced(through: fire2, fire3, maxPool3, fire4, fire5)
         let fired2 = fired1.sequenced(through: maxPool5, fire6, fire7, fire8, fire9)
         let convolved2 = fired2.sequenced(through: dropout, conv10, avgPool10)
+            .reshaped(to: [input.shape[0], conv10.filter.shape[3]])
         return convolved2
     }
 }

--- a/Models/ImageClassification/SqueezeNet.swift
+++ b/Models/ImageClassification/SqueezeNet.swift
@@ -53,8 +53,11 @@ public struct Fire: Layer {
 }
 
 public struct SqueezeNetV1_0: Layer {
-    public var conv1 = Conv2D<Float>(filterShape: (7, 7, 3, 96), strides: (2, 2), padding: .same,
-                                     activation: relu)
+    public var conv1 = Conv2D<Float>(
+        filterShape: (7, 7, 3, 96),
+        strides: (2, 2),
+        padding: .same,
+        activation: relu)
     public var maxPool1 = MaxPool2D<Float>(poolSize: (3, 3), strides: (2, 2))
     public var fire2 = Fire(
         inputFilterCount: 96,
@@ -118,8 +121,11 @@ public struct SqueezeNetV1_0: Layer {
 }
 
 public struct SqueezeNetV1_1: Layer {
-    public var conv1 = Conv2D<Float>(filterShape: (3, 3, 3, 64), strides: (2, 2), padding: .same,
-                                     activation: relu)
+    public var conv1 = Conv2D<Float>(
+        filterShape: (3, 3, 3, 64),
+        strides: (2, 2),
+        padding: .same,
+        activation: relu)
     public var maxPool1 = MaxPool2D<Float>(poolSize: (3, 3), strides: (2, 2))
     public var fire2 = Fire(
         inputFilterCount: 64,

--- a/Models/ImageClassification/SqueezeNet.swift
+++ b/Models/ImageClassification/SqueezeNet.swift
@@ -117,7 +117,7 @@ public struct SqueezeNetV1_0: Layer {
 }
 
 public struct SqueezeNetV1_1: Layer {
-    public var conv1 = Conv2D<Float>(filterShape: (3, 3, 3, 96), strides: (2, 2), padding: .same,
+    public var conv1 = Conv2D<Float>(filterShape: (3, 3, 3, 64), strides: (2, 2), padding: .same,
                                      activation: relu)
     public var maxPool1 = MaxPool2D<Float>(poolSize: (3, 3), strides: (2, 2))
     public var fire2 = Fire(

--- a/Tests/ImageClassificationTests/Inference.swift
+++ b/Tests/ImageClassificationTests/Inference.swift
@@ -92,11 +92,20 @@ final class ImageClassificationInferenceTests: XCTestCase {
         XCTAssertEqual(resNet34ImageNetResult.shape, [1, 1000])
     }
 
-    func testSqueezeNet() {
+    func testSqueezeNetV1_0() {
         let input = Tensor<Float>(
             randomNormal: [1, 224, 224, 3], mean: Tensor<Float>(0.5),
             standardDeviation: Tensor<Float>(0.1), seed: (0xffeffe, 0xfffe))
-        let squeezeNet = SqueezeNet(classCount: 1000)
+        let squeezeNet = SqueezeNetV1_0(classCount: 1000)
+        let squeezeNetResult = squeezeNet(input)
+        XCTAssertEqual(squeezeNetResult.shape, [1, 1000])
+    }
+
+    func testSqueezeNetV1_1() {
+        let input = Tensor<Float>(
+            randomNormal: [1, 224, 224, 3], mean: Tensor<Float>(0.5),
+            standardDeviation: Tensor<Float>(0.1), seed: (0xffeffe, 0xfffe))
+        let squeezeNet = SqueezeNetV1_1(classCount: 1000)
         let squeezeNetResult = squeezeNet(input)
         XCTAssertEqual(squeezeNetResult.shape, [1, 1000])
     }
@@ -152,7 +161,8 @@ extension ImageClassificationInferenceTests {
         ("testLeNet", testLeNet),
         ("testResNet", testResNet),
         ("testResNetV2", testResNetV2),
-        ("testSqueezeNet", testSqueezeNet),
+        ("testSqueezeNetV1_0", testSqueezeNetV1_0),
+        ("testSqueezeNetV1_1", testSqueezeNetV1_1),
         ("testWideResNet", testWideResNet),
     ]
 }


### PR DESCRIPTION
So the default activation in conv layers is identity, while the squeezenet paper mentions a relu activation after the 1st and last convolution.

Also adding the v1.1 version of squeezenet, its 2.4x less computation without sacrificing accuracy. For more check [here](https://github.com/DeepScale/SqueezeNet/tree/master/SqueezeNet_v1.1).