### PR TITLE
Minor edit to respond to Python linter warning

### DIFF
--- a/Benchmarks/__init__.py
+++ b/Benchmarks/__init__.py
@@ -59,7 +59,7 @@ cwd = '/workspace/perfzero/workspace/site-packages/swift-models/'
 
 
 def extract_extras(settings):
-  return None
+  return
 
 
 def extract_metrics(timings_ms, batch_size):


### PR DESCRIPTION
This is a small change, driven purely by a presubmit linter warning with an internal build system.