### PR TITLE
Revert "work around duplicate definition of diff witness (#234)"

### DIFF
--- a/MiniGo/Models/GoModel.swift
+++ b/MiniGo/Models/GoModel.swift
@@ -53,8 +53,7 @@ struct ConvBN: Layer {
     ) {
         // TODO(jekbradbury): thread through bias and affine boolean arguments
         // (behavior is correct for inference but this should be changed for training)
-        self.conv = Conv2D(
-          filterShape: filterShape, strides: strides, padding: padding, activation: identity)
+        self.conv = Conv2D(filterShape: filterShape, strides: strides, padding: padding)
         self.norm = BatchNorm(featureCount: filterShape.3, momentum: 0.95, epsilon: 1e-5)
     }
 

--- a/Models/ImageClassification/DenseNet121.swift
+++ b/Models/ImageClassification/DenseNet121.swift
@@ -71,8 +71,7 @@ extension DenseNet121 {
             conv = Conv2D(
                 filterShape: (filterSize, filterSize, inputFilterCount, outputFilterCount),
                 strides: (stride, stride),
-                padding: .same,
-                activation: identity
+                padding: .same
             )
         }
 

--- a/Models/ImageClassification/LeNet-5.swift
+++ b/Models/ImageClassification/LeNet-5.swift
@@ -30,7 +30,7 @@ public struct LeNet: Layer {
     public var flatten = Flatten<Float>()
     public var fc1 = Dense<Float>(inputSize: 400, outputSize: 120, activation: relu)
     public var fc2 = Dense<Float>(inputSize: 120, outputSize: 84, activation: relu)
-    public var fc3 = Dense<Float>(inputSize: 84, outputSize: 10, activation: identity)
+    public var fc3 = Dense<Float>(inputSize: 84, outputSize: 10)
 
     public init() {}
 

--- a/Models/ImageClassification/ResNet50.swift
+++ b/Models/ImageClassification/ResNet50.swift
@@ -34,8 +34,7 @@ public struct ConvBN: Layer {
         strides: (Int, Int) = (1, 1),
         padding: Padding = .valid
     ) {
-        self.conv = Conv2D(
-          filterShape: filterShape, strides: strides, padding: padding, activation: identity)
+        self.conv = Conv2D(filterShape: filterShape, strides: strides, padding: padding)
         self.norm = BatchNorm(featureCount: filterShape.3)
     }
 

--- a/Models/ImageClassification/ResNetV2.swift
+++ b/Models/ImageClassification/ResNetV2.swift
@@ -30,8 +30,7 @@ public struct Conv2DBatchNorm: Layer {
         strides: (Int, Int) = (1, 1),
         padding: Padding = .valid
     ) {
-        self.conv = Conv2D(
-          filterShape: filterShape, strides: strides, padding: padding, activation: identity)
+        self.conv = Conv2D(filterShape: filterShape, strides: strides, padding: padding)
         self.norm = BatchNorm(featureCount: filterShape.3)
     }
 

--- a/Models/ImageClassification/WideResNet.swift
+++ b/Models/ImageClassification/WideResNet.swift
@@ -39,17 +39,14 @@ public struct BatchNormConv2DBlock: Layer {
         self.conv1 = Conv2D(
             filterShape: (kernelSize, kernelSize, featureCounts.0, featureCounts.1), 
             strides: strides, 
-            padding: padding,
-            activation: identity)
+            padding: padding)
         self.norm2 = BatchNorm(featureCount: featureCounts.1)
         self.conv2 = Conv2D(filterShape: (kernelSize, kernelSize, featureCounts.1, featureCounts.1), 
                             strides: (1, 1), 
-                            padding: padding,
-                            activation: identity)
+                            padding: padding)
         self.shortcut = Conv2D(filterShape: (1, 1, featureCounts.0, featureCounts.1), 
                                strides: strides, 
-                               padding: padding,
-                               activation: identity)
+                               padding: padding)
         self.isExpansion = featureCounts.1 != featureCounts.0 || strides != (1, 1) 
     }
 
@@ -105,8 +102,7 @@ public struct WideResNet: Layer {
     public var classifier: Dense<Float>
 
     public init(depthFactor: Int = 2, widenFactor: Int = 8) {
-        self.l1 = Conv2D(
-          filterShape: (3, 3, 3, 16), strides: (1, 1), padding: .same, activation: identity)
+        self.l1 = Conv2D(filterShape: (3, 3, 3, 16), strides: (1, 1), padding: .same)
 
         self.l2 = WideResNetBasicBlock(
             featureCounts: (16, 16 * widenFactor), depthFactor: depthFactor, initialStride: (1, 1))


### PR DESCRIPTION
https://github.com/apple/swift/pull/28582 fixed https://bugs.swift.org/browse/TF-1025, making this workaround no longer necessary.