### PR TITLE
Use local archive for CIFAR10Tests

### DIFF
--- a/Datasets/CIFAR10/CIFAR10.swift
+++ b/Datasets/CIFAR10/CIFAR10.swift
@@ -62,7 +62,7 @@ func downloadCIFAR10IfNotPresent(to directory: URL) {
 
     guard !directoryExists else { return }
 
-    printError("Downloading CIFAR dataset...")
+    printError("Preparing CIFAR dataset...")
     let archivePath = directory.appendingPathComponent("cifar-10-binary.tar.gz").path
     let archiveExists = FileManager.default.fileExists(atPath: archivePath)
     if !archiveExists {
@@ -76,9 +76,10 @@ func downloadCIFAR10IfNotPresent(to directory: URL) {
             printError("Could not download CIFAR dataset, error: \(error)")
             exit(-1)
         }
+        print("Archive downloaded, processing...")
+    } else {
+        print("Archive exists, processing...")
     }
-
-    printError("Archive downloaded, processing...")
 
     #if os(macOS)
         let tarLocation = "/usr/bin/tar"

--- a/Tests/DatasetsTests/CIFAR10/CIFAR10Tests.swift
+++ b/Tests/DatasetsTests/CIFAR10/CIFAR10Tests.swift
@@ -3,6 +3,25 @@ import XCTest
 import Datasets
 
 final class CIFAR10Tests: XCTestCase {
+    override class func setUp() {
+        super.setUp()
+
+        // prepare data
+        let from = FileManager.default.currentDirectoryPath + "/Tests/DatasetsTests/CIFAR10/cifar-10-binary.tar.gz"
+        let toDir = FileManager.default.temporaryDirectory.path + "/CIFAR10"
+        do {
+            if !FileManager.default.fileExists(atPath: toDir) {
+                try FileManager.default.createDirectory(atPath: toDir, withIntermediateDirectories: false)
+            }
+
+            try FileManager.default.copyItem(atPath: from, toPath: toDir + "/cifar-10-binary.tar.gz")
+        } catch {
+            print("Could not copy over CIFAR archive, error: \(error)")
+            exit(-1)
+        }
+        print("CIFAR archive copied to \(toDir)")
+    }
+
     func testCreateCIFAR10() {
         let dataset = CIFAR10()
 
@@ -13,6 +32,22 @@ final class CIFAR10Tests: XCTestCase {
             totalCount += 1
         }
         XCTAssertEqual(totalCount, 50000)
+    }
+
+    override class func tearDown() {
+        super.tearDown()
+
+        // clean up archive
+        let archivePath = FileManager.default.temporaryDirectory.path + "/CIFAR10/cifar-10-binary.tar.gz"
+        do {
+            if FileManager.default.fileExists(atPath: archivePath) {
+                try FileManager.default.removeItem(atPath: archivePath)
+            }
+        } catch {
+            print("Could not remove archive, error: \(error)")
+            exit(-1)
+        }
+        print("CIFAR archive \(archivePath) cleaned")
     }
 }
 

--- a/Tests/DatasetsTests/CIFAR10/cifar-10-binary.tar.gz
+++ b/Tests/DatasetsTests/CIFAR10/cifar-10-binary.tar.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c4a38c50a1bc5f3a1c5537f2155ab9d68f9f25eb1ed8d9ddda3db29a59bca1dd
+size 170052171


### PR DESCRIPTION
This PR majorly fixes CIFAR10Tests internally due to unable to download archive from internet.
We also see GitHub tests failures a few times because the archive file was corrupted due to unstable download.

The fix is to include the archive in the repo under test folder.

I think it's doable for following reasons:
1. the archive is 162M and can be managed with Git LFS
2. CIFAR10.swift assumes the archive file to be in 5 chunks, so we can't say only pick 2 or 3 chunks in test, I don't think we can shrink individual chunk either.
3. The complete dataset can be used for testing training or inferencing in future.
