### PR TITLE
Have datasets use a temporary directory for downloads by default

### DIFF
--- a/Datasets/MNIST/MNIST.swift
+++ b/Datasets/MNIST/MNIST.swift
@@ -31,7 +31,8 @@ public struct MNIST: ImageClassificationDataset {
 
     public init(
         flattening: Bool = false, normalizing: Bool = false,
-        localStorageDirectory: URL = DatasetUtilities.currentWorkingDirectoryURL
+        localStorageDirectory: URL = FileManager.default.temporaryDirectory.appendingPathComponent(
+            "MNIST")
     ) {
         self.trainingDataset = Dataset<LabeledExample>(
             elements: fetchDataset(

--- a/Datasets/MNIST/MNIST.swift
+++ b/Datasets/MNIST/MNIST.swift
@@ -58,8 +58,19 @@ fileprivate func fetchDataset(
     flattening: Bool,
     normalizing: Bool
 ) -> LabeledExample {
-    guard let remoteRoot:URL = URL(string: "http://yann.lecun.com/exdb/mnist") else {
-        fatalError("Failed to create MNST root url: http://yann.lecun.com/exdb/mnist")
+    guard let remoteRoot = URL(string: "http://yann.lecun.com/exdb/mnist") else {
+        fatalError("Failed to create MNIST root url: http://yann.lecun.com/exdb/mnist")
+    }
+
+    if !FileManager.default.fileExists(atPath: localStorageDirectory.path) {
+        do {
+            try FileManager.default.createDirectory(
+                at: localStorageDirectory, withIntermediateDirectories: false)
+        } catch {
+            fatalError(
+                "Failed to create storage directory: \(localStorageDirectory.path), error: \(error)"
+            )
+        }
     }
 
     let imagesData = DatasetUtilities.fetchResource(
@@ -78,7 +89,8 @@ fileprivate func fetchDataset(
     let (imageWidth, imageHeight) = (28, 28)
 
     if flattening {
-        var flattenedImages = Tensor(shape: [rowCount, imageHeight * imageWidth], scalars: images)
+        var flattenedImages =
+            Tensor(shape: [rowCount, imageHeight * imageWidth], scalars: images)
             / 255.0
         if normalizing {
             flattenedImages = flattenedImages * 2.0 - 1.0

--- a/Examples/LeNet-MNIST/main.swift
+++ b/Examples/LeNet-MNIST/main.swift
@@ -12,13 +12,15 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import TensorFlow
 import Datasets
+import Foundation
+import TensorFlow
 
 let epochCount = 12
 let batchSize = 128
 
-let dataset = MNIST()
+let downloadLocation = FileManager.default.temporaryDirectory.appendingPathComponent("MNIST")
+let dataset = MNIST(localStorageDirectory: downloadLocation)
 // The LeNet-5 model, equivalent to `LeNet` in `ImageClassificationModels`.
 var classifier = Sequential {
     Conv2D<Float>(filterShape: (5, 5, 1, 6), padding: .same, activation: relu)

--- a/Examples/LeNet-MNIST/main.swift
+++ b/Examples/LeNet-MNIST/main.swift
@@ -19,8 +19,7 @@ import TensorFlow
 let epochCount = 12
 let batchSize = 128
 
-let downloadLocation = FileManager.default.temporaryDirectory.appendingPathComponent("MNIST")
-let dataset = MNIST(localStorageDirectory: downloadLocation)
+let dataset = MNIST()
 // The LeNet-5 model, equivalent to `LeNet` in `ImageClassificationModels`.
 var classifier = Sequential {
     Conv2D<Float>(filterShape: (5, 5, 1, 6), padding: .same, activation: relu)

--- a/Examples/LeNet-MNIST/main.swift
+++ b/Examples/LeNet-MNIST/main.swift
@@ -12,9 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import Datasets
-import Foundation
 import TensorFlow
+import Datasets
 
 let epochCount = 12
 let batchSize = 128

--- a/Examples/ResNet-CIFAR10/main.swift
+++ b/Examples/ResNet-CIFAR10/main.swift
@@ -16,7 +16,7 @@ import Datasets
 import ImageClassificationModels
 import TensorFlow
 
-let batchSize = 100
+let batchSize = 10
 
 let dataset = CIFAR10()
 let testBatches = dataset.testDataset.batched(batchSize)


### PR DESCRIPTION
At present, the MNIST and CIFAR10 datasets download their binary files into the current working directory when used in example applications and tests. This can place these binary files in undesirable locations and fail in certain cases.

This pull request changes the default behavior for the MNIST and CIFAR10 datasets to instead download their binary files to `[system temporary directory]/MNIST` and `[system temporary directory]/CIFAR10`. If such a directory doesn't exist, it is created. Additionally, both datasets now have the capability of saving their binary files into a custom user-defined directory (previously, only the MNIST dataset supported this).

Also, the batch size on the ResNet training example was reduced in order to avoid memory exhaustion on smaller GPUs.