### PR TITLE
 Enable user inputting source url while creating CIFAR10

### DIFF
--- a/Datasets/CIFAR10/CIFAR10.swift
+++ b/Datasets/CIFAR10/CIFAR10.swift
@@ -32,18 +32,16 @@ public struct CIFAR10: ImageClassificationDataset {
     public let testExampleCount = 10000
 
     public init() {
-        self.init(downloadResourceFrom: "https://www.cs.toronto.edu/~kriz/cifar-10-binary.tar.gz")
+        self.init(
+            remoteBinaryArchiveLocation: URL(
+                string: "https://www.cs.toronto.edu/~kriz/cifar-10-binary.tar.gz")!)
     }
 
-    public init(downloadResourceFrom: String) {
-        if let resourceUrl = URL(string:downloadResourceFrom) {
-            self.init(
-                remoteBinaryArchiveLocation: resourceUrl,
-                localStorageDirectory: FileManager.default.temporaryDirectory.appendingPathComponent("CIFAR10"))
-        } else {
-            printError("Invalid path, please specify another one")
-            exit(-1)
-        }
+    public init(remoteBinaryArchiveLocation: URL) {
+        self.init(
+            remoteBinaryArchiveLocation: remoteBinaryArchiveLocation,
+            localStorageDirectory: FileManager.default.temporaryDirectory.appendingPathComponent(
+                "CIFAR10"))
     }
 
     public init(remoteBinaryArchiveLocation: URL, localStorageDirectory: URL) {
@@ -72,7 +70,7 @@ func downloadCIFAR10IfNotPresent(from location: URL, to directory: URL) {
     let contentsOfDir = try? FileManager.default.contentsOfDirectory(atPath: downloadPath)
     let directoryEmpty = (contentsOfDir == nil) || (contentsOfDir!.isEmpty)
 
-    guard (!directoryExists || directoryEmpty) else { return }
+    guard !directoryExists || directoryEmpty else { return }
 
     printError("Preparing CIFAR dataset...")
     let archivePath = directory.appendingPathComponent("cifar-10-binary.tar.gz").path

--- a/Datasets/CIFAR10/CIFAR10.swift
+++ b/Datasets/CIFAR10/CIFAR10.swift
@@ -86,7 +86,7 @@ func downloadCIFAR10IfNotPresent(from location: URL, to directory: URL) {
             printError("Could not download CIFAR dataset, error: \(error)")
             exit(-1)
         }
-        print("Archive downloaded, processing...")
+        printError("Archive downloaded, processing...")
     } else {
         printError("Archive exists, processing...")
     }

--- a/Tests/DatasetsTests/CIFAR10/CIFAR10Tests.swift
+++ b/Tests/DatasetsTests/CIFAR10/CIFAR10Tests.swift
@@ -1,20 +1,24 @@
+import Datasets
 import Foundation
 import TensorFlow
 import XCTest
-import Datasets
 
 final class CIFAR10Tests: XCTestCase {
     override func setUp() {
         super.setUp()
-        // clean up dataset files in the first place
-        let path = FileManager.default.temporaryDirectory.appendingPathComponent("CIFAR10/cifar-10-batches-bin").path
+        // Force downloading of the dataset during tests by removing any pre-existing local files.
+        let path = FileManager.default.temporaryDirectory.appendingPathComponent(
+            "CIFAR10/cifar-10-batches-bin").path
         if FileManager.default.fileExists(atPath: path) {
             try! FileManager.default.removeItem(atPath: path)
         }
     }
 
     func testCreateCIFAR10() {
-        let dataset = CIFAR10(downloadResourceFrom: "https://storage.googleapis.com/s4tf-hosted-binaries/datasets/CIFAR10/cifar-10-binary.tar.gz")
+        let dataset = CIFAR10(
+            downloadResourceFrom:
+                "https://storage.googleapis.com/s4tf-hosted-binaries/datasets/CIFAR10/cifar-10-binary.tar.gz"
+        )
         verify(dataset)
     }
 
@@ -31,7 +35,6 @@ final class CIFAR10Tests: XCTestCase {
 
 extension CIFAR10Tests {
     static var allTests = [
-        ("testCreateCIFAR10", testCreateCIFAR10)
+        ("testCreateCIFAR10", testCreateCIFAR10),
     ]
 }
-

--- a/Tests/DatasetsTests/CIFAR10/CIFAR10Tests.swift
+++ b/Tests/DatasetsTests/CIFAR10/CIFAR10Tests.swift
@@ -1,11 +1,29 @@
+import Foundation
 import TensorFlow
 import XCTest
 import Datasets
 
 final class CIFAR10Tests: XCTestCase {
+    override func setUp() {
+        super.setUp()
+        // clean up dataset files in the first place
+        let path = FileManager.default.temporaryDirectory.appendingPathComponent("CIFAR10/cifar-10-batches-bin").path
+        if FileManager.default.fileExists(atPath: path) {
+            try! FileManager.default.removeItem(atPath: path)
+        }
+    }
+
     func testCreateCIFAR10() {
         let dataset = CIFAR10()
+        verify(dataset)
+    }
 
+    func testCreateCIFAR10FromS4TFHostedBinaries() {
+        let dataset = CIFAR10(downloadResourceFrom: "https://storage.googleapis.com/s4tf-hosted-binaries/datasets/CIFAR10/cifar-10-binary.tar.gz")
+        verify(dataset)
+    }
+
+    func verify(_ dataset: CIFAR10) {
         var totalCount = 0
         for example in dataset.trainingDataset {
             XCTAssertTrue((0..<10).contains(example.label.scalar!))
@@ -19,6 +37,7 @@ final class CIFAR10Tests: XCTestCase {
 extension CIFAR10Tests {
     static var allTests = [
         ("testCreateCIFAR10", testCreateCIFAR10),
+        ("testCreateCIFAR10FromS4TFHostedBinaries", testCreateCIFAR10FromS4TFHostedBinaries)
     ]
 }
 

--- a/Tests/DatasetsTests/CIFAR10/CIFAR10Tests.swift
+++ b/Tests/DatasetsTests/CIFAR10/CIFAR10Tests.swift
@@ -16,8 +16,11 @@ final class CIFAR10Tests: XCTestCase {
 
     func testCreateCIFAR10() {
         let dataset = CIFAR10(
-            downloadResourceFrom:
-                "https://storage.googleapis.com/s4tf-hosted-binaries/datasets/CIFAR10/cifar-10-binary.tar.gz"
+            remoteBinaryArchiveLocation:
+                URL(
+                    string:
+                        "https://storage.googleapis.com/s4tf-hosted-binaries/datasets/CIFAR10/cifar-10-binary.tar.gz"
+                )!
         )
         verify(dataset)
     }

--- a/Tests/DatasetsTests/CIFAR10/CIFAR10Tests.swift
+++ b/Tests/DatasetsTests/CIFAR10/CIFAR10Tests.swift
@@ -14,11 +14,6 @@ final class CIFAR10Tests: XCTestCase {
     }
 
     func testCreateCIFAR10() {
-        let dataset = CIFAR10()
-        verify(dataset)
-    }
-
-    func testCreateCIFAR10FromS4TFHostedBinaries() {
         let dataset = CIFAR10(downloadResourceFrom: "https://storage.googleapis.com/s4tf-hosted-binaries/datasets/CIFAR10/cifar-10-binary.tar.gz")
         verify(dataset)
     }
@@ -36,8 +31,7 @@ final class CIFAR10Tests: XCTestCase {
 
 extension CIFAR10Tests {
     static var allTests = [
-        ("testCreateCIFAR10", testCreateCIFAR10),
-        ("testCreateCIFAR10FromS4TFHostedBinaries", testCreateCIFAR10FromS4TFHostedBinaries)
+        ("testCreateCIFAR10", testCreateCIFAR10)
     ]
 }
 


### PR DESCRIPTION
This will provide flexibility to download dataset files from S4TF hosted binaries or any where else that the user can specify.