### PR TITLE
Remove _Raw from CIFAR10.swift

### DIFF
--- a/Datasets/CIFAR10/CIFAR10.swift
+++ b/Datasets/CIFAR10/CIFAR10.swift
@@ -125,8 +125,8 @@ func loadCIFARFile(named name: String, in directory: String = ".") -> CIFARExamp
 func loadCIFARTrainingFiles() -> CIFARExample {
     let data = (1..<6).map { loadCIFARFile(named: "data_batch_\($0).bin") }
     return CIFARExample(
-        label: _Raw.concat(concatDim: Tensor<Int32>(0), data.map { $0.label }),
-        data: _Raw.concat(concatDim: Tensor<Int32>(0), data.map { $0.data })
+        label: Tensor(concatenating: data.map { $0.label }, alongAxis: 0),
+        data: Tensor(concatenating: data.map { $0.data }, alongAxis: 0)
     )
 }
 

--- a/Package.swift
+++ b/Package.swift
@@ -45,6 +45,7 @@ let package = Package(
             sources: ["main.swift"]),
         .testTarget(name: "MiniGoTests", dependencies: ["MiniGo"]),
         .testTarget(name: "ImageClassificationTests", dependencies: ["ImageClassificationModels"]),
+        .testTarget(name: "DatasetsTests", dependencies: ["Datasets"]),
         .target(name: "Transformer", path: "Transformer"),
         .target(name: "GAN", dependencies: ["Datasets", "ModelSupport"], path: "GAN"),
         .target(

--- a/Tests/DatasetsTests/CIFAR10/CIFAR10Tests.swift
+++ b/Tests/DatasetsTests/CIFAR10/CIFAR10Tests.swift
@@ -9,11 +9,9 @@ final class CIFAR10Tests: XCTestCase {
 
 		var totalCount = 0
 		for example in dataset.trainingDataset {
-		  if totalCount == 0 {
-		    XCTAssertTrue((0..<10).contains(example.label.scalar!))
-		    XCTAssertEqual(example.data.shape, [32, 32, 3])
-		  }
-		  totalCount += 1
+	    	XCTAssertTrue((0..<10).contains(example.label.scalar!))
+	    	XCTAssertEqual(example.data.shape, [32, 32, 3])
+			totalCount += 1
 		}
 		XCTAssertEqual(totalCount, 50000)
 	}

--- a/Tests/DatasetsTests/CIFAR10/CIFAR10Tests.swift
+++ b/Tests/DatasetsTests/CIFAR10/CIFAR10Tests.swift
@@ -1,0 +1,20 @@
+import TensorFlow
+import XCTest
+
+@testable import Datasets
+
+final class CIFAR10Tests: XCTestCase {
+	func testCreateCIFAR10() {
+		let dataset = CIFAR10()
+
+		var totalCount = 0
+		for example in dataset.trainingDataset {
+		  if totalCount == 0 {
+		    XCTAssertTrue((0..<10).contains(example.label.scalar!))
+		    XCTAssertEqual(example.data.shape, [32, 32, 3])
+		  }
+		  totalCount += 1
+		}
+		XCTAssertEqual(totalCount, 50000)
+	}
+}

--- a/Tests/DatasetsTests/CIFAR10/CIFAR10Tests.swift
+++ b/Tests/DatasetsTests/CIFAR10/CIFAR10Tests.swift
@@ -1,18 +1,18 @@
 import TensorFlow
 import XCTest
-
-@testable import Datasets
+import Datasets
 
 final class CIFAR10Tests: XCTestCase {
-	func testCreateCIFAR10() {
-		let dataset = CIFAR10()
+    func testCreateCIFAR10() {
+        let dataset = CIFAR10()
 
-		var totalCount = 0
-		for example in dataset.trainingDataset {
-	    	XCTAssertTrue((0..<10).contains(example.label.scalar!))
-	    	XCTAssertEqual(example.data.shape, [32, 32, 3])
-			totalCount += 1
-		}
-		XCTAssertEqual(totalCount, 50000)
-	}
+        var totalCount = 0
+        for example in dataset.trainingDataset {
+            XCTAssertTrue((0..<10).contains(example.label.scalar!))
+            XCTAssertEqual(example.data.shape, [32, 32, 3])
+            totalCount += 1
+        }
+        XCTAssertEqual(totalCount, 50000)
+    }
 }
+

--- a/Tests/DatasetsTests/CIFAR10/CIFAR10Tests.swift
+++ b/Tests/DatasetsTests/CIFAR10/CIFAR10Tests.swift
@@ -16,3 +16,9 @@ final class CIFAR10Tests: XCTestCase {
     }
 }
 
+extension CIFAR10Tests {
+    static var allTests = [
+        ("testCreateCIFAR10", testCreateCIFAR10),
+    ]
+}
+

--- a/Tests/DatasetsTests/CIFAR10/XCTestManifests.swift
+++ b/Tests/DatasetsTests/CIFAR10/XCTestManifests.swift
@@ -1,0 +1,23 @@
+// Copyright 2019 The TensorFlow Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import XCTest
+
+#if !os(macOS)
+public func allTests() -> [XCTestCaseEntry] {
+    return [
+        testCase(CIFAR10Tests.allTests),
+    ]
+}
+#endif

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -2,8 +2,10 @@ import XCTest
 
 import ImageClassificationTests
 import MiniGoTests
+import DatasetsTests
 
 var tests = [XCTestCaseEntry]()
 tests += ImageClassificationTests.allTests()
 tests += MiniGoTests.allTests()
+tests += DatasetsTests.allTests()
 XCTMain(tests)


### PR DESCRIPTION
Removing using _Raw and use Tensor initializer instead to concatenate segments of datasets.
Details about removing _Raw see https://github.com/tensorflow/swift-models/issues/225.