### PR TITLE
Remove _Raw in Transformer/Operators.swift

### DIFF
--- a/Transformer/Operators.swift
+++ b/Transformer/Operators.swift
@@ -37,7 +37,7 @@ func batchedMatmul<Scalar : Numeric>(
     adjointLeft: Bool = false,
     adjointRight: Bool = false
 ) -> Tensor<Scalar> {
-    return _Raw.batchMatMul(left, right, adjX: adjointLeft, adjY: adjointRight)
+    return matmul(left, transposed: adjointLeft, right, transposed: adjointRight)
 }
 
 @usableFromInline


### PR DESCRIPTION
This PR switches off _Raw from Transformer/Operators.swift by using matmul operator in Math.swift.

More about removing _Raw: #225

Able to run the model and got reasonable output after the change.