### PR TITLE
Correcting block sizes for ResNet models

### DIFF
--- a/Models/ImageClassification/ResNet50.swift
+++ b/Models/ImageClassification/ResNet50.swift
@@ -218,16 +218,16 @@ public struct ResNetBasic: Layer {
 
         l2b = ResidualBasicBlockStack(
             featureCounts: (64, 64, 64, 64),
-            blockCount: layerBlockCounts.0)
+            blockCount: layerBlockCounts.0 - 1)
         l3b = ResidualBasicBlockStack(
             featureCounts: (128, 128, 128, 128),
-            blockCount: layerBlockCounts.1)
+            blockCount: layerBlockCounts.1 - 1)
         l4b = ResidualBasicBlockStack(
             featureCounts: (256, 256, 256, 256),
-            blockCount: layerBlockCounts.2)
+            blockCount: layerBlockCounts.2 - 1)
         l5b = ResidualBasicBlockStack(
             featureCounts: (512, 512, 512, 512),
-            blockCount: layerBlockCounts.3)
+            blockCount: layerBlockCounts.3 - 1)
     }
 
     @differentiable
@@ -293,16 +293,16 @@ public struct ResNet: Layer {
 
         l2b = ResidualIdentityBlockStack(
             featureCounts: (256, 64, 64, 256),
-            blockCount: layerBlockCounts.0)
+            blockCount: layerBlockCounts.0 - 1)
         l3b = ResidualIdentityBlockStack(
             featureCounts: (512, 128, 128, 512),
-            blockCount: layerBlockCounts.1)
+            blockCount: layerBlockCounts.1 - 1)
         l4b = ResidualIdentityBlockStack(
             featureCounts: (1024, 256, 256, 1024),
-            blockCount: layerBlockCounts.2)
+            blockCount: layerBlockCounts.2 - 1)
         l5b = ResidualIdentityBlockStack(
             featureCounts: (2048, 512, 512, 2048),
-            blockCount: layerBlockCounts.3)
+            blockCount: layerBlockCounts.3 - 1)
     }
 
     @differentiable


### PR DESCRIPTION
I had specified the block sizes for the various sizes of ResNet models based on Table 1 of ["Deep Residual Learning for Image Recognition"](https://arxiv.org/abs/1512.03385), however those block sizes did not account for the ResidualConvBlock before each ResidualIdentityBlockStack.

In order to still have each list of block counts match the published specification, I opted to subtract one from the input count at the point of forming the ResidualBasicBlockStack in order to account for the ResidualConvBlock before each.

After this change, the numbers and types of convolutions for each size should match reference implementations for the various sizes.