### PR TITLE
Use stderr for logging messages

### DIFF
--- a/Benchmarks/main.swift
+++ b/Benchmarks/main.swift
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 import Commander
+import ModelSupport
 
 func runBenchmark(
     _ name: String,
@@ -42,8 +43,8 @@ func runBenchmark(
             benchmark: bench,
             callback: logResults)
     } else {
-        print("No registered inference benchmark with a name: \(name)")
-        print("Consider running `list` command to see all available benchmarks.")
+        printerr("No registered inference benchmark with a name: \(name)")
+        printerr("Consider running `list` command to see all available benchmarks.")
     }
 }
 
@@ -98,11 +99,11 @@ let main =
                 iterations: iterations,
                 epochs: epochs)
             if !trainingFlag && !inferenceFlag {
-                print("Must specify either --training xor --inference benchmark variety.")
+                printerr("Must specify either --training xor --inference benchmark variety.")
             } else if trainingFlag && inferenceFlag {
-                print("Can't specify both --training and --inference benchmark variety.")
+                printerr("Can't specify both --training and --inference benchmark variety.")
             } else if name == "" {
-                print("Must provide a --benchmark to run.")
+                printerr("Must provide a --benchmark to run.")
             } else {
                 var variety: BenchmarkVariety
                 if trainingFlag {

--- a/Benchmarks/main.swift
+++ b/Benchmarks/main.swift
@@ -43,8 +43,8 @@ func runBenchmark(
             benchmark: bench,
             callback: logResults)
     } else {
-        printerr("No registered inference benchmark with a name: \(name)")
-        printerr("Consider running `list` command to see all available benchmarks.")
+        printError("No registered inference benchmark with a name: \(name)")
+        printError("Consider running `list` command to see all available benchmarks.")
     }
 }
 
@@ -99,11 +99,11 @@ let main =
                 iterations: iterations,
                 epochs: epochs)
             if !trainingFlag && !inferenceFlag {
-                printerr("Must specify either --training xor --inference benchmark variety.")
+                printError("Must specify either --training xor --inference benchmark variety.")
             } else if trainingFlag && inferenceFlag {
-                printerr("Can't specify both --training and --inference benchmark variety.")
+                printError("Can't specify both --training and --inference benchmark variety.")
             } else if name == "" {
-                printerr("Must provide a --benchmark to run.")
+                printError("Must provide a --benchmark to run.")
             } else {
                 var variety: BenchmarkVariety
                 if trainingFlag {

--- a/Datasets/CIFAR10/CIFAR10.swift
+++ b/Datasets/CIFAR10/CIFAR10.swift
@@ -42,23 +42,23 @@ func downloadCIFAR10IfNotPresent(to directory: String = ".") {
 
     guard !directoryExists else { return }
 
-    printerr("Downloading CIFAR dataset...")
+    printError("Downloading CIFAR dataset...")
     let archivePath = "\(directory)/cifar-10-binary.tar.gz"
     let archiveExists = FileManager.default.fileExists(atPath: archivePath)
     if !archiveExists {
-        printerr("Archive missing, downloading...")
+        printError("Archive missing, downloading...")
         do {
             let downloadedFile = try Data(
                 contentsOf: URL(
                     string: "https://www.cs.toronto.edu/~kriz/cifar-10-binary.tar.gz")!)
             try downloadedFile.write(to: URL(fileURLWithPath: archivePath))
         } catch {
-            printerr("Could not download CIFAR dataset, error: \(error)")
+            printError("Could not download CIFAR dataset, error: \(error)")
             exit(-1)
         }
     }
 
-    printerr("Archive downloaded, processing...")
+    printError("Archive downloaded, processing...")
 
     #if os(macOS)
         let tarLocation = "/usr/bin/tar"
@@ -73,17 +73,17 @@ func downloadCIFAR10IfNotPresent(to directory: String = ".") {
         try task.run()
         task.waitUntilExit()
     } catch {
-        printerr("CIFAR extraction failed with error: \(error)")
+        printError("CIFAR extraction failed with error: \(error)")
     }
 
     do {
         try FileManager.default.removeItem(atPath: archivePath)
     } catch {
-        printerr("Could not remove archive, error: \(error)")
+        printError("Could not remove archive, error: \(error)")
         exit(-1)
     }
 
-    printerr("Unarchiving completed")
+    printError("Unarchiving completed")
 }
 
 func loadCIFARFile(named name: String, in directory: String = ".") -> LabeledExample {
@@ -92,11 +92,11 @@ func loadCIFARFile(named name: String, in directory: String = ".") -> LabeledExa
 
     let imageCount = 10000
     guard let fileContents = try? Data(contentsOf: URL(fileURLWithPath: path)) else {
-        printerr("Could not read dataset file: \(name)")
+        printError("Could not read dataset file: \(name)")
         exit(-1)
     }
     guard fileContents.count == 30_730_000 else {
-        printerr(
+        printError(
             "Dataset file \(name) should have 30730000 bytes, instead had \(fileContents.count)")
         exit(-1)
     }

--- a/Datasets/CIFAR10/CIFAR10.swift
+++ b/Datasets/CIFAR10/CIFAR10.swift
@@ -18,6 +18,7 @@
 // https://www.cs.toronto.edu/~kriz/cifar.html
 
 import Foundation
+import ModelSupport
 import TensorFlow
 
 #if canImport(FoundationNetworking)
@@ -41,23 +42,23 @@ func downloadCIFAR10IfNotPresent(to directory: String = ".") {
 
     guard !directoryExists else { return }
 
-    print("Downloading CIFAR dataset...")
+    printerr("Downloading CIFAR dataset...")
     let archivePath = "\(directory)/cifar-10-binary.tar.gz"
     let archiveExists = FileManager.default.fileExists(atPath: archivePath)
     if !archiveExists {
-        print("Archive missing, downloading...")
+        printerr("Archive missing, downloading...")
         do {
             let downloadedFile = try Data(
                 contentsOf: URL(
                     string: "https://www.cs.toronto.edu/~kriz/cifar-10-binary.tar.gz")!)
             try downloadedFile.write(to: URL(fileURLWithPath: archivePath))
         } catch {
-            print("Could not download CIFAR dataset, error: \(error)")
+            printerr("Could not download CIFAR dataset, error: \(error)")
             exit(-1)
         }
     }
 
-    print("Archive downloaded, processing...")
+    printerr("Archive downloaded, processing...")
 
     #if os(macOS)
         let tarLocation = "/usr/bin/tar"
@@ -72,17 +73,17 @@ func downloadCIFAR10IfNotPresent(to directory: String = ".") {
         try task.run()
         task.waitUntilExit()
     } catch {
-        print("CIFAR extraction failed with error: \(error)")
+        printerr("CIFAR extraction failed with error: \(error)")
     }
 
     do {
         try FileManager.default.removeItem(atPath: archivePath)
     } catch {
-        print("Could not remove archive, error: \(error)")
+        printerr("Could not remove archive, error: \(error)")
         exit(-1)
     }
 
-    print("Unarchiving completed")
+    printerr("Unarchiving completed")
 }
 
 func loadCIFARFile(named name: String, in directory: String = ".") -> LabeledExample {
@@ -91,11 +92,11 @@ func loadCIFARFile(named name: String, in directory: String = ".") -> LabeledExa
 
     let imageCount = 10000
     guard let fileContents = try? Data(contentsOf: URL(fileURLWithPath: path)) else {
-        print("Could not read dataset file: \(name)")
+        printerr("Could not read dataset file: \(name)")
         exit(-1)
     }
     guard fileContents.count == 30_730_000 else {
-        print(
+        printerr(
             "Dataset file \(name) should have 30730000 bytes, instead had \(fileContents.count)")
         exit(-1)
     }

--- a/Datasets/DatasetUtilities.swift
+++ b/Datasets/DatasetUtilities.swift
@@ -28,7 +28,7 @@ public struct DatasetUtilities {
         remoteRoot: URL,
         localStorageDirectory: URL = currentWorkingDirectoryURL
     ) -> Data {
-        printerr("Loading resource: \(filename)")
+        printError("Loading resource: \(filename)")
 
         let resource = ResourceDefinition(
             filename: filename,
@@ -38,16 +38,16 @@ public struct DatasetUtilities {
         let localURL = resource.localURL
 
         if !FileManager.default.fileExists(atPath: localURL.path) {
-            printerr(
+            printError(
                 "File does not exist locally at expected path: \(localURL.path) and must be fetched"
             )
             fetchFromRemoteAndSave(resource)
         }
 
         do {
-            printerr("Loading local data at: \(localURL.path)")
+            printError("Loading local data at: \(localURL.path)")
             let data = try Data(contentsOf: localURL)
-            printerr("Succesfully loaded resource: \(filename)")
+            printError("Succesfully loaded resource: \(filename)")
             return data
         } catch {
             fatalError("Failed to contents of resource: \(localURL)")
@@ -77,20 +77,20 @@ public struct DatasetUtilities {
         let archiveLocation = resource.archiveURL
 
         do {
-            printerr("Fetching URL: \(remoteLocation)...")
+            printError("Fetching URL: \(remoteLocation)...")
             let archiveData = try Data(contentsOf: remoteLocation)
-            printerr("Writing fetched archive to: \(archiveLocation.path)")
+            printError("Writing fetched archive to: \(archiveLocation.path)")
             try archiveData.write(to: archiveLocation)
         } catch {
             fatalError("Failed to fetch and save resource with error: \(error)")
         }
-        printerr("Archive saved to: \(archiveLocation.path)")
+        printError("Archive saved to: \(archiveLocation.path)")
 
         extractArchive(for: resource)
     }
 
     static func extractArchive(for resource: ResourceDefinition) {
-        printerr("Extracting archive...")
+        printError("Extracting archive...")
 
         let archivePath = resource.archiveURL.path
 

--- a/Datasets/DatasetUtilities.swift
+++ b/Datasets/DatasetUtilities.swift
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 import Foundation
+import ModelSupport
 
 #if canImport(FoundationNetworking)
     import FoundationNetworking
@@ -27,7 +28,7 @@ public struct DatasetUtilities {
         remoteRoot: URL,
         localStorageDirectory: URL = currentWorkingDirectoryURL
     ) -> Data {
-        print("Loading resource: \(filename)")
+        printerr("Loading resource: \(filename)")
 
         let resource = ResourceDefinition(
             filename: filename,
@@ -37,16 +38,16 @@ public struct DatasetUtilities {
         let localURL = resource.localURL
 
         if !FileManager.default.fileExists(atPath: localURL.path) {
-            print(
+            printerr(
                 "File does not exist locally at expected path: \(localURL.path) and must be fetched"
             )
             fetchFromRemoteAndSave(resource)
         }
 
         do {
-            print("Loading local data at: \(localURL.path)")
+            printerr("Loading local data at: \(localURL.path)")
             let data = try Data(contentsOf: localURL)
-            print("Succesfully loaded resource: \(filename)")
+            printerr("Succesfully loaded resource: \(filename)")
             return data
         } catch {
             fatalError("Failed to contents of resource: \(localURL)")
@@ -76,20 +77,20 @@ public struct DatasetUtilities {
         let archiveLocation = resource.archiveURL
 
         do {
-            print("Fetching URL: \(remoteLocation)...")
+            printerr("Fetching URL: \(remoteLocation)...")
             let archiveData = try Data(contentsOf: remoteLocation)
-            print("Writing fetched archive to: \(archiveLocation.path)")
+            printerr("Writing fetched archive to: \(archiveLocation.path)")
             try archiveData.write(to: archiveLocation)
         } catch {
             fatalError("Failed to fetch and save resource with error: \(error)")
         }
-        print("Archive saved to: \(archiveLocation.path)")
+        printerr("Archive saved to: \(archiveLocation.path)")
 
         extractArchive(for: resource)
     }
 
     static func extractArchive(for resource: ResourceDefinition) {
-        print("Extracting archive...")
+        printerr("Extracting archive...")
 
         let archivePath = resource.archiveURL.path
 

--- a/Package.swift
+++ b/Package.swift
@@ -25,7 +25,7 @@ let package = Package(
     ],
     targets: [
         .target(name: "ImageClassificationModels", path: "Models/ImageClassification"),
-        .target(name: "Datasets", path: "Datasets"),
+        .target(name: "Datasets", dependencies: ["ModelSupport"], path: "Datasets"),
         .target(name: "ModelSupport", path: "Support"),
         .target(
             name: "Autoencoder", dependencies: ["Datasets", "ModelSupport"], path: "Autoencoder"),

--- a/Support/Image.swift
+++ b/Support/Image.swift
@@ -81,10 +81,12 @@ public struct Image {
     }
 }
 
-public func saveImage(_ tensor: Tensor<Float>, size: (Int, Int), directory: String, name: String) throws {
+public func saveImage(_ tensor: Tensor<Float>, size: (Int, Int), directory: String, name: String)
+    throws
+{
     try createDirectoryIfMissing(at: directory)
     let reshapedTensor = tensor.reshaped(to: [size.0, size.1, 1])
     let image = Image(tensor: reshapedTensor)
-    let outputURL = URL(fileURLWithPath:"\(directory)\(name).jpg")
+    let outputURL = URL(fileURLWithPath: "\(directory)\(name).jpg")
     image.save(to: outputURL)
 }

--- a/Support/Stderr.swift
+++ b/Support/Stderr.swift
@@ -9,6 +9,6 @@ extension FileHandle: TextOutputStream {
     }
 }
 
-public func printerr(_ msg: String) {
-    print(msg, to: &stderr)
+public func printError(_ message: String) {
+    print(message, to: &stderr)
 }

--- a/Support/Stderr.swift
+++ b/Support/Stderr.swift
@@ -1,0 +1,14 @@
+import Foundation
+
+var stderr = FileHandle.standardError
+
+extension FileHandle: TextOutputStream {
+    public func write(_ string: String) {
+        guard let data = string.data(using: .utf8) else { return }
+        self.write(data)
+    }
+}
+
+public func printerr(_ msg: String) {
+    print(msg, to: &stderr)
+}


### PR DESCRIPTION
Currently, we show log-style messages in stdout together with actual tool output (e.g., models print messages to show progress on loading the models). This makes it difficult to programmatically involve benchmarks cli from other tools. 

In this PR, we use stderr for logging-style messages instead. This is fairly standard convention in *nix world.