### PR TITLE
Use Tensor categorical initializer in Transformer/main.swift

### DIFF
--- a/Transformer/main.swift
+++ b/Transformer/main.swift
@@ -53,7 +53,7 @@ for _ in 0..<100 {
     let lastLogit = logits.slice(
         lowerBounds: [0, timeSteps - 1, 0],
         upperBounds: [batchSize, timeSteps, vocabSize]) / temperature
-    tokens = _Raw.multinomial(logits: lastLogit.squeezingShape(at: 1), numSamples: Tensor<Int32>(1))
+    tokens = Tensor(randomCategorialLogits: lastLogit.squeezingShape(at: 1), sampleCount: 1)
     print(encoder.decode(tokens[0].makeNumpyArray()), terminator: "")
 }
 print()


### PR DESCRIPTION
This PR switches off _Raw from Transformer/main.swift by using Tensor categorical initializer.

More about removing _Raw: #225

Able to run the model and got reasonable output after the change.