### PR TITLE
Add initial support for command-line argument parsing

### DIFF
--- a/Benchmarks/Benchmark.swift
+++ b/Benchmarks/Benchmark.swift
@@ -37,6 +37,13 @@ extension BenchmarkResults {
     }
 }
 
+struct BenchmarkSettings {
+    let batches: Int
+    let batchSize: Int
+    let iterations: Int
+    let epochs: Int
+}
+
 /// Performs the specified benchmark over a certain number of iterations and provides the result to a callback function.
 func benchmark(
     name: String,

--- a/Benchmarks/Benchmark.swift
+++ b/Benchmarks/Benchmark.swift
@@ -18,6 +18,13 @@ protocol Benchmark {
     func run()
 }
 
+protocol BenchmarkModel {
+    func inferenceDefaults() -> BenchmarkSettings
+    func inferenceBenchmark(_ settings: BenchmarkSettings) -> Benchmark
+    func trainingDefaults() -> BenchmarkSettings
+    func trainingBenchmark(_ settings: BenchmarkSettings) -> Benchmark
+}
+
 enum BenchmarkVariety {
     case inferenceThroughput
     case trainingTime
@@ -28,6 +35,16 @@ struct BenchmarkSettings {
     let batchSize: Int
     let iterations: Int
     let epochs: Int
+
+    func withDefaults(_ defaults: BenchmarkSettings) -> BenchmarkSettings {
+        let newBatches = batches == -1 ? defaults.batches : batches
+        let newBatchSize = batchSize == -1 ? defaults.batchSize : batchSize
+        let newIterations = iterations == -1 ? defaults.iterations : iterations
+        let newEpochs = epochs == -1 ? defaults.epochs : epochs
+        return BenchmarkSettings(
+            batches: newBatches, batchSize: newBatchSize,
+            iterations: newIterations, epochs: newEpochs)
+    }
 }
 
 struct BenchmarkResults {

--- a/Benchmarks/Models.swift
+++ b/Benchmarks/Models.swift
@@ -1,0 +1,24 @@
+import Datasets
+import ImageClassificationModels
+
+struct LeNetMnist: BenchmarkModel {
+    func inferenceDefaults() -> BenchmarkSettings {
+        return BenchmarkSettings(batches: 1000, batchSize: 1, iterations: 10, epochs: -1)
+    }
+
+    func inferenceBenchmark(_ settings: BenchmarkSettings) -> Benchmark {
+        return ImageClassificationInference<LeNet, MNIST>(settings: settings)
+    }
+
+    func trainingDefaults() -> BenchmarkSettings {
+        return BenchmarkSettings(batches: -1, batchSize: 128, iterations: 10, epochs: 1)
+    }
+
+    func trainingBenchmark(_ settings: BenchmarkSettings) -> Benchmark {
+        return ImageClassificationTraining<LeNet, MNIST>(settings: settings)
+    }
+}
+
+let benchmarkModels = [
+    "lenet-mnist": LeNetMnist(),
+]

--- a/Benchmarks/Models/ImageClassificationInference.swift
+++ b/Benchmarks/Models/ImageClassificationInference.swift
@@ -12,9 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import TensorFlow
 import Datasets
 import ImageClassificationModels
+import TensorFlow
 
 protocol ImageClassificationModel: Layer where Input == Tensor<Float>, Output == Tensor<Float> {
     init()
@@ -22,19 +22,20 @@ protocol ImageClassificationModel: Layer where Input == Tensor<Float>, Output ==
 
 extension LeNet: ImageClassificationModel {}
 
-class ImageClassificationInference<Model, ClassificationDataset>
+class ImageClassificationInference<Model, ClassificationDataset>: Benchmark
 where Model: ImageClassificationModel, ClassificationDataset: ImageClassificationDataset {
     // TODO: (https://github.com/tensorflow/swift-models/issues/206) Datasets should have a common
     // interface to allow for them to be interchangeable in these benchmark cases.
     let dataset: ClassificationDataset
+
     var model: Model
     let images: Tensor<Float>
     let batches: Int
     let batchSize: Int
 
-    init(batches: Int, batchSize: Int, images: Tensor<Float>? = nil) {
-        self.batches = batches
-        self.batchSize = batchSize
+    init(withSettings settings: BenchmarkSettings, andImages images: Tensor<Float>? = nil) {
+        self.batches = settings.batches
+        self.batchSize = settings.batchSize
         self.dataset = ClassificationDataset()
         self.model = Model()
         if let providedImages = images {
@@ -46,7 +47,7 @@ where Model: ImageClassificationModel, ClassificationDataset: ImageClassificatio
         }
     }
 
-    func performInference() {
+    func run() {
         for _ in 0..<batches {
             let _ = model(images)
         }

--- a/Benchmarks/Models/ImageClassificationInference.swift
+++ b/Benchmarks/Models/ImageClassificationInference.swift
@@ -33,7 +33,7 @@ where Model: ImageClassificationModel, ClassificationDataset: ImageClassificatio
     let batches: Int
     let batchSize: Int
 
-    init(withSettings settings: BenchmarkSettings, andImages images: Tensor<Float>? = nil) {
+    init(settings: BenchmarkSettings, images: Tensor<Float>? = nil) {
         self.batches = settings.batches
         self.batchSize = settings.batchSize
         self.dataset = ClassificationDataset()

--- a/Benchmarks/Models/ImageClassificationTraining.swift
+++ b/Benchmarks/Models/ImageClassificationTraining.swift
@@ -27,7 +27,7 @@ where
     let epochs: Int
     let batchSize: Int
 
-    init(withSettings settings: BenchmarkSettings) {
+    init(settings: BenchmarkSettings) {
         self.epochs = settings.epochs
         self.batchSize = settings.batchSize
         self.dataset = ClassificationDataset()

--- a/Benchmarks/Models/ImageClassificationTraining.swift
+++ b/Benchmarks/Models/ImageClassificationTraining.swift
@@ -12,26 +12,28 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import TensorFlow
 import Datasets
+import TensorFlow
 
-struct ImageClassificationTraining<Model, ClassificationDataset>
-where Model: ImageClassificationModel, Model.TangentVector.VectorSpaceScalar == Float,
+struct ImageClassificationTraining<Model, ClassificationDataset>: Benchmark
+where
+    Model: ImageClassificationModel, Model.TangentVector.VectorSpaceScalar == Float,
     ClassificationDataset: ImageClassificationDataset
 {
     // TODO: (https://github.com/tensorflow/swift-models/issues/206) Datasets should have a common
     // interface to allow for them to be interchangeable in these benchmark cases.
     let dataset: ClassificationDataset
+
     let epochs: Int
     let batchSize: Int
 
-    init(epochs: Int, batchSize: Int) {
-        self.epochs = epochs
-        self.batchSize = batchSize
+    init(withSettings settings: BenchmarkSettings) {
+        self.epochs = settings.epochs
+        self.batchSize = settings.batchSize
         self.dataset = ClassificationDataset()
     }
 
-    func train() {
+    func run() {
         var model = Model()
         // TODO: Split out the optimizer as a separate specification.
         let optimizer = SGD(for: model, learningRate: 0.1)

--- a/Benchmarks/README.md
+++ b/Benchmarks/README.md
@@ -18,8 +18,18 @@ installed. Make sure you've added the correct version of `swift` to your path.
 To run all benchmarks, type the following while in the swift-models directory:
 
 ```sh
-swift run -c release Benchmarks measure --benchmark lanet-mnist --training
---epochs 1 --batchSize 128
-swift run -c release Benchmarks measure --benchmark lanet-mnist --training
---batches 1000 --batchSize 1
+swift run -c release Benchmarks measure-all
+```
+
+To run an an individual benchmark, use `measure`:
+
+```sh
+swift run -c release Benchmarks measure --benchmark <name> --training
+swift run -c release Benchmarks measure --benchmark <name> --inference
+```
+
+To list all benchmarks and their default settings use `list-defaults`:
+
+```sh
+swift run -c release Benchmarks list-defaults
 ```

--- a/Benchmarks/README.md
+++ b/Benchmarks/README.md
@@ -18,5 +18,8 @@ installed. Make sure you've added the correct version of `swift` to your path.
 To run all benchmarks, type the following while in the swift-models directory:
 
 ```sh
-swift run -c release Benchmarks
+swift run -c release Benchmarks measure --benchmark lanet-mnist --training
+--epochs 1 --batchSize 128
+swift run -c release Benchmarks measure --benchmark lanet-mnist --training
+--batches 1000 --batchSize 1
 ```

--- a/Benchmarks/main.swift
+++ b/Benchmarks/main.swift
@@ -12,85 +12,91 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import ImageClassificationModels
-import Datasets
 import Commander
+import Datasets
+import ImageClassificationModels
 
 let trainingBenchmarks = [
-	"lenet-mnist": { (settings: BenchmarkSettings) in
-        let leNetTrainingBenchmark = ImageClassificationTraining<LeNet, MNIST>(
-            epochs: settings.epochs, batchSize: settings.batchSize)
-        benchmark(
-            name: "LeNet-MNIST (training)",
-            iterations: 10, variety: .trainingTime, operation: leNetTrainingBenchmark.train,
-            callback: logResults)
-    }
+    "lenet-mnist": { ImageClassificationTraining<LeNet, MNIST>(withSettings: $0) },
 ]
 
 let inferenceBenchmarks = [
-    "lenet-mnist": { (settings: BenchmarkSettings) in
-        let leNetInferenceBenchmark = ImageClassificationInference<LeNet, MNIST>(
-            batches: settings.batches, batchSize: settings.batchSize)
-        benchmark(
-            name: "LeNet-MNIST (inference)",
-            iterations: settings.iterations,
-            variety: .inferenceThroughput(batches: settings.batches, batchSize: settings.batchSize),
-            operation: leNetInferenceBenchmark.performInference,
-            callback: logResults)
-    }
+    "lenet-mnist": { ImageClassificationInference<LeNet, MNIST>(withSettings: $0) },
 ]
 
-let main = Group { group in
-    group.command(
-        "inference",
-        Argument<String>("name", description: "Benchmark name."),
-        Option("batches", default: 1000),
-        Option("batchSize", default: 1),
-        Option("iterations", default: 10),
-        Option("epochs", default: 1)
-    ) { (name, batches, batchSize, iterations, epochs) in
-        let settings = BenchmarkSettings(
-            batches: batches,
-            batchSize: batchSize,
-            iterations: iterations,
-            epochs: epochs)
-        if let runner = inferenceBenchmarks[name] {
-            runner(settings)
-        } else {
-            print("No registered inference benchmark with a name: \(name)")
-            print("Consider running `list` command to see all available benchmarks.")
-        }
-    }
-    group.command(
-        "training",
-        Argument<String>("name", description: "Benchmark name."),
-        Option("batches", default: 1000),
-        Option("batchSize", default: 1),
-        Option("iterations", default: 10),
-        Option("epochs", default: 1)
-    ) { (name, batches, batchSize, iterations, epochs) in
-        let settings = BenchmarkSettings(
-            batches: batches,
-            batchSize: batchSize,
-            iterations: iterations,
-            epochs: epochs)
-        if let runner = trainingBenchmarks[name] {
-            runner(settings)
-        } else {
-            print("No registered training benchmark with a name: \(name)")
-            print("Consider running `list` command to see all available benchmarks.")
-        }
-    }
-    group.command("list") {
-        print("Registered training benchmarks:")
-        for (name, _) in trainingBenchmarks {
-            print("  * \(name)")
-        }
-        print("Registered inference benchmarks:")
-        for (name, _) in inferenceBenchmarks {
-            print("  * \(name)")
-        }
+func runTrainingBenchmark(_ name: String, withSettings settings: BenchmarkSettings) {
+    if let makeBenchmark = trainingBenchmarks[name] {
+        let bench = makeBenchmark(settings)
+        benchmark(
+            name: "\(name) (training)",
+            settings: settings,
+            variety: .trainingTime,
+            benchmark: bench,
+            callback: logResults)
+    } else {
+        print("No registered training benchmark with a name: \(name)")
+        print("Consider running `list` command to see all available benchmarks.")
     }
 }
+
+func runInferenceBenchmark(_ name: String, withSettings settings: BenchmarkSettings) {
+    if let makeBenchmark = inferenceBenchmarks[name] {
+        let bench = makeBenchmark(settings)
+        benchmark(
+            name: "\(name) (inference)",
+            settings: settings,
+            variety: .inferenceThroughput,
+            benchmark: bench,
+            callback: logResults)
+    } else {
+        print("No registered inference benchmark with a name: \(name)")
+        print("Consider running `list` command to see all available benchmarks.")
+    }
+}
+
+let main =
+    Group {
+        group
+        ingroup.command(
+            "measure",
+            Flag("training"),
+            Flag("inference"),
+            Option("benchmark", default: ""),
+            Option("batches", default: 1000),
+            Option("batchSize", default: 1),
+            Option("iterations", default: 10),
+            Option("epochs", default: 1)
+        ) { (trainingFlag, inferenceFlag, name, batches, batchSize, iterations, epochs) in
+            let settings = BenchmarkSettings(
+                batches: batches,
+                batchSize: batchSize,
+                iterations: iterations,
+                epochs: epochs)
+            if !trainingFlag && !inferenceFlag {
+                print("Must specify either --training xor --inference benchmark variety.")
+            } else if trainingFlag && inferenceFlag {
+                print("Can't specify both --training and --inference benchmark variety.")
+            } else if name == "" {
+                print("Must provide a --benchmark to run.")
+            } else {
+                if trainingFlag {
+                    runTrainingBenchmark(name, withSettings: settings)
+                }
+                if inferenceFlag {
+                    runInferenceBenchmark(name, withSettings: settings)
+                }
+            }
+        }
+        group.command("list") {
+            print("Registered training benchmarks:")
+            for (name, _) in trainingBenchmarks {
+                print("  * \(name)")
+            }
+            print("Registered inference benchmarks:")
+            for (name, _) in inferenceBenchmarks {
+                print("  * \(name)")
+            }
+        }
+    }
 
 main.run()

--- a/Benchmarks/main.swift
+++ b/Benchmarks/main.swift
@@ -68,7 +68,7 @@ let main =
     Group { group in
         group.command(
             "measure-all",
-            description: "run all benchmarks with default settigns"
+            description: "Run all benchmarks with default settings."
         ) {
             for (name, benchmarkModel) in benchmarkModels {
                 runBenchmark(
@@ -83,14 +83,14 @@ let main =
         }
         group.command(
             "measure",
-            Flag("training"),
-            Flag("inference"),
-            Option("benchmark", default: ""),
-            Option("batches", default: -1),
-            Option("batchSize", default: -1),
-            Option("iterations", default: -1),
-            Option("epochs", default: -1),
-            description: "run a single benchmark with custom settings"
+            Flag("training", description: "Run training benchmark."),
+            Flag("inference", description: "Run inference benchmark."),
+            Option("benchmark", default: "", description: "Name of the benchmark to run."),
+            Option("batches", default: -1, description: "Number of batches."),
+            Option("batchSize", default: -1, description: "Size of a single batch."),
+            Option("iterations", default: -1, description: "Number of benchmark iterations."),
+            Option("epochs", default: -1, description: "Number of training epochs."),
+            description: "Run a single benchmark with provided settings."
         ) { (trainingFlag, inferenceFlag, name, batches, batchSize, iterations, epochs) in
             let settings = BenchmarkSettings(
                 batches: batches,
@@ -115,8 +115,8 @@ let main =
             }
         }
         group.command(
-            "list",
-            description: "list all available benchmarks and their default settings"
+            "list-defaults",
+            description: "List all available benchmarks and their default settings."
         ) {
             for (name, benchmarkModel) in benchmarkModels {
                 print(

--- a/Benchmarks/main.swift
+++ b/Benchmarks/main.swift
@@ -17,11 +17,11 @@ import Datasets
 import ImageClassificationModels
 
 let trainingBenchmarks = [
-    "lenet-mnist": { ImageClassificationTraining<LeNet, MNIST>(withSettings: $0) },
+    "lenet-mnist": { ImageClassificationTraining<LeNet, MNIST>(settings: $0) },
 ]
 
 let inferenceBenchmarks = [
-    "lenet-mnist": { ImageClassificationInference<LeNet, MNIST>(withSettings: $0) },
+    "lenet-mnist": { ImageClassificationInference<LeNet, MNIST>(settings: $0) },
 ]
 
 func runTrainingBenchmark(_ name: String, withSettings settings: BenchmarkSettings) {
@@ -55,9 +55,8 @@ func runInferenceBenchmark(_ name: String, withSettings settings: BenchmarkSetti
 }
 
 let main =
-    Group {
-        group
-        ingroup.command(
+    Group { group in
+        group.command(
             "measure",
             Flag("training"),
             Flag("inference"),

--- a/Package.swift
+++ b/Package.swift
@@ -20,6 +20,9 @@ let package = Package(
         .executable(name: "GAN", targets: ["GAN"]),
         .executable(name: "Benchmarks", targets: ["Benchmarks"]),
     ],
+    dependencies: [
+        .package(url: "https://github.com/kylef/Commander.git", from: "0.9.1"),
+    ],
     targets: [
         .target(name: "ImageClassificationModels", path: "Models/ImageClassification"),
         .target(name: "Datasets", path: "Datasets"),
@@ -49,7 +52,7 @@ let package = Package(
         .target(name: "GAN", dependencies: ["Datasets", "ModelSupport"], path: "GAN"),
         .target(
             name: "Benchmarks",
-            dependencies: ["Datasets", "ModelSupport", "ImageClassificationModels"],
+            dependencies: ["Datasets", "ModelSupport", "ImageClassificationModels", "Commander"],
             path: "Benchmarks"),
     ]
 )


### PR DESCRIPTION
This PR adds support for command-line argument parsing to the Benchmarks. The implementation is build upon Commander library and introduces two commands:

* `measure`. Starts a benchmarking of a single benchmark with given settings.
* `measure-all`. Run all benchmarks with default settings.
* `list-defaults`. See the list of all benchmarks and their default settings.


