### PR TITLE
Fixed typo: curentWorkingDirectoryURL -> currentWorkingDirectoryURL

### DIFF
--- a/Datasets/DatasetUtilities.swift
+++ b/Datasets/DatasetUtilities.swift
@@ -19,13 +19,13 @@ import Foundation
 #endif
 
 public struct DatasetUtilities {
-    public static let curentWorkingDirectoryURL = URL(
+    public static let currentWorkingDirectoryURL = URL(
         fileURLWithPath: FileManager.default.currentDirectoryPath)
 
     public static func fetchResource(
         filename: String,
         remoteRoot: URL,
-        localStorageDirectory: URL = curentWorkingDirectoryURL
+        localStorageDirectory: URL = currentWorkingDirectoryURL
     ) -> Data {
         print("Loading resource: \(filename)")
 

--- a/Datasets/MNIST/MNIST.swift
+++ b/Datasets/MNIST/MNIST.swift
@@ -31,7 +31,7 @@ public struct MNIST: ImageClassificationDataset {
 
     public init(
         flattening: Bool = false, normalizing: Bool = false,
-        localStorageDirectory: URL = DatasetUtilities.curentWorkingDirectoryURL
+        localStorageDirectory: URL = DatasetUtilities.currentWorkingDirectoryURL
     ) {
         self.trainingDataset = Dataset<LabeledExample>(
             elements: fetchDataset(


### PR DESCRIPTION
Fixed typo in name of static property of type `URL` at [Datasets/DatasetUtilities.swift](https://github.com/tensorflow/swift-models/blob/master/Datasets/DatasetUtilities.swift)