### PR TITLE
Add MobileNet v1

### DIFF
--- a/Models/ImageClassification/MobileNet.swift
+++ b/Models/ImageClassification/MobileNet.swift
@@ -22,190 +22,199 @@ import TensorFlow
 // https://arxiv.org/abs/1704.04861
 
 public struct ConvBlock: Layer {
-  public var zeroPad = ZeroPadding2D<Float>(padding: ((0, 1), (0, 1)))
-  public var conv: Conv2D<Float>
-  public var batchNorm: BatchNorm<Float>
+    public var zeroPad = ZeroPadding2D<Float>(padding: ((0, 1), (0, 1)))
+    public var conv: Conv2D<Float>
+    public var batchNorm: BatchNorm<Float>
 
-  public init(filterCount: Int, strides: (Int, Int)) {
-    conv = Conv2D<Float>(
-      filterShape: (3, 3, 3, filterCount),
-      strides: strides,
-      padding: .valid)
-    batchNorm = BatchNorm<Float>(featureCount: filterCount)
-  }
+    public init(filterCount: Int, strides: (Int, Int)) {
+        conv = Conv2D<Float>(
+            filterShape: (3, 3, 3, filterCount),
+            strides: strides,
+            padding: .valid)
+        batchNorm = BatchNorm<Float>(featureCount: filterCount)
+    }
 
-  @differentiable
-  public func callAsFunction(_ input: Tensor<Float>) -> Tensor<Float> {
-    let convolved = input.sequenced(through: zeroPad, conv, batchNorm)
-    return relu6(convolved)
-  }
+    @differentiable
+    public func callAsFunction(_ input: Tensor<Float>) -> Tensor<Float> {
+        let convolved = input.sequenced(through: zeroPad, conv, batchNorm)
+        return relu6(convolved)
+    }
 }
 
 public struct DepthwiseConvBlock: Layer {
-  @noDerivative
-  let depthMultiplier: Int
-  @noDerivative
-  let strides: (Int, Int)
+    @noDerivative
+    let depthMultiplier: Int
 
-  @noDerivative
-  public let zeroPad = ZeroPadding2D<Float>(padding: ((0, 1), (0, 1)))
-  public var dConv: DepthwiseConv2D<Float>
-  public var batchNorm1: BatchNorm<Float>
-  public var conv: Conv2D<Float>
-  public var batchNorm2: BatchNorm<Float>
+    @noDerivative
+    let strides: (Int, Int)
 
-  public init(filterCount: Int, pointwiseFilterCount: Int, depthMultiplier: Int,
-    strides: (Int, Int)) {
-    if depthMultiplier < 1 {
-      fatalError("Depth multiplier must be an integer greater than 0.")
+    @noDerivative
+    public let zeroPad = ZeroPadding2D<Float>(padding: ((0, 1), (0, 1)))
+    public var dConv: DepthwiseConv2D<Float>
+    public var batchNorm1: BatchNorm<Float>
+    public var conv: Conv2D<Float>
+    public var batchNorm2: BatchNorm<Float>
+
+    public init(
+        filterCount: Int, pointwiseFilterCount: Int, depthMultiplier: Int,
+        strides: (Int, Int)
+    ) {
+        if depthMultiplier < 1 {
+            fatalError("Depth multiplier must be an integer greater than 0.")
+        }
+        self.depthMultiplier = depthMultiplier
+        self.strides = strides
+
+        dConv = DepthwiseConv2D<Float>(
+            filterShape: (3, 3, filterCount, self.depthMultiplier),
+            strides: strides,
+            padding: strides == (1, 1) ? .same : .valid)
+        batchNorm1 = BatchNorm<Float>(
+            featureCount: filterCount * self.depthMultiplier)
+        conv = Conv2D<Float>(
+            filterShape: (
+                1, 1, filterCount * self.depthMultiplier,
+                pointwiseFilterCount
+            ),
+            strides: (1, 1),
+            padding: .same)
+        batchNorm2 = BatchNorm<Float>(featureCount: pointwiseFilterCount)
     }
-    self.depthMultiplier = depthMultiplier
-    self.strides = strides
 
-    dConv = DepthwiseConv2D<Float>(
-      filterShape: (3, 3, filterCount, self.depthMultiplier),
-      strides: strides,
-      padding: strides == (1, 1) ? .same : .valid)
-    batchNorm1 = BatchNorm<Float>(
-      featureCount: filterCount * self.depthMultiplier)
-    conv = Conv2D<Float>(
-      filterShape: (1, 1, filterCount * self.depthMultiplier,
-        pointwiseFilterCount),
-      strides: (1, 1),
-      padding: .same)
-    batchNorm2 = BatchNorm<Float>(featureCount: pointwiseFilterCount)
-  }
-
-  @differentiable
-  public func callAsFunction(_ input: Tensor<Float>) -> Tensor<Float> {
-    var convolved1: Tensor<Float>
-    if self.strides == (1, 1) {
-      convolved1 = input.sequenced(through: dConv, batchNorm1)
+    @differentiable
+    public func callAsFunction(_ input: Tensor<Float>) -> Tensor<Float> {
+        var convolved1: Tensor<Float>
+        if self.strides == (1, 1) {
+            convolved1 = input.sequenced(through: dConv, batchNorm1)
+        } else {
+            convolved1 = input.sequenced(through: zeroPad, dConv, batchNorm1)
+        }
+        let convolved2 = relu6(convolved1)
+        let convolved3 = relu6(convolved2.sequenced(through: conv, batchNorm2))
+        return convolved3
     }
-    else {
-      convolved1 = input.sequenced(through: zeroPad, dConv, batchNorm1)
-    }
-    let convolved2 = relu6(convolved1)
-    let convolved3 = relu6(convolved2.sequenced(through: conv, batchNorm2))
-    return convolved3
-  }
 }
 
 public struct MobileNetV1: Layer {
-  @noDerivative
-  let classCount: Int
+    @noDerivative
+    let classCount: Int
 
-  public var convBlock1: ConvBlock
-  public var dConvBlock1: DepthwiseConvBlock
-  public var dConvBlock2: DepthwiseConvBlock
-  public var dConvBlock3: DepthwiseConvBlock
-  public var dConvBlock4: DepthwiseConvBlock
-  public var dConvBlock5: DepthwiseConvBlock
-  public var dConvBlock6: DepthwiseConvBlock
-  public var dConvBlock7: DepthwiseConvBlock
-  public var dConvBlock8: DepthwiseConvBlock
-  public var dConvBlock9: DepthwiseConvBlock
-  public var dConvBlock10: DepthwiseConvBlock
-  public var dConvBlock11: DepthwiseConvBlock
-  public var dConvBlock12: DepthwiseConvBlock
-  public var dConvBlock13: DepthwiseConvBlock
-  public var avgPool = GlobalAvgPool2D<Float>()
-  public var reshape = Reshape<Float>(shape: [1, 1, 1, 1024])
-  public var dropoutLayer: Dropout<Float>
-  public var convLast: Conv2D<Float>
+    public var convBlock1: ConvBlock
+    public var dConvBlock1: DepthwiseConvBlock
+    public var dConvBlock2: DepthwiseConvBlock
+    public var dConvBlock3: DepthwiseConvBlock
+    public var dConvBlock4: DepthwiseConvBlock
+    public var dConvBlock5: DepthwiseConvBlock
+    public var dConvBlock6: DepthwiseConvBlock
+    public var dConvBlock7: DepthwiseConvBlock
+    public var dConvBlock8: DepthwiseConvBlock
+    public var dConvBlock9: DepthwiseConvBlock
+    public var dConvBlock10: DepthwiseConvBlock
+    public var dConvBlock11: DepthwiseConvBlock
+    public var dConvBlock12: DepthwiseConvBlock
+    public var dConvBlock13: DepthwiseConvBlock
+    public var avgPool = GlobalAvgPool2D<Float>()
+    public var reshape = Reshape<Float>(shape: [1, 1, 1, 1024])
+    public var dropoutLayer: Dropout<Float>
+    public var convLast: Conv2D<Float>
 
-  public init(classCount: Int, depthMultiplier: Int = 1,
-    dropout: Double = 0.001) {
-    self.classCount = classCount
+    public init(
+        classCount: Int, depthMultiplier: Int = 1,
+        dropout: Double = 0.001
+    ) {
+        self.classCount = classCount
 
-    convBlock1 = ConvBlock(filterCount: 32, strides: (2, 2))
-    dConvBlock1 = DepthwiseConvBlock(
-      filterCount: 32,
-      pointwiseFilterCount: 64,
-      depthMultiplier: depthMultiplier,
-      strides: (1, 1))
-    dConvBlock2 = DepthwiseConvBlock(
-      filterCount: 64,
-      pointwiseFilterCount: 128,
-      depthMultiplier: depthMultiplier,
-      strides: (2, 2))
-    dConvBlock3 = DepthwiseConvBlock(
-      filterCount: 128,
-      pointwiseFilterCount: 128,
-      depthMultiplier: depthMultiplier,
-      strides: (1, 1))
-    dConvBlock4 = DepthwiseConvBlock(
-      filterCount: 128,
-      pointwiseFilterCount: 256,
-      depthMultiplier: depthMultiplier,
-      strides: (2, 2))
-    dConvBlock5 = DepthwiseConvBlock(
-      filterCount: 256,
-      pointwiseFilterCount: 256,
-      depthMultiplier: depthMultiplier,
-      strides: (1, 1))
-    dConvBlock6 = DepthwiseConvBlock(
-      filterCount: 256,
-      pointwiseFilterCount: 512,
-      depthMultiplier: depthMultiplier,
-      strides: (2, 2))
-    dConvBlock7 = DepthwiseConvBlock(
-      filterCount: 512,
-      pointwiseFilterCount: 512,
-      depthMultiplier: depthMultiplier,
-      strides: (1, 1))
-    dConvBlock8 = DepthwiseConvBlock(
-      filterCount: 512,
-      pointwiseFilterCount: 512,
-      depthMultiplier: depthMultiplier,
-      strides: (1, 1))
-    dConvBlock9 = DepthwiseConvBlock(
-      filterCount: 512,
-      pointwiseFilterCount: 512,
-      depthMultiplier: depthMultiplier,
-      strides: (1, 1))
-    dConvBlock10 = DepthwiseConvBlock(
-      filterCount: 512,
-      pointwiseFilterCount: 512,
-      depthMultiplier: depthMultiplier,
-      strides: (1, 1))
-    dConvBlock11 = DepthwiseConvBlock(
-      filterCount: 512,
-      pointwiseFilterCount: 512,
-      depthMultiplier: depthMultiplier,
-      strides: (1, 1))
-    dConvBlock12 = DepthwiseConvBlock(
-      filterCount: 512,
-      pointwiseFilterCount: 1024,
-      depthMultiplier: depthMultiplier,
-      strides: (2, 2))
-    dConvBlock13 = DepthwiseConvBlock(
-      filterCount: 1024,
-      pointwiseFilterCount: 1024,
-      depthMultiplier: depthMultiplier,
-      strides: (1, 1))
+        convBlock1 = ConvBlock(filterCount: 32, strides: (2, 2))
+        dConvBlock1 = DepthwiseConvBlock(
+            filterCount: 32,
+            pointwiseFilterCount: 64,
+            depthMultiplier: depthMultiplier,
+            strides: (1, 1))
+        dConvBlock2 = DepthwiseConvBlock(
+            filterCount: 64,
+            pointwiseFilterCount: 128,
+            depthMultiplier: depthMultiplier,
+            strides: (2, 2))
+        dConvBlock3 = DepthwiseConvBlock(
+            filterCount: 128,
+            pointwiseFilterCount: 128,
+            depthMultiplier: depthMultiplier,
+            strides: (1, 1))
+        dConvBlock4 = DepthwiseConvBlock(
+            filterCount: 128,
+            pointwiseFilterCount: 256,
+            depthMultiplier: depthMultiplier,
+            strides: (2, 2))
+        dConvBlock5 = DepthwiseConvBlock(
+            filterCount: 256,
+            pointwiseFilterCount: 256,
+            depthMultiplier: depthMultiplier,
+            strides: (1, 1))
+        dConvBlock6 = DepthwiseConvBlock(
+            filterCount: 256,
+            pointwiseFilterCount: 512,
+            depthMultiplier: depthMultiplier,
+            strides: (2, 2))
+        dConvBlock7 = DepthwiseConvBlock(
+            filterCount: 512,
+            pointwiseFilterCount: 512,
+            depthMultiplier: depthMultiplier,
+            strides: (1, 1))
+        dConvBlock8 = DepthwiseConvBlock(
+            filterCount: 512,
+            pointwiseFilterCount: 512,
+            depthMultiplier: depthMultiplier,
+            strides: (1, 1))
+        dConvBlock9 = DepthwiseConvBlock(
+            filterCount: 512,
+            pointwiseFilterCount: 512,
+            depthMultiplier: depthMultiplier,
+            strides: (1, 1))
+        dConvBlock10 = DepthwiseConvBlock(
+            filterCount: 512,
+            pointwiseFilterCount: 512,
+            depthMultiplier: depthMultiplier,
+            strides: (1, 1))
+        dConvBlock11 = DepthwiseConvBlock(
+            filterCount: 512,
+            pointwiseFilterCount: 512,
+            depthMultiplier: depthMultiplier,
+            strides: (1, 1))
+        dConvBlock12 = DepthwiseConvBlock(
+            filterCount: 512,
+            pointwiseFilterCount: 1024,
+            depthMultiplier: depthMultiplier,
+            strides: (2, 2))
+        dConvBlock13 = DepthwiseConvBlock(
+            filterCount: 1024,
+            pointwiseFilterCount: 1024,
+            depthMultiplier: depthMultiplier,
+            strides: (1, 1))
 
-    dropoutLayer = Dropout<Float>(probability: dropout)
-    convLast = Conv2D<Float>(
-      filterShape: (1, 1, 1024, classCount),
-      strides: (1, 1),
-      padding: .same)
-  }
+        dropoutLayer = Dropout<Float>(probability: dropout)
+        convLast = Conv2D<Float>(
+            filterShape: (1, 1, 1024, classCount),
+            strides: (1, 1),
+            padding: .same)
+    }
 
-  @differentiable
-  public func callAsFunction(_ input: Tensor<Float>) -> Tensor<Float> {
-    let convolved = input.sequenced(through: convBlock1, dConvBlock1,
-      dConvBlock2, dConvBlock3, dConvBlock4)
-    let convolved2 = convolved.sequenced(through: dConvBlock5, dConvBlock6,
-      dConvBlock7, dConvBlock8, dConvBlock9)
-    let convolved3 = convolved2.sequenced(through: dConvBlock10, dConvBlock11,
-      dConvBlock12, dConvBlock13)
+    @differentiable
+    public func callAsFunction(_ input: Tensor<Float>) -> Tensor<Float> {
+        let convolved = input.sequenced(
+            through: convBlock1, dConvBlock1,
+            dConvBlock2, dConvBlock3, dConvBlock4)
+        let convolved2 = convolved.sequenced(
+            through: dConvBlock5, dConvBlock6,
+            dConvBlock7, dConvBlock8, dConvBlock9)
+        let convolved3 = convolved2.sequenced(
+            through: dConvBlock10, dConvBlock11,
+            dConvBlock12, dConvBlock13)
 
-    // Verify shape since any discrepancies will be masked after pooling
-    let convolved4 = convolved3.sequenced(through: avgPool, reshape,
-      dropoutLayer, convLast)
-    let output = convolved4.reshaped(to: [1, classCount])
-    return output
-  }  
+        // Verify shape since any discrepancies will be masked after pooling
+        let convolved4 = convolved3.sequenced(
+            through: avgPool, reshape,
+            dropoutLayer, convLast)
+        let output = convolved4.reshaped(to: [1, classCount])
+        return output
+    }
 }
-

--- a/Models/ImageClassification/MobileNet.swift
+++ b/Models/ImageClassification/MobileNet.swift
@@ -15,8 +15,8 @@
 import TensorFlow
 
 // Original Paper:
-// "MobileNets: Efficient Convolutional Neural Networks for Mobile Vision
-// Applications"
+// MobileNets: Efficient Convolutional Neural Networks for Mobile Vision
+// Applications
 // Andrew G. Howard, Menglong Zhu, Bo Chen, Dmitry Kalenichenko
 // Weijun Wang, Tobias Weyand, Marco Andreetto, Hartwig Adam
 // https://arxiv.org/abs/1704.04861
@@ -27,158 +27,91 @@ public struct ConvBlock: Layer {
   public var conv: Conv2D<Float>
   public var batchNorm: BatchNorm<Float>
 
-  public init(featureCount: Int, filterShape: (Int, Int, Int, Int), strides: (Int, Int)) {
+  public init(filterCount: Int, strides: (Int, Int)) {
     conv = Conv2D<Float>(
-      filterShape: filterShape,
+      filterShape: (3, 3, 3, filterCount),
       strides: strides,
       padding: .valid)
-    batchNorm = BatchNorm<Float>(featureCount: featureCount)
+    batchNorm = BatchNorm<Float>(featureCount: filterCount)
   }
 
   @differentiable
   public func callAsFunction(_ input: Tensor<Float>) -> Tensor<Float> {
-    // let convolved = input.sequenced(through: zeroPad, conv, batchNorm)
-    // return relu6(convolved)
-    let c1 = zeroPad(input)
-//    print("zeroPad: \(c1.shape)")
-    let c2 = conv(c1)
-//    print("conv: \(c2.shape)")
-    let c3 = batchNorm(c2)
-//    print("batchNorm: \(c3.shape)")
-    let c4 = relu(c3)
-//    print("relu: \(c4.shape)")
-    return c4
+    let convolved = input.sequenced(through: zeroPad, conv, batchNorm)
+    return relu6(convolved)
   }
-
 }
 
 public struct DepthwiseConvBlock: Layer {
-  public var zeroPad = ZeroPadding2D<Float>(
-      padding: ((0, 1), (0, 1)))
+  public var zeroPad = ZeroPadding2D<Float>(padding: ((0, 1), (0, 1)))
   public var dConv: DepthwiseConv2D<Float>
   public var batchNorm1: BatchNorm<Float>
   public var conv: Conv2D<Float>
   public var batchNorm2: BatchNorm<Float>
 
-  public init(inputChannel: Int, outputChannel: Int, strides: (Int, Int)) {
+  public init(filterCount: Int, pointwiseFilterCount: Int, strides: (Int, Int)) {
     dConv = DepthwiseConv2D<Float>(
-      filterShape: (3, 3, inputChannel, 1),
+      filterShape: (3, 3, filterCount, 1),
       strides: strides,
       padding: .same)
-    batchNorm1 = BatchNorm<Float>(featureCount: inputChannel)
+    batchNorm1 = BatchNorm<Float>(featureCount: filterCount)
     conv = Conv2D<Float>(
-      filterShape: (1, 1, inputChannel, outputChannel),
+      filterShape: (1, 1, filterCount, pointwiseFilterCount),
       strides: (1, 1),
       padding: .same)
-    batchNorm2 = BatchNorm<Float>(featureCount: outputChannel)
+    batchNorm2 = BatchNorm<Float>(featureCount: pointwiseFilterCount)
   }
 
   @differentiable
   public func callAsFunction(_ input: Tensor<Float>) -> Tensor<Float> {
-    // let convolved1 = input.sequenced(through: zeroPad, dConv, batchNorm1)
-    // let convolved2 = relu6(convolved1).sequenced(through: conv, batchNorm2)
-    // return relu6(convolved2)
-    let c1 = dConv(input)
- //   print("dConv: \(c1.shape)")
-    let c2 = batchNorm1(c1)
- //   print("batchNorm1: \(c2.shape)")
-    let c2_2 = relu6(c2)
- //   print("relu6: \(c2_2.shape)")
-    let c3 = conv(c2_2)
- //   print("conv: \(c3.shape)")
-    let c4 = batchNorm2(c3)
- //   print("batchNorm2: \(c4.shape)")
-    let c5 = relu6(c4)
- //   print("relu6: \(c5.shape)")
-    return c5
+    // TODO(michellecasbon): Add conditional zero padding
+    let convolved1 = relu6(input.sequenced(through: dConv, batchNorm1))
+    let convolved2 = relu6(convolved1.sequenced(through: conv, batchNorm2))
+    return convolved2
   }
 
 }
 
 public struct MobileNetV1: Layer {
-  public var convBlock1: ConvBlock
-  public var dConvBlock1: DepthwiseConvBlock
-  public var dConvBlock2: DepthwiseConvBlock
-  public var dConvBlock3: DepthwiseConvBlock
-  public var dConvBlock4: DepthwiseConvBlock
-  public var dConvBlock5: DepthwiseConvBlock
-  public var dConvBlock6: DepthwiseConvBlock
-  public var dConvBlock7: DepthwiseConvBlock
-  public var dConvBlock8: DepthwiseConvBlock
-  public var dConvBlock9: DepthwiseConvBlock
-  public var dConvBlock10: DepthwiseConvBlock
-  public var dConvBlock11: DepthwiseConvBlock
-  public var dConvBlock12: DepthwiseConvBlock
-  public var dConvBlock13: DepthwiseConvBlock
+  @noDerivative
+  var classCount: Int
+
+  public var convBlock1 = ConvBlock(filterCount: 32, strides: (2, 2))
+  public var dConvBlock1 = DepthwiseConvBlock(filterCount: 32, pointwiseFilterCount: 64, strides: (1, 1))
+  public var dConvBlock2 = DepthwiseConvBlock(filterCount: 64, pointwiseFilterCount: 128, strides: (2, 2))
+  public var dConvBlock3 = DepthwiseConvBlock(filterCount: 128, pointwiseFilterCount: 128, strides: (1, 1))
+  public var dConvBlock4 = DepthwiseConvBlock(filterCount: 128, pointwiseFilterCount: 256, strides: (2, 2))
+  public var dConvBlock5 = DepthwiseConvBlock(filterCount: 256, pointwiseFilterCount: 256, strides: (1, 1))
+  public var dConvBlock6 = DepthwiseConvBlock(filterCount: 256, pointwiseFilterCount: 512, strides: (2, 2))
+  public var dConvBlock7 = DepthwiseConvBlock(filterCount: 512, pointwiseFilterCount: 512, strides: (1, 1))
+  public var dConvBlock8 = DepthwiseConvBlock(filterCount: 512, pointwiseFilterCount: 512, strides: (1, 1))
+  public var dConvBlock9 = DepthwiseConvBlock(filterCount: 512, pointwiseFilterCount: 512, strides: (1, 1))
+  public var dConvBlock10 = DepthwiseConvBlock(filterCount: 512, pointwiseFilterCount: 512, strides: (1, 1))
+  public var dConvBlock11 = DepthwiseConvBlock(filterCount: 512, pointwiseFilterCount: 512, strides: (1, 1))
+  public var dConvBlock12 = DepthwiseConvBlock(filterCount: 512, pointwiseFilterCount: 1024, strides: (2, 2))
+  public var dConvBlock13 = DepthwiseConvBlock(filterCount: 1024, pointwiseFilterCount: 1024, strides: (1, 1))
   public var avgPool = GlobalAvgPool2D<Float>()
   public var reshape = Reshape<Float>(shape: [1, 1, 1, 1024])
   public var dropout = Dropout<Float>(probability: 0.001)
   public var convLast: Conv2D<Float>
-  public var dense: Dense<Float>
 
   public init(classCount: Int) {
-  //  convBlock1 = ConvBlock(featureCount: classCount, filterShape: (1, 1, 224, 32), strides: (2, 2))
-    convBlock1 = ConvBlock(featureCount: 32, filterShape: (3, 3, 3, 32), strides: (2, 2))
-    dConvBlock1 = DepthwiseConvBlock(inputChannel: 32, outputChannel: 64, strides: (1, 1))
-    dConvBlock2 = DepthwiseConvBlock(inputChannel: 64, outputChannel: 128, strides: (2, 2))
-    dConvBlock3 = DepthwiseConvBlock(inputChannel: 128, outputChannel: 128, strides: (1, 1))
-    dConvBlock4 = DepthwiseConvBlock(inputChannel: 128, outputChannel: 256, strides: (2, 2))
-    dConvBlock5 = DepthwiseConvBlock(inputChannel: 256, outputChannel: 256, strides: (1, 1))
-    dConvBlock6 = DepthwiseConvBlock(inputChannel: 256, outputChannel: 512, strides: (2, 2))
-    dConvBlock7 = DepthwiseConvBlock(inputChannel: 512, outputChannel: 512, strides: (1, 1))
-    dConvBlock8 = DepthwiseConvBlock(inputChannel: 512, outputChannel: 512, strides: (1, 1))
-    dConvBlock9 = DepthwiseConvBlock(inputChannel: 512, outputChannel: 512, strides: (1, 1))
-    dConvBlock10 = DepthwiseConvBlock(inputChannel: 512, outputChannel: 512, strides: (1, 1))
-    dConvBlock11 = DepthwiseConvBlock(inputChannel: 512, outputChannel: 512, strides: (1, 1))
-    dConvBlock12 = DepthwiseConvBlock(inputChannel: 512, outputChannel: 1024, strides: (2, 2))
-    dConvBlock13 = DepthwiseConvBlock(inputChannel: 1024, outputChannel: 1024, strides: (1, 1))
-
-    // TODO(michellecasbon): Add remaining layers
+    self.classCount = classCount
     convLast = Conv2D<Float>(
       filterShape: (1, 1, 1024, classCount),
       strides: (1, 1),
       padding: .same,
       activation: softmax)
-    dense = Dense<Float>(inputSize: 32, outputSize: 32)
   }
 
   @differentiable
   public func callAsFunction(_ input: Tensor<Float>) -> Tensor<Float> {
-    // let convolved = input.sequenced(through: convBlock1, dConvBlock1, dConvBlock2, convLast)
-    //return softmax(convolved)
-    print("input: \(input.shape)")
-    let convolved = convBlock1(input)
-    print("convBlock1: \(convolved.shape)")
-    let c2 = dConvBlock1(convolved)
-    print("dConvBlock1: \(c2.shape)")
-    let c3 = dConvBlock2(c2)
-    print("dConvBlock2: \(c3.shape)")
-    let c4 = dConvBlock3(c3)
-    print("dConvBlock3: \(c4.shape)")
-    let c5 = dConvBlock4(c4)
-    print("dConvBlock4: \(c5.shape)")
-    let c6 = dConvBlock5(c5)
-    print("dConvBlock5: \(c6.shape)")
-
-    let c7 = c6.sequenced(through: dConvBlock6, dConvBlock7, dConvBlock8, dConvBlock9)
-    print("dConvBlock9: \(c7.shape)")
-    let c8 = c7.sequenced(through: dConvBlock10, dConvBlock11, dConvBlock12, dConvBlock13)
-    print("dConvBlock13: \(c8.shape)")
- 
-    let c9 = avgPool(c8)
-    print("avgPool: \(c9.shape)")
-    let c9_2 = reshape(c9)
-    print("reshape: \(c9_2.shape)")
-    let c10 = dropout(c9_2)
-    print("dropout: \(c10.shape)")
-    let c11 = convLast(c10)
-    print("convLast: \(c11.shape)")
-    let c12 = softmax(c11)
-    print("softmax: \(c12.shape)")
-    let c13 = c12.reshaped(to: [1, 1000])
-    print("reshaped: \(c13.shape)")
-  
-    return c13
+    let convolved = input.sequenced(through: convBlock1, dConvBlock1, dConvBlock2, dConvBlock3, dConvBlock4)
+    let convolved2 = convolved.sequenced(through: dConvBlock5, dConvBlock6, dConvBlock7, dConvBlock8, dConvBlock9)
+    let convolved3 = convolved2.sequenced(through: dConvBlock10, dConvBlock11, dConvBlock12, dConvBlock13)
+    let convolved4 = convolved3.sequenced(through: avgPool, reshape, dropout, convLast)
+    let output = softmax(convolved4).reshaped(to: [1, classCount])
+    return output
   }  
 }
 

--- a/Models/ImageClassification/MobileNet.swift
+++ b/Models/ImageClassification/MobileNet.swift
@@ -59,9 +59,7 @@ public struct DepthwiseConvBlock: Layer {
         filterCount: Int, pointwiseFilterCount: Int, depthMultiplier: Int,
         strides: (Int, Int)
     ) {
-        if depthMultiplier < 1 {
-            fatalError("Depth multiplier must be an integer greater than 0.")
-        }
+        precondition(depthMultiplier > 0, "Depth multiplier must be positive")
         self.depthMultiplier = depthMultiplier
         self.strides = strides
 

--- a/Models/ImageClassification/MobileNet.swift
+++ b/Models/ImageClassification/MobileNet.swift
@@ -29,7 +29,8 @@ public struct ConvBlock: Layer {
   public var conv: Conv2D<Float>
   public var batchNorm: BatchNorm<Float>
 
-  public init(filterCount: Int, strides: (Int, Int), printSummary: Bool = false) {
+  public init(filterCount: Int, strides: (Int, Int),
+    printSummary: Bool = false) {
     self.printSummary = printSummary
 
     conv = Conv2D<Float>(
@@ -67,23 +68,29 @@ public struct DepthwiseConvBlock: Layer {
   public var conv: Conv2D<Float>
   public var batchNorm2: BatchNorm<Float>
 
-  public init(filterCount: Int, pointwiseFilterCount: Int, depthMultiplier: Int, strides: (Int, Int), printSummary: Bool = false) {
+  public init(filterCount: Int, pointwiseFilterCount: Int, depthMultiplier: Int,
+    strides: (Int, Int), printSummary: Bool = false) {
     self.strides = strides
     self.printSummary = printSummary
     if depthMultiplier > 0 {
-        self.depthMultiplier = depthMultiplier
+      self.depthMultiplier = depthMultiplier
     } else {
-        print("Depth multiplier must be an integer greater than 0. Setting to default value of 1.")
-        self.depthMultiplier = 1
+      print("""
+            Depth multiplier must be an integer greater than 0.
+            Setting depth multiplier to default value of 1.
+            """)
+      self.depthMultiplier = 1
     }
 
     dConv = DepthwiseConv2D<Float>(
       filterShape: (3, 3, filterCount, self.depthMultiplier),
       strides: strides,
       padding: strides == (1, 1) ? .same : .valid)
-    batchNorm1 = BatchNorm<Float>(featureCount: filterCount * self.depthMultiplier)
+    batchNorm1 = BatchNorm<Float>(
+      featureCount: filterCount * self.depthMultiplier)
     conv = Conv2D<Float>(
-      filterShape: (1, 1, filterCount * self.depthMultiplier, pointwiseFilterCount),
+      filterShape: (1, 1, filterCount * self.depthMultiplier,
+        pointwiseFilterCount),
       strides: (1, 1),
       padding: .same)
     batchNorm2 = BatchNorm<Float>(featureCount: pointwiseFilterCount)
@@ -147,24 +154,92 @@ public struct MobileNetV1: Layer {
   public var dropoutLayer: Dropout<Float>
   public var convLast: Conv2D<Float>
 
-  public init(classCount: Int, depthMultiplier: Int = 1, dropout: Double = 0.001, printSummary: Bool = false) {
+  public init(classCount: Int, depthMultiplier: Int = 1,
+    dropout: Double = 0.001, printSummary: Bool = false) {
     self.classCount = classCount
     self.printSummary = printSummary
 
-    convBlock1 = ConvBlock(filterCount: 32, strides: (2, 2), printSummary: printSummary)
-    dConvBlock1 = DepthwiseConvBlock(filterCount: 32, pointwiseFilterCount: 64, depthMultiplier: depthMultiplier, strides: (1, 1), printSummary: printSummary)
-    dConvBlock2 = DepthwiseConvBlock(filterCount: 64, pointwiseFilterCount: 128, depthMultiplier: depthMultiplier, strides: (2, 2), printSummary: printSummary)
-    dConvBlock3 = DepthwiseConvBlock(filterCount: 128, pointwiseFilterCount: 128, depthMultiplier: depthMultiplier, strides: (1, 1), printSummary: printSummary)
-    dConvBlock4 = DepthwiseConvBlock(filterCount: 128, pointwiseFilterCount: 256, depthMultiplier: depthMultiplier, strides: (2, 2), printSummary: printSummary)
-    dConvBlock5 = DepthwiseConvBlock(filterCount: 256, pointwiseFilterCount: 256, depthMultiplier: depthMultiplier, strides: (1, 1), printSummary: printSummary)
-    dConvBlock6 = DepthwiseConvBlock(filterCount: 256, pointwiseFilterCount: 512, depthMultiplier: depthMultiplier, strides: (2, 2), printSummary: printSummary)
-    dConvBlock7 = DepthwiseConvBlock(filterCount: 512, pointwiseFilterCount: 512, depthMultiplier: depthMultiplier, strides: (1, 1), printSummary: printSummary)
-    dConvBlock8 = DepthwiseConvBlock(filterCount: 512, pointwiseFilterCount: 512, depthMultiplier: depthMultiplier, strides: (1, 1), printSummary: printSummary)
-    dConvBlock9 = DepthwiseConvBlock(filterCount: 512, pointwiseFilterCount: 512, depthMultiplier: depthMultiplier, strides: (1, 1), printSummary: printSummary)
-    dConvBlock10 = DepthwiseConvBlock(filterCount: 512, pointwiseFilterCount: 512, depthMultiplier: depthMultiplier, strides: (1, 1), printSummary: printSummary)
-    dConvBlock11 = DepthwiseConvBlock(filterCount: 512, pointwiseFilterCount: 512, depthMultiplier: depthMultiplier, strides: (1, 1), printSummary: printSummary)
-    dConvBlock12 = DepthwiseConvBlock(filterCount: 512, pointwiseFilterCount: 1024, depthMultiplier: depthMultiplier, strides: (2, 2), printSummary: printSummary)
-    dConvBlock13 = DepthwiseConvBlock(filterCount: 1024, pointwiseFilterCount: 1024, depthMultiplier: depthMultiplier, strides: (1, 1), printSummary: printSummary)
+    convBlock1 = ConvBlock(filterCount: 32,
+      strides: (2, 2),
+      printSummary: printSummary)
+    dConvBlock1 = DepthwiseConvBlock(
+      filterCount: 32,
+      pointwiseFilterCount: 64,
+      depthMultiplier: depthMultiplier,
+      strides: (1, 1),
+      printSummary: printSummary)
+    dConvBlock2 = DepthwiseConvBlock(
+      filterCount: 64,
+      pointwiseFilterCount: 128,
+      depthMultiplier: depthMultiplier,
+      strides: (2, 2),
+      printSummary: printSummary)
+    dConvBlock3 = DepthwiseConvBlock(
+      filterCount: 128,
+      pointwiseFilterCount: 128,
+      depthMultiplier: depthMultiplier,
+      strides: (1, 1),
+      printSummary: printSummary)
+    dConvBlock4 = DepthwiseConvBlock(
+      filterCount: 128,
+      pointwiseFilterCount: 256,
+      depthMultiplier: depthMultiplier,
+      strides: (2, 2),
+      printSummary: printSummary)
+    dConvBlock5 = DepthwiseConvBlock(
+      filterCount: 256,
+      pointwiseFilterCount: 256,
+      depthMultiplier: depthMultiplier,
+      strides: (1, 1),
+      printSummary: printSummary)
+    dConvBlock6 = DepthwiseConvBlock(
+      filterCount: 256,
+      pointwiseFilterCount: 512,
+      depthMultiplier: depthMultiplier,
+      strides: (2, 2),
+      printSummary: printSummary)
+    dConvBlock7 = DepthwiseConvBlock(
+      filterCount: 512,
+      pointwiseFilterCount: 512,
+      depthMultiplier: depthMultiplier,
+      strides: (1, 1),
+      printSummary: printSummary)
+    dConvBlock8 = DepthwiseConvBlock(
+      filterCount: 512,
+      pointwiseFilterCount: 512,
+      depthMultiplier: depthMultiplier,
+      strides: (1, 1),
+      printSummary: printSummary)
+    dConvBlock9 = DepthwiseConvBlock(
+      filterCount: 512,
+      pointwiseFilterCount: 512,
+      depthMultiplier: depthMultiplier,
+      strides: (1, 1),
+      printSummary: printSummary)
+    dConvBlock10 = DepthwiseConvBlock(
+      filterCount: 512,
+      pointwiseFilterCount: 512,
+      depthMultiplier: depthMultiplier,
+      strides: (1, 1),
+      printSummary: printSummary)
+    dConvBlock11 = DepthwiseConvBlock(
+      filterCount: 512,
+      pointwiseFilterCount: 512,
+      depthMultiplier: depthMultiplier,
+      strides: (1, 1),
+      printSummary: printSummary)
+    dConvBlock12 = DepthwiseConvBlock(
+      filterCount: 512,
+      pointwiseFilterCount: 1024,
+      depthMultiplier: depthMultiplier,
+      strides: (2, 2),
+      printSummary: printSummary)
+    dConvBlock13 = DepthwiseConvBlock(
+      filterCount: 1024,
+      pointwiseFilterCount: 1024,
+      depthMultiplier: depthMultiplier,
+      strides: (1, 1),
+      printSummary: printSummary)
 
     dropoutLayer = Dropout<Float>(probability: dropout)
     convLast = Conv2D<Float>(
@@ -175,18 +250,25 @@ public struct MobileNetV1: Layer {
 
   @differentiable
   public func callAsFunction(_ input: Tensor<Float>) -> Tensor<Float> {
-    let convolved = input.sequenced(through: convBlock1, dConvBlock1, dConvBlock2, dConvBlock3, dConvBlock4)
-    let convolved2 = convolved.sequenced(through: dConvBlock5, dConvBlock6, dConvBlock7, dConvBlock8, dConvBlock9)
-    let convolved3 = convolved2.sequenced(through: dConvBlock10, dConvBlock11, dConvBlock12, dConvBlock13)
+    let convolved = input.sequenced(through: convBlock1, dConvBlock1,
+      dConvBlock2, dConvBlock3, dConvBlock4)
+    let convolved2 = convolved.sequenced(through: dConvBlock5, dConvBlock6,
+      dConvBlock7, dConvBlock8, dConvBlock9)
+    let convolved3 = convolved2.sequenced(through: dConvBlock10, dConvBlock11,
+      dConvBlock12, dConvBlock13)
 
     // Verify shape since any discrepancies will be masked after pooling
     let expectedWidth = input.shape[1] / 32
     let expectedHeight = input.shape[2] / 32
     if convolved3.shape != TensorShape(1, expectedWidth, expectedHeight, 1024) {
-      print("Invalid shape before GlobalAveragePooling2D: \(convolved2.shape) should be [1, \(expectedWidth), \(expectedHeight), 1024].")
+      print("""
+            Invalid shape before GlobalAveragePooling2D: \(convolved2.shape)
+            should be [1, \(expectedWidth), \(expectedHeight), 1024].
+            """)
     }
 
-    let convolved4 = convolved3.sequenced(through: avgPool, reshape, dropoutLayer, convLast)
+    let convolved4 = convolved3.sequenced(through: avgPool, reshape,
+      dropoutLayer, convLast)
     let output = convolved4.reshaped(to: [1, classCount])
     if self.printSummary {
       print("GlobalAvgPool2D")

--- a/Models/ImageClassification/MobileNet.swift
+++ b/Models/ImageClassification/MobileNet.swift
@@ -100,11 +100,12 @@ public struct MobileNetV1: Layer {
   public var dConvBlock13 = DepthwiseConvBlock(filterCount: 1024, pointwiseFilterCount: 1024, strides: (1, 1))
   public var avgPool = GlobalAvgPool2D<Float>()
   public var reshape = Reshape<Float>(shape: [1, 1, 1, 1024])
-  public var dropout = Dropout<Float>(probability: 0.001)
+  public var dropoutLayer: Dropout<Float>
   public var convLast: Conv2D<Float>
 
-  public init(classCount: Int) {
+  public init(classCount: Int, dropout: Double = 0.001) {
     self.classCount = classCount
+    dropoutLayer = Dropout<Float>(probability: dropout)
     convLast = Conv2D<Float>(
       filterShape: (1, 1, 1024, classCount),
       strides: (1, 1),
@@ -116,7 +117,7 @@ public struct MobileNetV1: Layer {
     let convolved = input.sequenced(through: convBlock1, dConvBlock1, dConvBlock2, dConvBlock3, dConvBlock4)
     let convolved2 = convolved.sequenced(through: dConvBlock5, dConvBlock6, dConvBlock7, dConvBlock8, dConvBlock9)
     let convolved3 = convolved2.sequenced(through: dConvBlock10, dConvBlock11, dConvBlock12, dConvBlock13)
-    let convolved4 = convolved3.sequenced(through: avgPool, reshape, dropout, convLast)
+    let convolved4 = convolved3.sequenced(through: avgPool, reshape, dropoutLayer, convLast)
     let output = convolved4.reshaped(to: [1, classCount])
     return output
   }  

--- a/Models/ImageClassification/MobileNet.swift
+++ b/Models/ImageClassification/MobileNet.swift
@@ -97,8 +97,7 @@ public struct MobileNetV1: Layer {
     convLast = Conv2D<Float>(
       filterShape: (1, 1, 1024, classCount),
       strides: (1, 1),
-      padding: .same,
-      activation: softmax)
+      padding: .same)
   }
 
   @differentiable

--- a/Models/ImageClassification/MobileNet.swift
+++ b/Models/ImageClassification/MobileNet.swift
@@ -15,8 +15,8 @@
 import TensorFlow
 
 // Original Paper:
-// MobileNets: Efficient Convolutional Neural Networks for Mobile Vision
-// Applications
+// "MobileNets: Efficient Convolutional Neural Networks for Mobile Vision
+// Applications"
 // Andrew G. Howard, Menglong Zhu, Bo Chen, Dmitry Kalenichenko
 // Weijun Wang, Tobias Weyand, Marco Andreetto, Hartwig Adam
 // https://arxiv.org/abs/1704.04861
@@ -69,7 +69,6 @@ public struct DepthwiseConvBlock: Layer {
     let convolved2 = relu6(convolved1.sequenced(through: conv, batchNorm2))
     return convolved2
   }
-
 }
 
 public struct MobileNetV1: Layer {

--- a/Models/ImageClassification/MobileNet.swift
+++ b/Models/ImageClassification/MobileNet.swift
@@ -56,13 +56,14 @@ public struct ConvBlock: Layer {
 
 public struct DepthwiseConvBlock: Layer {
   @noDerivative
-  var depthMultiplier: Int
+  let depthMultiplier: Int
   @noDerivative
-  var strides: (Int, Int)
+  let strides: (Int, Int)
   @noDerivative
-  var printSummary: Bool
+  let printSummary: Bool
 
-  public var zeroPad = ZeroPadding2D<Float>(padding: ((0, 1), (0, 1)))
+  @noDerivative
+  public let zeroPad = ZeroPadding2D<Float>(padding: ((0, 1), (0, 1)))
   public var dConv: DepthwiseConv2D<Float>
   public var batchNorm1: BatchNorm<Float>
   public var conv: Conv2D<Float>
@@ -70,17 +71,12 @@ public struct DepthwiseConvBlock: Layer {
 
   public init(filterCount: Int, pointwiseFilterCount: Int, depthMultiplier: Int,
     strides: (Int, Int), printSummary: Bool = false) {
+    if depthMultiplier < 1 {
+      fatalError("Depth multiplier must be an integer greater than 0.")
+    }
+    self.depthMultiplier = depthMultiplier
     self.strides = strides
     self.printSummary = printSummary
-    if depthMultiplier > 0 {
-      self.depthMultiplier = depthMultiplier
-    } else {
-      print("""
-            Depth multiplier must be an integer greater than 0.
-            Setting depth multiplier to default value of 1.
-            """)
-      self.depthMultiplier = 1
-    }
 
     dConv = DepthwiseConv2D<Float>(
       filterShape: (3, 3, filterCount, self.depthMultiplier),
@@ -131,9 +127,9 @@ public struct DepthwiseConvBlock: Layer {
 
 public struct MobileNetV1: Layer {
   @noDerivative
-  var classCount: Int
+  let classCount: Int
   @noDerivative
-  var printSummary: Bool
+  let printSummary: Bool
 
   public var convBlock1: ConvBlock
   public var dConvBlock1: DepthwiseConvBlock

--- a/Models/ImageClassification/MobileNet.swift
+++ b/Models/ImageClassification/MobileNet.swift
@@ -209,8 +209,6 @@ public struct MobileNetV1: Layer {
         let convolved3 = convolved2.sequenced(
             through: dConvBlock10, dConvBlock11,
             dConvBlock12, dConvBlock13)
-
-        // Verify shape since any discrepancies will be masked after pooling
         let convolved4 = convolved3.sequenced(
             through: avgPool, reshape,
             dropoutLayer, convLast)

--- a/Models/ImageClassification/MobileNet.swift
+++ b/Models/ImageClassification/MobileNet.swift
@@ -22,8 +22,7 @@ import TensorFlow
 // https://arxiv.org/abs/1704.04861
 
 public struct ConvBlock: Layer {
-  public var zeroPad = ZeroPadding2D<Float>(
-      padding: ((0, 1), (0, 1)))
+  public var zeroPad = ZeroPadding2D<Float>(padding: ((0, 1), (0, 1)))
   public var conv: Conv2D<Float>
   public var batchNorm: BatchNorm<Float>
 
@@ -43,7 +42,6 @@ public struct ConvBlock: Layer {
 }
 
 public struct DepthwiseConvBlock: Layer {
-  public var zeroPad = ZeroPadding2D<Float>(padding: ((0, 1), (0, 1)))
   public var dConv: DepthwiseConv2D<Float>
   public var batchNorm1: BatchNorm<Float>
   public var conv: Conv2D<Float>
@@ -109,7 +107,7 @@ public struct MobileNetV1: Layer {
     let convolved2 = convolved.sequenced(through: dConvBlock5, dConvBlock6, dConvBlock7, dConvBlock8, dConvBlock9)
     let convolved3 = convolved2.sequenced(through: dConvBlock10, dConvBlock11, dConvBlock12, dConvBlock13)
     let convolved4 = convolved3.sequenced(through: avgPool, reshape, dropout, convLast)
-    let output = softmax(convolved4).reshaped(to: [1, classCount])
+    let output = convolved4.reshaped(to: [1, classCount])
     return output
   }  
 }

--- a/Models/ImageClassification/MobileNet.swift
+++ b/Models/ImageClassification/MobileNet.swift
@@ -43,6 +43,8 @@ public struct ConvBlock: Layer {
 
 public struct DepthwiseConvBlock: Layer {
   @noDerivative
+  var depthMultiplier: Int
+  @noDerivative
   var strides: (Int, Int)
 
   public var zeroPad = ZeroPadding2D<Float>(padding: ((0, 1), (0, 1)))
@@ -51,10 +53,18 @@ public struct DepthwiseConvBlock: Layer {
   public var conv: Conv2D<Float>
   public var batchNorm2: BatchNorm<Float>
 
-  public init(filterCount: Int, pointwiseFilterCount: Int, strides: (Int, Int)) {
+  public init(filterCount: Int, pointwiseFilterCount: Int, depthMultiplier: Int, strides: (Int, Int)) {
+    if depthMultiplier > 0 {
+        self.depthMultiplier = depthMultiplier
+    } else {
+        print("Depth multiplier must be an integer greater than 0. Setting to default value of 1.")
+        self.depthMultiplier = 1
+    }
+
     self.strides = strides
+
     dConv = DepthwiseConv2D<Float>(
-      filterShape: (3, 3, filterCount, 1),
+      filterShape: (3, 3, filterCount, self.depthMultiplier),
       strides: strides,
       padding: .same)
     batchNorm1 = BatchNorm<Float>(featureCount: filterCount)
@@ -85,26 +95,41 @@ public struct MobileNetV1: Layer {
   var classCount: Int
 
   public var convBlock1 = ConvBlock(filterCount: 32, strides: (2, 2))
-  public var dConvBlock1 = DepthwiseConvBlock(filterCount: 32, pointwiseFilterCount: 64, strides: (1, 1))
-  public var dConvBlock2 = DepthwiseConvBlock(filterCount: 64, pointwiseFilterCount: 128, strides: (2, 2))
-  public var dConvBlock3 = DepthwiseConvBlock(filterCount: 128, pointwiseFilterCount: 128, strides: (1, 1))
-  public var dConvBlock4 = DepthwiseConvBlock(filterCount: 128, pointwiseFilterCount: 256, strides: (2, 2))
-  public var dConvBlock5 = DepthwiseConvBlock(filterCount: 256, pointwiseFilterCount: 256, strides: (1, 1))
-  public var dConvBlock6 = DepthwiseConvBlock(filterCount: 256, pointwiseFilterCount: 512, strides: (2, 2))
-  public var dConvBlock7 = DepthwiseConvBlock(filterCount: 512, pointwiseFilterCount: 512, strides: (1, 1))
-  public var dConvBlock8 = DepthwiseConvBlock(filterCount: 512, pointwiseFilterCount: 512, strides: (1, 1))
-  public var dConvBlock9 = DepthwiseConvBlock(filterCount: 512, pointwiseFilterCount: 512, strides: (1, 1))
-  public var dConvBlock10 = DepthwiseConvBlock(filterCount: 512, pointwiseFilterCount: 512, strides: (1, 1))
-  public var dConvBlock11 = DepthwiseConvBlock(filterCount: 512, pointwiseFilterCount: 512, strides: (1, 1))
-  public var dConvBlock12 = DepthwiseConvBlock(filterCount: 512, pointwiseFilterCount: 1024, strides: (2, 2))
-  public var dConvBlock13 = DepthwiseConvBlock(filterCount: 1024, pointwiseFilterCount: 1024, strides: (1, 1))
+  public var dConvBlock1: DepthwiseConvBlock
+  public var dConvBlock2: DepthwiseConvBlock
+  public var dConvBlock3: DepthwiseConvBlock
+  public var dConvBlock4: DepthwiseConvBlock
+  public var dConvBlock5: DepthwiseConvBlock
+  public var dConvBlock6: DepthwiseConvBlock
+  public var dConvBlock7: DepthwiseConvBlock
+  public var dConvBlock8: DepthwiseConvBlock
+  public var dConvBlock9: DepthwiseConvBlock
+  public var dConvBlock10: DepthwiseConvBlock
+  public var dConvBlock11: DepthwiseConvBlock
+  public var dConvBlock12: DepthwiseConvBlock
+  public var dConvBlock13: DepthwiseConvBlock
   public var avgPool = GlobalAvgPool2D<Float>()
   public var reshape = Reshape<Float>(shape: [1, 1, 1, 1024])
   public var dropoutLayer: Dropout<Float>
   public var convLast: Conv2D<Float>
 
-  public init(classCount: Int, dropout: Double = 0.001) {
+  public init(classCount: Int, depthMultiplier: Int = 1, dropout: Double = 0.001) {
     self.classCount = classCount
+
+    dConvBlock1 = DepthwiseConvBlock(filterCount: 32, pointwiseFilterCount: 64, depthMultiplier: depthMultiplier, strides: (1, 1))
+    dConvBlock2 = DepthwiseConvBlock(filterCount: 64, pointwiseFilterCount: 128, depthMultiplier: depthMultiplier, strides: (2, 2))
+    dConvBlock3 = DepthwiseConvBlock(filterCount: 128, pointwiseFilterCount: 128, depthMultiplier: depthMultiplier, strides: (1, 1))
+    dConvBlock4 = DepthwiseConvBlock(filterCount: 128, pointwiseFilterCount: 256, depthMultiplier: depthMultiplier, strides: (2, 2))
+    dConvBlock5 = DepthwiseConvBlock(filterCount: 256, pointwiseFilterCount: 256, depthMultiplier: depthMultiplier, strides: (1, 1))
+    dConvBlock6 = DepthwiseConvBlock(filterCount: 256, pointwiseFilterCount: 512, depthMultiplier: depthMultiplier, strides: (2, 2))
+    dConvBlock7 = DepthwiseConvBlock(filterCount: 512, pointwiseFilterCount: 512, depthMultiplier: depthMultiplier, strides: (1, 1))
+    dConvBlock8 = DepthwiseConvBlock(filterCount: 512, pointwiseFilterCount: 512, depthMultiplier: depthMultiplier, strides: (1, 1))
+    dConvBlock9 = DepthwiseConvBlock(filterCount: 512, pointwiseFilterCount: 512, depthMultiplier: depthMultiplier, strides: (1, 1))
+    dConvBlock10 = DepthwiseConvBlock(filterCount: 512, pointwiseFilterCount: 512, depthMultiplier: depthMultiplier, strides: (1, 1))
+    dConvBlock11 = DepthwiseConvBlock(filterCount: 512, pointwiseFilterCount: 512, depthMultiplier: depthMultiplier, strides: (1, 1))
+    dConvBlock12 = DepthwiseConvBlock(filterCount: 512, pointwiseFilterCount: 1024, depthMultiplier: depthMultiplier, strides: (2, 2))
+    dConvBlock13 = DepthwiseConvBlock(filterCount: 1024, pointwiseFilterCount: 1024, depthMultiplier: depthMultiplier, strides: (1, 1))
+
     dropoutLayer = Dropout<Float>(probability: dropout)
     convLast = Conv2D<Float>(
       filterShape: (1, 1, 1024, classCount),

--- a/Models/ImageClassification/MobileNet.swift
+++ b/Models/ImageClassification/MobileNet.swift
@@ -1,0 +1,166 @@
+// Copyright 2019 The TensorFlow Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import TensorFlow
+
+// Original Paper:
+// "MobileNets: Efficient Convolutional Neural Networks for Mobile Vision
+// Applications"
+// Andrew G. Howard, Menglong Zhu, Bo Chen, Dmitry Kalenichenko
+// Weijun Wang, Tobias Weyand, Marco Andreetto, Hartwig Adam
+// https://arxiv.org/abs/1704.04861
+
+public struct ConvBlock: Layer {
+  public var zeroPad = ZeroPadding2D<Float>(
+      padding: ((0, 1), (0, 1)))
+  public var conv: Conv2D<Float>
+  public var batchNorm: BatchNorm<Float>
+
+  public init(featureCount: Int, filterShape: (Int, Int, Int, Int), strides: (Int, Int)) {
+    conv = Conv2D<Float>(
+      filterShape: filterShape,
+      strides: strides,
+      padding: .valid)
+    batchNorm = BatchNorm<Float>(featureCount: featureCount)
+  }
+
+  @differentiable
+  public func callAsFunction(_ input: Tensor<Float>) -> Tensor<Float> {
+    // let convolved = input.sequenced(through: zeroPad, conv, batchNorm)
+    // return relu6(convolved)
+    let c1 = zeroPad(input)
+    print("zeroPad: \(c1.shape)")
+    let c2 = conv(c1)
+    print("conv: \(c2.shape)")
+    let c3 = batchNorm(c2)
+    print("batchNorm: \(c3.shape)")
+    let c4 = relu(c3)
+    print("relu: \(c4.shape)")
+    return c4
+  }
+
+}
+
+public struct DepthwiseConvBlock: Layer {
+  public var zeroPad = ZeroPadding2D<Float>(
+      padding: ((0, 1), (0, 1)))
+  public var dConv: DepthwiseConv2D<Float>
+  public var batchNorm1: BatchNorm<Float>
+  public var conv: Conv2D<Float>
+  public var batchNorm2: BatchNorm<Float>
+
+  public init(inputChannel: Int, outputChannel: Int, strides: (Int, Int)) {
+    dConv = DepthwiseConv2D<Float>(
+      filterShape: (3, 3, inputChannel, 1),
+      strides: strides,
+      padding: .same)
+    batchNorm1 = BatchNorm<Float>(featureCount: inputChannel)
+    conv = Conv2D<Float>(
+      filterShape: (1, 1, inputChannel, outputChannel),
+      strides: (1, 1),
+      padding: .same)
+    batchNorm2 = BatchNorm<Float>(featureCount: outputChannel)
+  }
+
+  @differentiable
+  public func callAsFunction(_ input: Tensor<Float>) -> Tensor<Float> {
+    // let convolved1 = input.sequenced(through: zeroPad, dConv, batchNorm1)
+    // let convolved2 = relu6(convolved1).sequenced(through: conv, batchNorm2)
+    // return relu6(convolved2)
+    let c1 = dConv(input)
+    print("dConv: \(c1.shape)")
+    let c2 = batchNorm1(c1)
+    print("batchNorm1: \(c2.shape)")
+    let c2_2 = relu6(c2)
+    print("relu6: \(c2_2.shape)")
+    let c3 = conv(c2)
+    print("conv: \(c3.shape)")
+    let c4 = batchNorm2(c3)
+    print("batchNorm2: \(c4.shape)")
+    let c5 = relu6(c4)
+    print("relu6: \(c5.shape)")
+    return c5
+  }
+
+}
+
+public struct MobileNetV1: Layer {
+  public var convBlock1: ConvBlock
+  public var dConvBlock1: DepthwiseConvBlock
+  public var dConvBlock2: DepthwiseConvBlock
+  public var dConvBlock3: DepthwiseConvBlock
+  public var dConvBlock4: DepthwiseConvBlock
+  public var dConvBlock5: DepthwiseConvBlock
+  public var dConvBlock6: DepthwiseConvBlock
+  public var dConvBlock7: DepthwiseConvBlock
+  public var dConvBlock8: DepthwiseConvBlock
+  public var dConvBlock9: DepthwiseConvBlock
+  public var dConvBlock10: DepthwiseConvBlock
+  public var dConvBlock11: DepthwiseConvBlock
+  public var dConvBlock12: DepthwiseConvBlock
+  public var dConvBlock13: DepthwiseConvBlock
+  public var convLast: Conv2D<Float>
+  public var dense: Dense<Float>
+
+  public init(classCount: Int) {
+  //  convBlock1 = ConvBlock(featureCount: classCount, filterShape: (1, 1, 224, 32), strides: (2, 2))
+    convBlock1 = ConvBlock(featureCount: 32, filterShape: (3, 3, 3, 32), strides: (2, 2))
+    dConvBlock1 = DepthwiseConvBlock(inputChannel: 32, outputChannel: 64, strides: (1, 1))
+    dConvBlock2 = DepthwiseConvBlock(inputChannel: 64, outputChannel: 128, strides: (2, 2))
+    dConvBlock3 = DepthwiseConvBlock(inputChannel: 128, outputChannel: 128, strides: (1, 1))
+    dConvBlock4 = DepthwiseConvBlock(inputChannel: 128, outputChannel: 256, strides: (2, 2))
+    dConvBlock5 = DepthwiseConvBlock(inputChannel: 256, outputChannel: 256, strides: (1, 1))
+    dConvBlock6 = DepthwiseConvBlock(inputChannel: 256, outputChannel: 512, strides: (2, 2))
+    dConvBlock7 = DepthwiseConvBlock(inputChannel: 512, outputChannel: 512, strides: (1, 1))
+    dConvBlock8 = DepthwiseConvBlock(inputChannel: 512, outputChannel: 512, strides: (1, 1))
+    dConvBlock9 = DepthwiseConvBlock(inputChannel: 512, outputChannel: 512, strides: (1, 1))
+    dConvBlock10 = DepthwiseConvBlock(inputChannel: 512, outputChannel: 512, strides: (1, 1))
+    dConvBlock11 = DepthwiseConvBlock(inputChannel: 512, outputChannel: 512, strides: (1, 1))
+    dConvBlock12 = DepthwiseConvBlock(inputChannel: 512, outputChannel: 1024, strides: (2, 2))
+    dConvBlock13 = DepthwiseConvBlock(inputChannel: 1024, outputChannel: 1024, strides: (1, 1))
+
+    // TODO(michellecasbon): Add remaining layers
+    convLast = Conv2D<Float>(
+      filterShape: (1, 1, 1024, classCount),
+      strides: (1, 1))
+    dense = Dense<Float>(inputSize: 32, outputSize: 32)
+  }
+
+  @differentiable
+  public func callAsFunction(_ input: Tensor<Float>) -> Tensor<Float> {
+    // let convolved = input.sequenced(through: convBlock1, dConvBlock1, dConvBlock2, convLast)
+    //return softmax(convolved)
+    print("input: \(input.shape)")
+    let convolved = convBlock1(input)
+    print("convBlock1: \(convolved.shape)")
+    let c2 = dConvBlock1(convolved)
+    print("dConvBlock1: \(c2.shape)")
+    let c3 = dConvBlock2(c2)
+    print("dConvBlock2: \(c3.shape)")
+    let c4 = dConvBlock3(c3)
+    print("dConvBlock3: \(c4.shape)")
+    let c5 = dConvBlock4(c4)
+    print("dConvBlock4: \(c5.shape)")
+    let c6 = dConvBlock5(c5)
+    print("dConvBlock5: \(c6.shape)")
+
+    let c7 = c6.sequenced(through: dConvBlock6, dConvBlock7, dConvBlock8, dConvBlock9)
+    print("dConvBlock9: \(c7.shape)")
+    let c8 = c7.sequenced(through: dConvBlock10, dConvBlock11, dConvBlock12, dConvBlock13)
+    print("dConvBlock13: \(c8.shape)")
+  
+    return c8
+  }  
+}
+

--- a/Tests/ImageClassificationTests/Inference.swift
+++ b/Tests/ImageClassificationTests/Inference.swift
@@ -40,6 +40,15 @@ final class ImageClassificationInferenceTests: XCTestCase {
         XCTAssertEqual(result.shape, [1, 10])
     }
 
+    func testMobileNetV1() {
+        let input = Tensor<Float>(
+            randomNormal: [1, 224, 224, 3], mean: Tensor<Float>(0.5),
+            standardDeviation: Tensor<Float>(0.1), seed: (0xffeffe, 0xfffe))
+        let mobileNet = MobileNetV1(classCount: 1000)
+        let mobileNetResult = mobileNet(input)
+        XCTAssertEqual(mobileNetResult.shape, [1, 1000])
+    }
+
     func testResNet() {
         let inputCIFAR = Tensor<Float>(
             randomNormal: [1, 32, 32, 3], mean: Tensor<Float>(0.5),
@@ -169,6 +178,7 @@ extension ImageClassificationInferenceTests {
     static var allTests = [
         ("testDenseNet121", testDenseNet121),
         ("testLeNet", testLeNet),
+        ("testMobileNetV1", testMobileNetV1),
         ("testResNet", testResNet),
         ("testResNetV2", testResNetV2),
         ("testSqueezeNetV1_0", testSqueezeNetV1_0),

--- a/Tests/ImageClassificationTests/Inference.swift
+++ b/Tests/ImageClassificationTests/Inference.swift
@@ -57,6 +57,16 @@ final class ImageClassificationInferenceTests: XCTestCase {
         let mobileNetCIFARResult = mobileNetCIFAR(inputCIFAR)
         XCTAssertEqual(mobileNetCIFARResult.shape, [1, 10])
 
+        // Width multiplier
+        let mobileNetWMSmall = MobileNetV1(classCount: 10, widthMultiplier: 0.5)
+        let mobileNetWMSmallResult = mobileNetWMSmall(inputCIFAR)
+        XCTAssertEqual(mobileNetWMSmallResult.shape, [1, 10])
+
+        // Width multiplier
+        let mobileNetWMLarge = MobileNetV1(classCount: 10, widthMultiplier: 1.5)
+        let mobileNetWMLargeResult = mobileNetWMLarge(inputCIFAR)
+        XCTAssertEqual(mobileNetWMLargeResult.shape, [1, 10])
+
         // Depth multiplier and dropout
         let mobileNetDMD = MobileNetV1(classCount: 10, depthMultiplier: 2, dropout: 0.01)
         let mobileNetDMDResult = mobileNetDMD(inputCIFAR)

--- a/Tests/ImageClassificationTests/Inference.swift
+++ b/Tests/ImageClassificationTests/Inference.swift
@@ -21,7 +21,7 @@ final class ImageClassificationInferenceTests: XCTestCase {
     override class func setUp() {
         Context.local.learningPhase = .inference
     }
-    
+
     func testDenseNet121() {
         let input = Tensor<Float>(
             randomNormal: [1, 224, 224, 3], mean: Tensor<Float>(0.5),

--- a/Tests/ImageClassificationTests/Inference.swift
+++ b/Tests/ImageClassificationTests/Inference.swift
@@ -41,12 +41,26 @@ final class ImageClassificationInferenceTests: XCTestCase {
     }
 
     func testMobileNetV1() {
-        let input = Tensor<Float>(
+        // ImageNet size
+        let inputImageNet = Tensor<Float>(
             randomNormal: [1, 224, 224, 3], mean: Tensor<Float>(0.5),
             standardDeviation: Tensor<Float>(0.1), seed: (0xffeffe, 0xfffe))
         let mobileNet = MobileNetV1(classCount: 1000)
-        let mobileNetResult = mobileNet(input)
+        let mobileNetResult = mobileNet(inputImageNet)
         XCTAssertEqual(mobileNetResult.shape, [1, 1000])
+
+        // CIFAR10 size
+        let inputCIFAR = Tensor<Float>(
+            randomNormal: [1, 32, 32, 3], mean: Tensor<Float>(0.5),
+            standardDeviation: Tensor<Float>(0.1), seed: (0xffeffe, 0xfffe))
+        let mobileNetCIFAR = MobileNetV1(classCount: 10)
+        let mobileNetCIFARResult = mobileNetCIFAR(inputCIFAR)
+        XCTAssertEqual(mobileNetCIFARResult.shape, [1, 10])
+
+        // Depth multiplier and dropout
+        let mobileNetDMD = MobileNetV1(classCount: 10, depthMultiplier: 2, dropout: 0.01)
+        let mobileNetDMDResult = mobileNetDMD(inputCIFAR)
+        XCTAssertEqual(mobileNetDMDResult.shape, [1, 10])
     }
 
     func testResNet() {


### PR DESCRIPTION
Fixes #238.

Add MobileNet v1 model based on the [keras implementation](https://github.com/keras-team/keras-applications/blob/master/keras_applications/mobilenet.py).

- [X] MobileNet v1 model
- [X] MobileNet v1 test
- [x] Conditional zero padding
- [x] Dropout probability
- [x] Depth multiplier with minimum depth
- [x] Verify layer architecture with python keras implementation for additional input sizes
- [x] Verify tensor size fed into the GlobalAvgPool2D layer

Follow-on PRs will address creating a dataset (#237) and example that uses this model (#239).