### PR TITLE
Remove _Raw in Transformer/Model.swift

### DIFF
--- a/Transformer/Model.swift
+++ b/Transformer/Model.swift
@@ -92,10 +92,7 @@ func causallyMasked(_ dotProducts: Tensor<Float>, enable: Bool = false) -> Tenso
     }
     let (queryTimeSteps, keyTimeSteps) = (dotProducts.shape[1], dotProducts.shape[2])
     let ones = Tensor<Float>(ones: [1, queryTimeSteps, keyTimeSteps])
-    let mask = _Raw.matrixBandPart(
-        ones,
-        numLower: Tensor(Int32(-1)),
-        numUpper: Tensor(Int32(queryTimeSteps - keyTimeSteps)))
+    let mask = ones.bandPart(-1, queryTimeSteps - keyTimeSteps)
     return dotProducts * mask - 1e10 * (1 - mask)
 }
 
@@ -173,7 +170,7 @@ func _vjpSplitQKV(_ input: Tensor<Float>)
     -> (AttentionInput, (AttentionInput.TangentVector) -> Tensor<Float>) {
     let value = splitQKV(input)
     return (value, { seed in
-        return _Raw.concatV2([seed.query, seed.key, seed.value], axis: Tensor<Int32>(2))
+        return Tensor(concatenating: [seed.query, seed.key, seed.value], alongAxis: 2)
     })
 }
 


### PR DESCRIPTION
This PR switches off _Raw from Transformer/Model.swift by:
- using Tensor's concatenating initializer for concatenating tensors.
- using Tensor's bandPart operator for matrix bandPart operation.

More about removing _Raw: https://github.com/tensorflow/swift-models/issues/225

Able to run the model and got reasonable output after the change.