### PR TITLE
Remove init as a requirement in ImageClassificationDataset

### DIFF
--- a/Datasets/ImageClassificationDataset.swift
+++ b/Datasets/ImageClassificationDataset.swift
@@ -15,7 +15,6 @@
 import TensorFlow
 
 public protocol ImageClassificationDataset {
-    init()
     var trainingDataset: Dataset<LabeledExample> { get }
     var testDataset: Dataset<LabeledExample> { get }
     var trainingExampleCount: Int { get }


### PR DESCRIPTION
Every type that conforms to this protocol will automatically have an initializer requirement set by Swift (`class`/`struct`).

Having it as a requirement prevents users from using the automatically generated struct initializers in Swift.