### PR TITLE
Remove _Raw from CIFAR10.swift

### DIFF
--- a/Datasets/CIFAR10/CIFAR10.swift
+++ b/Datasets/CIFAR10/CIFAR10.swift
@@ -127,8 +127,8 @@ func loadCIFARFile(named name: String, in directory: String = ".") -> LabeledExa
 func loadCIFARTrainingFiles() -> LabeledExample {
     let data = (1..<6).map { loadCIFARFile(named: "data_batch_\($0).bin") }
     return LabeledExample(
-        label: _Raw.concat(concatDim: Tensor<Int32>(0), data.map { $0.label }),
-        data: _Raw.concat(concatDim: Tensor<Int32>(0), data.map { $0.data })
+        label: Tensor(concatenating: data.map { $0.label }, alongAxis: 0),
+        data: Tensor(concatenating: data.map { $0.data }, alongAxis: 0)
     )
 }
 

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,0 +1,25 @@
+{
+  "object": {
+    "pins": [
+      {
+        "package": "Commander",
+        "repositoryURL": "https://github.com/kylef/Commander.git",
+        "state": {
+          "branch": null,
+          "revision": "4b6133c3071d521489a80c38fb92d7983f19d438",
+          "version": "0.9.1"
+        }
+      },
+      {
+        "package": "Spectre",
+        "repositoryURL": "https://github.com/kylef/Spectre.git",
+        "state": {
+          "branch": null,
+          "revision": "f14ff47f45642aa5703900980b014c2e9394b6e5",
+          "version": "0.9.0"
+        }
+      }
+    ]
+  },
+  "version": 1
+}

--- a/Package.swift
+++ b/Package.swift
@@ -50,6 +50,7 @@ let package = Package(
             sources: ["main.swift"]),
         .testTarget(name: "MiniGoTests", dependencies: ["MiniGo"]),
         .testTarget(name: "ImageClassificationTests", dependencies: ["ImageClassificationModels"]),
+        .testTarget(name: "DatasetsTests", dependencies: ["Datasets"]),
         .target(name: "Transformer", path: "Transformer"),
         .target(name: "GAN", dependencies: ["Datasets", "ModelSupport"], path: "GAN"),
         .target(name: "FastStyleTransfer", path: "FastStyleTransfer", exclude: ["Demo"]),

--- a/Tests/DatasetsTests/CIFAR10/CIFAR10Tests.swift
+++ b/Tests/DatasetsTests/CIFAR10/CIFAR10Tests.swift
@@ -1,0 +1,24 @@
+import TensorFlow
+import XCTest
+import Datasets
+
+final class CIFAR10Tests: XCTestCase {
+    func testCreateCIFAR10() {
+        let dataset = CIFAR10()
+
+        var totalCount = 0
+        for example in dataset.trainingDataset {
+            XCTAssertTrue((0..<10).contains(example.label.scalar!))
+            XCTAssertEqual(example.data.shape, [32, 32, 3])
+            totalCount += 1
+        }
+        XCTAssertEqual(totalCount, 50000)
+    }
+}
+
+extension CIFAR10Tests {
+    static var allTests = [
+        ("testCreateCIFAR10", testCreateCIFAR10),
+    ]
+}
+

--- a/Tests/DatasetsTests/CIFAR10/XCTestManifests.swift
+++ b/Tests/DatasetsTests/CIFAR10/XCTestManifests.swift
@@ -1,0 +1,23 @@
+// Copyright 2019 The TensorFlow Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import XCTest
+
+#if !os(macOS)
+public func allTests() -> [XCTestCaseEntry] {
+    return [
+        testCase(CIFAR10Tests.allTests),
+    ]
+}
+#endif

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -3,9 +3,12 @@ import XCTest
 import ImageClassificationTests
 import MiniGoTests
 import FastStyleTransferTests
+import DatasetsTests
+
 
 var tests = [XCTestCaseEntry]()
 tests += ImageClassificationTests.allTests()
 tests += MiniGoTests.allTests()
 tests += FastStyleTransferTests.allTests()
+tests += DatasetsTests.allTests()
 XCTMain(tests)


### PR DESCRIPTION
Removing using _Raw and use Tensor initializer instead to concatenate segments of datasets.
Details about removing _Raw see #225.