### PR TITLE
Update deprecated APIs in Catch

### DIFF
--- a/Catch/main.swift
+++ b/Catch/main.swift
@@ -20,8 +20,6 @@ import TensorFlow
 //   gradients). The algorithm should perform some tensor computation (not a
 //   purely table-based approach).
 
-var rng = PhiloxRandomNumberGenerator(seed: 0xdeadbeef)
-
 extension Sequence {
     /// Returns elements' descriptions joined by a separator.
     func description(joinedBy separator: String) -> String {

--- a/Catch/main.swift
+++ b/Catch/main.swift
@@ -20,6 +20,8 @@ import TensorFlow
 //   gradients). The algorithm should perform some tensor computation (not a
 //   purely table-based approach).
 
+var rng = PhiloxRandomNumberGenerator(seed: 0xdeadbeef)
+
 extension Sequence {
     /// Returns elements' descriptions joined by a separator.
     func description(joinedBy separator: String) -> String {

--- a/Catch/main.swift
+++ b/Catch/main.swift
@@ -47,8 +47,8 @@ class CatchAgent: Agent {
     typealias Action = CatchAction
 
     var model = Sequential {
-        Dense<Float>(inputSize: 3, outputSize: 50, activation: sigmoid, generator: &rng)
-        Dense<Float>(inputSize: 50, outputSize: 3, activation: sigmoid, generator: &rng)
+        Dense<Float>(inputSize: 3, outputSize: 50, activation: sigmoid)
+        Dense<Float>(inputSize: 50, outputSize: 3, activation: sigmoid)
     }
 
     var learningRate: Float


### PR DESCRIPTION
[swift-apis/#497](https://github.com/tensorflow/swift-apis/pull/497) deprecates layer apis, now that we are moving onward to v0.5. This PR updates the catch file which has a deprecated dense layer. 