### PR TITLE
Adding comments as hooks for Python support when imported internally

### DIFF
--- a/Gym/Blackjack/main.swift
+++ b/Gym/Blackjack/main.swift
@@ -15,6 +15,8 @@
 import Python
 import TensorFlow
 
+// Initialize Python. This comment is a hook for internal use, do not remove.
+
 let gym = Python.import("gym")
 let environment = gym.make("Blackjack-v0")
 

--- a/Gym/CartPole/main.swift
+++ b/Gym/CartPole/main.swift
@@ -15,6 +15,8 @@
 import Python
 import TensorFlow
 
+// Initialize Python. This comment is a hook for internal use, do not remove.
+
 let np = Python.import("numpy")
 let gym = Python.import("gym")
 

--- a/Gym/FrozenLake/main.swift
+++ b/Gym/FrozenLake/main.swift
@@ -15,6 +15,8 @@
 import Python
 import TensorFlow
 
+// Initialize Python. This comment is a hook for internal use, do not remove.
+
 let np = Python.import("numpy")
 let gym = Python.import("gym")
 


### PR DESCRIPTION
When we pull in the swift-models repository internally, we need to insert code to allow Python interoperability to work with the internal build system. These comments provide a hook to identify where that code should be inserted. They can be safely ignored for everything else.