### PR TITLE
Add support for additional benchmark metrics

### DIFF
--- a/Benchmarks/Benchmark.swift
+++ b/Benchmarks/Benchmark.swift
@@ -15,6 +15,7 @@
 import Foundation
 
 protocol Benchmark {
+    var exampleCount: Int { get }
     func run()
 }
 
@@ -29,7 +30,8 @@ func measure(
         timings.append(timing)
     }
 
-    return BenchmarkResults(configuration: configuration, timings: timings)
+    return BenchmarkResults(
+        configuration: configuration, timings: timings, exampleCount: benchmark.exampleCount)
 }
 
 /// Returns the time elapsed while running `body` in milliseconds.

--- a/Benchmarks/BenchmarkResults.swift
+++ b/Benchmarks/BenchmarkResults.swift
@@ -15,6 +15,7 @@
 struct BenchmarkResults: Codable {
     let configuration: BenchmarkConfiguration
     let timings: [Double]
+    let exampleCount: Int
 }
 
 extension BenchmarkResults {

--- a/Benchmarks/Models/ImageClassificationInference.swift
+++ b/Benchmarks/Models/ImageClassificationInference.swift
@@ -31,6 +31,10 @@ where Model: ImageClassificationModel, ClassificationDataset: ImageClassificatio
     let batches: Int
     let batchSize: Int
 
+    var exampleCount: Int {
+        return batches * batchSize
+    }
+
     init(settings: BenchmarkSettings, images: Tensor<Float>? = nil) {
         self.batches = settings.batches
         self.batchSize = settings.batchSize

--- a/Benchmarks/Models/ImageClassificationTraining.swift
+++ b/Benchmarks/Models/ImageClassificationTraining.swift
@@ -24,6 +24,10 @@ where
     let epochs: Int
     let batchSize: Int
 
+    var exampleCount: Int {
+        return epochs * dataset.trainingExampleCount
+    }
+
     init(settings: BenchmarkSettings) {
         self.epochs = settings.epochs
         self.batchSize = settings.batchSize

--- a/Benchmarks/__init__.py
+++ b/Benchmarks/__init__.py
@@ -44,10 +44,12 @@ class SwiftBenchmark(tf.test.Benchmark):
     pass
 
   def training(self):
+    """Runner-ccallable benchmark entry point for training benchmark."""
     result = run_swift_benchmark(name=self.benchmark_name, variety='training')
     self.report_benchmark(**result)
 
   def inference(self):
+    """Runner-callable benchmark entry point for inference benchmark."""
     result = run_swift_benchmark(name=self.benchmark_name, variety='inference')
     self.report_benchmark(**result)
 
@@ -59,31 +61,71 @@ cwd = '/workspace/perfzero/workspace/site-packages/swift-models/'
 
 
 def extract_extras(settings):
+  """Extract additional benchmark metadata.
+
+  Returns a json-style object or None for additional
+  benchmark metadata such as flags that can be useful for debugging.
+  """
+
   return
 
 
-def extract_metrics(timings_ms, batch_size):
-  metrics = []
-  return metrics
+def extract_metrics(result, variety):
+  """Extract perfzero metrics based on the measurmenets.
+
+  Extracts metrics such as number of examples per second,
+  based on the the original raw timings.
+  """
+
+  timings = result['timings']
+  example_count = result['exampleCount']
+
+  # 50 percentile of a single iteration running time in seconds.
+  timings_s = np.array(timings) / 1000
+  wall_time = np.percentile(timings_s, 50)
+
+  # Average examples per second across the entire
+  # benchmark run. Doesn't account for warm-up.
+  total_time_s = sum(timings_s)
+  total_num_examples = example_count * len(timings_s)
+  average_examples_per_second = total_num_examples / total_time_s
+
+  # Examples per second across the second half
+  # of the measurements. First half of measurements
+  # is dropped to account for warm-up.
+  warmup = int(len(timings_s) / 2 if len(timings_s) > 1 else 0)
+  warm_timings_s = timings_s[warmup:]
+  warm_time_s = sum(warm_timings_s)
+  warm_num_examples = example_count * len(warm_timings_s)
+  examples_per_second = warm_num_examples / warm_time_s
+
+  metrics = [{
+      'name': 'exp_per_second',
+      'value': examples_per_second
+  }, {
+      'name': 'avg_exp_per_second',
+      'value': average_examples_per_second
+  }]
+
+  return (wall_time, metrics)
 
 
 def run_swift_benchmark(name, variety):
   print('running swift benchmark {} ({})'.format(name, variety))
-  output = subp.check_output(['swift', 'run', '-c', 'release', 
-                              'Benchmarks', 'measure', '--benchmark',
-                              name, '--' + variety, '--json'],
-                             cwd=cwd)
+  output = subp.check_output([
+      'swift', 'run', '-c', 'release', 'Benchmarks', 'measure', '--benchmark',
+      name, '--' + variety, '--json'
+  ], cwd=cwd)
   result = json.loads(output)
+  print('got json result back from swift: ')
   print(result)
   settings = result['configuration']['settings']
-  iters = settings['iterations']
-  timings_ms = np.array(result['timings'])
-  timings_s = timings_ms / 1000
+  wall_time, metrics = extract_metrics(result, variety)
   return {
       'iters': settings['iterations'],
-      'wall_time': np.percentile(timings_s, 50),
+      'wall_time': wall_time,
       'extras': extract_extras(settings),
-      'metrics': extract_metrics(timings_ms, settings['batchSize']),
+      'metrics': metrics
   }
 
 
@@ -94,15 +136,15 @@ def new_swift_benchmark(name):
 
 def discover_swift_benchmarks():
   """Automatically discover and register swift benchmarks.
-  
+
   Invokes swift benchmark cli to enumarate all available benchmarks
   and add them as new top-level types in the current module.
   """
 
   g = globals()
-  defaults = subp.check_output(['swift', 'run', '-c', 'release', 
-                                'Benchmarks', 'list-defaults', '--json'], 
-                               cwd=cwd)
+  defaults = subp.check_output([
+      'swift', 'run', '-c', 'release', 'Benchmarks', 'list-defaults', '--json'
+  ], cwd=cwd)
   for line in defaults.split(b'\n'):
     if len(line) > 0:
       name = json.loads(line)['name']

--- a/Benchmarks/__init__.py
+++ b/Benchmarks/__init__.py
@@ -80,7 +80,7 @@ def extract_metrics(result, variety):
   timings = result['timings']
   example_count = result['exampleCount']
 
-  # 50 percentile of a single iteration running time in seconds.
+  # 50th percentile of a single iteration's running time in seconds.
   timings_s = np.array(timings) / 1000
   wall_time = np.percentile(timings_s, 50)
 

--- a/Benchmarks/__init__.py
+++ b/Benchmarks/__init__.py
@@ -71,7 +71,7 @@ def extract_extras(settings):
 
 
 def extract_metrics(result, variety):
-  """Extract perfzero metrics based on the measurmenets.
+  """Extract PerfZero metrics based on the measurements.
 
   Extracts metrics such as number of examples per second,
   based on the the original raw timings.


### PR DESCRIPTION
This commit adds support for two extra perfzero metrics:

* `exp_per_second` - number of examples per second, excluding warm-up.
* `avg_exp_per_second` - number of examples per second, including
warm-up.