### PR TITLE
Creating a common protocol for image classification datasets, reworking MNIST to comply

### DIFF
--- a/Autoencoder/main.swift
+++ b/Autoencoder/main.swift
@@ -23,7 +23,7 @@ let imageHeight = 28
 let imageWidth = 28
 
 let outputFolder = "./output/"
-let dataset = MNIST(batchSize: batchSize, flattening: true)
+let dataset = MNIST(flattening: true)
 // An autoencoder.
 var autoencoder = Sequential {
     // The encoder.
@@ -59,8 +59,10 @@ for epoch in 1...epochCount {
     let sampleLoss = meanSquaredError(predicted: testImage, expected: sampleImage)
     print("[Epoch: \(epoch)] Loss: \(sampleLoss)")
 
-    for i in 0 ..< dataset.trainingSize / batchSize {
-        let x = dataset.trainingImages.minibatch(at: i, batchSize: batchSize)
+    let trainingShuffled = dataset.trainingDataset.shuffled(
+        sampleCount: dataset.trainingExampleCount, randomSeed: Int64(epoch))
+    for batch in trainingShuffled.batched(batchSize) {
+        let x = batch.data
 
         let 𝛁model = autoencoder.gradient { autoencoder -> Tensor<Float> in
             let image = autoencoder(x)

--- a/Benchmarks/Models/ImageClassificationInference.swift
+++ b/Benchmarks/Models/ImageClassificationInference.swift
@@ -22,10 +22,11 @@ protocol ImageClassificationModel: Layer where Input == Tensor<Float>, Output ==
 
 extension LeNet: ImageClassificationModel {}
 
-class ImageClassificationInference<Model> where Model: ImageClassificationModel {
+class ImageClassificationInference<Model, ClassificationDataset>
+where Model: ImageClassificationModel, ClassificationDataset: ImageClassificationDataset {
     // TODO: (https://github.com/tensorflow/swift-models/issues/206) Datasets should have a common
     // interface to allow for them to be interchangeable in these benchmark cases.
-    let dataset: MNIST
+    let dataset: ClassificationDataset
     var model: Model
     let images: Tensor<Float>
     let batches: Int
@@ -34,7 +35,7 @@ class ImageClassificationInference<Model> where Model: ImageClassificationModel 
     init(batches: Int, batchSize: Int, images: Tensor<Float>? = nil) {
         self.batches = batches
         self.batchSize = batchSize
-        self.dataset = MNIST(batchSize: batchSize)
+        self.dataset = ClassificationDataset()
         self.model = Model()
         if let providedImages = images {
             self.images = providedImages

--- a/Benchmarks/main.swift
+++ b/Benchmarks/main.swift
@@ -13,15 +13,17 @@
 // limitations under the License.
 
 import ImageClassificationModels
+import Datasets
 
 // LeNet-MNIST
-let leNetTrainingBenchmark = ImageClassificationTraining<LeNet>(epochs: 1, batchSize: 128)
+let leNetTrainingBenchmark = ImageClassificationTraining<LeNet, MNIST>(epochs: 1, batchSize: 128)
 benchmark(
     name: "LeNet-MNIST (training)",
     iterations: 10, variety: .trainingTime, operation: leNetTrainingBenchmark.train,
     callback: logResults)
 
-let leNetInferenceBenchmark = ImageClassificationInference<LeNet>(batches: 1000, batchSize: 1)
+let leNetInferenceBenchmark = ImageClassificationInference<LeNet, MNIST>(
+    batches: 1000, batchSize: 1)
 benchmark(
     name: "LeNet-MNIST (inference)",
     iterations: 10, variety: .inferenceThroughput(batches: 1000, batchSize: 1),

--- a/Datasets/CIFAR10/CIFAR10.swift
+++ b/Datasets/CIFAR10/CIFAR10.swift
@@ -27,6 +27,7 @@ import TensorFlow
 public struct CIFAR10: ImageClassificationDataset {
     public let trainingDataset: Dataset<LabeledExample>
     public let testDataset: Dataset<LabeledExample>
+    public let trainingExampleCount = 50000
 
     public init() {
         self.trainingDataset = Dataset<LabeledExample>(elements: loadCIFARTrainingFiles())

--- a/Datasets/CIFAR10/CIFAR10.swift
+++ b/Datasets/CIFAR10/CIFAR10.swift
@@ -25,12 +25,12 @@ import TensorFlow
 #endif
 
 public struct CIFAR10: ImageClassificationDataset {
-    public let trainingDataset: Dataset<CIFARExample>
-    public let testDataset: Dataset<CIFARExample>
+    public let trainingDataset: Dataset<LabeledExample>
+    public let testDataset: Dataset<LabeledExample>
 
     public init() {
-        self.trainingDataset = Dataset<CIFARExample>(elements: loadCIFARTrainingFiles())
-        self.testDataset = Dataset<CIFARExample>(elements: loadCIFARTestFile())
+        self.trainingDataset = Dataset<LabeledExample>(elements: loadCIFARTrainingFiles())
+        self.testDataset = Dataset<LabeledExample>(elements: loadCIFARTestFile())
     }
 }
 
@@ -84,7 +84,7 @@ func downloadCIFAR10IfNotPresent(to directory: String = ".") {
     print("Unarchiving completed")
 }
 
-func loadCIFARFile(named name: String, in directory: String = ".") -> CIFARExample {
+func loadCIFARFile(named name: String, in directory: String = ".") -> LabeledExample {
     downloadCIFAR10IfNotPresent(to: directory)
     let path = "\(directory)/cifar-10-batches-bin/\(name)"
 
@@ -119,17 +119,17 @@ func loadCIFARFile(named name: String, in directory: String = ".") -> CIFARExamp
     let std = Tensor<Float>([0.229, 0.224, 0.225])
     let imagesNormalized = ((imageTensor / 255.0) - mean) / std
 
-    return CIFARExample(label: Tensor<Int32>(labelTensor), data: imagesNormalized)
+    return LabeledExample(label: Tensor<Int32>(labelTensor), data: imagesNormalized)
 }
 
-func loadCIFARTrainingFiles() -> CIFARExample {
+func loadCIFARTrainingFiles() -> LabeledExample {
     let data = (1..<6).map { loadCIFARFile(named: "data_batch_\($0).bin") }
-    return CIFARExample(
+    return LabeledExample(
         label: _Raw.concat(concatDim: Tensor<Int32>(0), data.map { $0.label }),
         data: _Raw.concat(concatDim: Tensor<Int32>(0), data.map { $0.data })
     )
 }
 
-func loadCIFARTestFile() -> CIFARExample {
+func loadCIFARTestFile() -> LabeledExample {
     return loadCIFARFile(named: "test_batch.bin")
 }

--- a/Datasets/CIFAR10/CIFAR10.swift
+++ b/Datasets/CIFAR10/CIFAR10.swift
@@ -24,7 +24,7 @@ import TensorFlow
     import FoundationNetworking
 #endif
 
-public struct CIFAR10 {
+public struct CIFAR10: ImageClassificationDataset {
     public let trainingDataset: Dataset<CIFARExample>
     public let testDataset: Dataset<CIFARExample>
 

--- a/Datasets/ImageClassificationDataset.swift
+++ b/Datasets/ImageClassificationDataset.swift
@@ -12,6 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-protocol ImageClassificationDataset {
+import TensorFlow
 
+public protocol ImageClassificationDataset {
+    var trainingDataset: Dataset<LabeledExample> { get }
+    var testDataset: Dataset<LabeledExample> { get }
 }

--- a/Datasets/ImageClassificationDataset.swift
+++ b/Datasets/ImageClassificationDataset.swift
@@ -1,0 +1,17 @@
+// Copyright 2019 The TensorFlow Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+protocol ImageClassificationDataset {
+
+}

--- a/Datasets/ImageClassificationDataset.swift
+++ b/Datasets/ImageClassificationDataset.swift
@@ -15,6 +15,8 @@
 import TensorFlow
 
 public protocol ImageClassificationDataset {
+    init()
     var trainingDataset: Dataset<LabeledExample> { get }
     var testDataset: Dataset<LabeledExample> { get }
+    var trainingExampleCount: Int { get }
 }

--- a/Datasets/LabeledExample.swift
+++ b/Datasets/LabeledExample.swift
@@ -14,7 +14,7 @@
 
 import TensorFlow
 
-public struct CIFARExample: TensorGroup {
+public struct LabeledExample: TensorGroup {
     public var label: Tensor<Int32>
     public var data: Tensor<Float>
 

--- a/Datasets/MNIST/MNIST.swift
+++ b/Datasets/MNIST/MNIST.swift
@@ -20,7 +20,7 @@
 import Foundation
 import TensorFlow
 
-public struct MNIST {
+public struct MNIST: ImageClassificationDataset {
     public let trainingImages: Tensor<Float>
     public let trainingLabels: Tensor<Int32>
     public let testImages: Tensor<Float>

--- a/Datasets/MNIST/MNIST.swift
+++ b/Datasets/MNIST/MNIST.swift
@@ -20,7 +20,7 @@
 import Foundation
 import TensorFlow
 
-public struct MNIST: ImageClassificationDataset {
+public struct MNIST {
     public let trainingImages: Tensor<Float>
     public let trainingLabels: Tensor<Int32>
     public let testImages: Tensor<Float>

--- a/Examples/LeNet-MNIST/main.swift
+++ b/Examples/LeNet-MNIST/main.swift
@@ -18,7 +18,7 @@ import Datasets
 let epochCount = 12
 let batchSize = 128
 
-let dataset = MNIST(batchSize: batchSize)
+let dataset = MNIST()
 // The LeNet-5 model, equivalent to `LeNet` in `ImageClassificationModels`.
 var classifier = Sequential {
     Conv2D<Float>(filterShape: (5, 5, 1, 6), padding: .same, activation: relu)
@@ -41,22 +41,26 @@ struct Statistics {
     var totalLoss: Float = 0
 }
 
+let testBatches = dataset.testDataset.batched(batchSize)
+
 // The training loop.
 for epoch in 1...epochCount {
     var trainStats = Statistics()
     var testStats = Statistics()
+    let trainingShuffled = dataset.trainingDataset.shuffled(
+        sampleCount: dataset.trainingExampleCount, randomSeed: Int64(epoch))
+
     Context.local.learningPhase = .training
-    for i in 0 ..< dataset.trainingSize / batchSize {
-        let x = dataset.trainingImages.minibatch(at: i, batchSize: batchSize)
-        let y = dataset.trainingLabels.minibatch(at: i, batchSize: batchSize)
+    for batch in trainingShuffled.batched(batchSize) {
+        let (labels, images) = (batch.label, batch.data)
         // Compute the gradient with respect to the model.
         let 𝛁model = classifier.gradient { classifier -> Tensor<Float> in
-            let ŷ = classifier(x)
-            let correctPredictions = ŷ.argmax(squeezingAxis: 1) .== y
+            let ŷ = classifier(images)
+            let correctPredictions = ŷ.argmax(squeezingAxis: 1) .== labels
             trainStats.correctGuessCount += Int(
-              Tensor<Int32>(correctPredictions).sum().scalarized())
+                Tensor<Int32>(correctPredictions).sum().scalarized())
             trainStats.totalGuessCount += batchSize
-            let loss = softmaxCrossEntropy(logits: ŷ, labels: y)
+            let loss = softmaxCrossEntropy(logits: ŷ, labels: labels)
             trainStats.totalLoss += loss.scalarized()
             return loss
         }
@@ -65,27 +69,27 @@ for epoch in 1...epochCount {
     }
 
     Context.local.learningPhase = .inference
-    for i in 0 ..< dataset.testSize / batchSize {
-        let x = dataset.testImages.minibatch(at: i, batchSize: batchSize)
-        let y = dataset.testLabels.minibatch(at: i, batchSize: batchSize)
+    for batch in testBatches {
+        let (labels, images) = (batch.label, batch.data)
         // Compute loss on test set
-        let ŷ = classifier(x)
-        let correctPredictions = ŷ.argmax(squeezingAxis: 1) .== y
+        let ŷ = classifier(images)
+        let correctPredictions = ŷ.argmax(squeezingAxis: 1) .== labels
         testStats.correctGuessCount += Int(Tensor<Int32>(correctPredictions).sum().scalarized())
         testStats.totalGuessCount += batchSize
-        let loss = softmaxCrossEntropy(logits: ŷ, labels: y)
+        let loss = softmaxCrossEntropy(logits: ŷ, labels: labels)
         testStats.totalLoss += loss.scalarized()
     }
 
     let trainAccuracy = Float(trainStats.correctGuessCount) / Float(trainStats.totalGuessCount)
     let testAccuracy = Float(testStats.correctGuessCount) / Float(testStats.totalGuessCount)
-    print("""
-          [Epoch \(epoch)] \
-          Training Loss: \(trainStats.totalLoss), \
-          Training Accuracy: \(trainStats.correctGuessCount)/\(trainStats.totalGuessCount) \
-          (\(trainAccuracy)), \
-          Test Loss: \(testStats.totalLoss), \
-          Test Accuracy: \(testStats.correctGuessCount)/\(testStats.totalGuessCount) \
-          (\(testAccuracy))
-          """)
+    print(
+        """
+        [Epoch \(epoch)] \
+        Training Loss: \(trainStats.totalLoss), \
+        Training Accuracy: \(trainStats.correctGuessCount)/\(trainStats.totalGuessCount) \
+        (\(trainAccuracy)), \
+        Test Loss: \(testStats.totalLoss), \
+        Test Accuracy: \(testStats.correctGuessCount)/\(testStats.totalGuessCount) \
+        (\(testAccuracy))
+        """)
 }

--- a/GAN/main.swift
+++ b/GAN/main.swift
@@ -146,7 +146,9 @@ print("Start training...")
 for epoch in 1...epochCount {
     // Start training phase.
     Context.local.learningPhase = .training
-    for i in 0..<dataset.trainingSize / batchSize {
+    let trainingShuffled = dataset.trainingDataset.shuffled(
+        sampleCount: dataset.trainingExampleCount, randomSeed: Int64(epoch))
+    for batch in trainingShuffled.batched(batchSize) {
         // Perform alternative update.
         // Update generator.
         let vec1 = sampleVector(size: batchSize)
@@ -160,7 +162,7 @@ for epoch in 1...epochCount {
         optG.update(&generator, along: 𝛁generator)
 
         // Update discriminator.
-        let realImages = dataset.trainingImages.minibatch(at: i, batchSize: batchSize)
+        let realImages = batch.data
         let vec2 = sampleVector(size: batchSize)
         let fakeImages = generator(vec2)
 

--- a/GAN/main.swift
+++ b/GAN/main.swift
@@ -105,7 +105,7 @@ func sampleVector(size: Int) -> Tensor<Float> {
     Tensor(randomNormal: [size, latentSize])
 }
 
-let dataset = MNIST(batchSize: batchSize, flattening: true, normalizing: true)
+let dataset = MNIST(flattening: true, normalizing: true)
 
 var generator = Generator()
 var discriminator = Discriminator()
@@ -146,7 +146,7 @@ print("Start training...")
 for epoch in 1...epochCount {
     // Start training phase.
     Context.local.learningPhase = .training
-    for i in 0 ..< dataset.trainingSize / batchSize {
+    for i in 0..<dataset.trainingSize / batchSize {
         // Perform alternative update.
         // Update generator.
         let vec1 = sampleVector(size: batchSize)


### PR DESCRIPTION
This addresses the remaining items in issue #206:

- An ImageClassificationDataset protocol has been introduced that both the MNIST and CIFAR10 datasets now conform to.
- Both datasets now use a simpler, common interface.
- MNIST has been reworked to provide the same kind of shuffling and batching that the CIFAR10 dataset does.

As a result, the benchmarks have been made generic over image classification datasets, allowing for that to be specified as part of the benchmark. This removes the hardcoded dependency on MNIST as the only benchmark source dataset.

All example applications that used the MNIST dataset have been updated to match the new interface.