### PR TITLE
tweak mnist batchsize logic

### DIFF
--- a/Examples/LeNet-MNIST/main.swift
+++ b/Examples/LeNet-MNIST/main.swift
@@ -60,7 +60,7 @@ for epoch in 1...epochCount {
             let correctPredictions = ŷ.argmax(squeezingAxis: 1) .== labels
             trainStats.correctGuessCount += Int(
                 Tensor<Int32>(correctPredictions).sum().scalarized())
-            trainStats.totalGuessCount += batchSize
+            trainStats.totalGuessCount += batch.data.shape[0]
             let loss = softmaxCrossEntropy(logits: ŷ, labels: labels)
             trainStats.totalLoss += loss.scalarized()
             trainStats.batches += 1
@@ -77,7 +77,7 @@ for epoch in 1...epochCount {
         let ŷ = classifier(images)
         let correctPredictions = ŷ.argmax(squeezingAxis: 1) .== labels
         testStats.correctGuessCount += Int(Tensor<Int32>(correctPredictions).sum().scalarized())
-        testStats.totalGuessCount += batchSize
+        testStats.totalGuessCount += batch.data.shape[0]
         let loss = softmaxCrossEntropy(logits: ŷ, labels: labels)
         testStats.totalLoss += loss.scalarized()
         testStats.batches += 1


### PR DESCRIPTION
this is minor, but it's been driving me nuts for a little while.
originally the batchsize % dataset size == 0, so the logic worked.
but when moving to 128 as a batchsize, all the stats are now subtly off since the last batch size != 128.
we should find a better way to address this long term, or otherwise this bug will be copy-pasted everywhere. #241 is showing num_correct/512, when it should be /500, for example.  the two cifar demos use N * 10k % 100 so they work for now.
if there's a better way to calculate this, let me know!