### PR TITLE
Restructuring dataset downloading code

### DIFF
--- a/Datasets/DatasetUtilities.swift
+++ b/Datasets/DatasetUtilities.swift
@@ -19,19 +19,21 @@ import ModelSupport
     import FoundationNetworking
 #endif
 
-public struct DatasetUtilities {
+public enum DatasetUtilities {
     public static let currentWorkingDirectoryURL = URL(
         fileURLWithPath: FileManager.default.currentDirectoryPath)
 
-    public static func fetchResource(
+    public static func downloadResource(
         filename: String,
+        fileExtension: String,
         remoteRoot: URL,
         localStorageDirectory: URL = currentWorkingDirectoryURL
-    ) -> Data {
+    ) -> URL {
         printError("Loading resource: \(filename)")
 
         let resource = ResourceDefinition(
             filename: filename,
+            fileExtension: fileExtension,
             remoteRoot: remoteRoot,
             localStorageDirectory: localStorageDirectory)
 
@@ -44,10 +46,21 @@ public struct DatasetUtilities {
             fetchFromRemoteAndSave(resource)
         }
 
+        return localURL
+    }
+
+    public static func fetchResource(
+        filename: String,
+        fileExtension: String,
+        remoteRoot: URL,
+        localStorageDirectory: URL = currentWorkingDirectoryURL
+    ) -> Data {
+        let localURL = DatasetUtilities.downloadResource(
+            filename: filename, fileExtension: fileExtension, remoteRoot: remoteRoot,
+            localStorageDirectory: localStorageDirectory)
+
         do {
-            printError("Loading local data at: \(localURL.path)")
             let data = try Data(contentsOf: localURL)
-            printError("Succesfully loaded resource: \(filename)")
             return data
         } catch {
             fatalError("Failed to contents of resource: \(localURL)")
@@ -56,6 +69,7 @@ public struct DatasetUtilities {
 
     struct ResourceDefinition {
         let filename: String
+        let fileExtension: String
         let remoteRoot: URL
         let localStorageDirectory: URL
 
@@ -64,23 +78,21 @@ public struct DatasetUtilities {
         }
 
         var remoteURL: URL {
-            remoteRoot.appendingPathComponent(filename).appendingPathExtension("gz")
+            remoteRoot.appendingPathComponent(filename).appendingPathExtension(fileExtension)
         }
 
         var archiveURL: URL {
-            localURL.appendingPathExtension("gz")
+            localURL.appendingPathExtension(fileExtension)
         }
     }
 
     static func fetchFromRemoteAndSave(_ resource: ResourceDefinition) {
         let remoteLocation = resource.remoteURL
-        let archiveLocation = resource.archiveURL
+        let archiveLocation = resource.localStorageDirectory
 
         do {
             printError("Fetching URL: \(remoteLocation)...")
-            let archiveData = try Data(contentsOf: remoteLocation)
-            printError("Writing fetched archive to: \(archiveLocation.path)")
-            try archiveData.write(to: archiveLocation)
+            try download(from: remoteLocation, to: archiveLocation)
         } catch {
             fatalError("Failed to fetch and save resource with error: \(error)")
         }
@@ -95,19 +107,44 @@ public struct DatasetUtilities {
         let archivePath = resource.archiveURL.path
 
         #if os(macOS)
-            let gunzipLocation = "/usr/bin/gunzip"
+            let binaryLocation = "/usr/bin/"
         #else
-            let gunzipLocation = "/bin/gunzip"
+            let binaryLocation = "/bin/"
         #endif
 
+        let toolName: String
+        let arguments: [String]
+        switch resource.fileExtension {
+        case "gz":
+            toolName = "gunzip"
+            arguments = [archivePath]
+        case "tar.gz":
+            toolName = "tar"
+            arguments = ["xzf", archivePath, "-C", resource.localStorageDirectory.path]
+        default:
+            printError("Unable to find archiver for extension \(resource.fileExtension).")
+            exit(-1)
+        }
+        let toolLocation = "\(binaryLocation)\(toolName)"
+
         let task = Process()
-        task.executableURL = URL(fileURLWithPath: gunzipLocation)
-        task.arguments = [archivePath]
+        task.executableURL = URL(fileURLWithPath: toolLocation)
+        task.arguments = arguments
         do {
             try task.run()
             task.waitUntilExit()
         } catch {
-            fatalError("Failed to extract \(archivePath) with error: \(error)")
+            printError("Failed to extract \(archivePath) with error: \(error)")
+            exit(-1)
+        }
+
+        if FileManager.default.fileExists(atPath: archivePath) {
+            do {
+                try FileManager.default.removeItem(atPath: archivePath)
+            } catch {
+                printError("Could not remove archive, error: \(error)")
+                exit(-1)
+            }
         }
     }
 }

--- a/Datasets/DatasetUtilities.swift
+++ b/Datasets/DatasetUtilities.swift
@@ -118,7 +118,7 @@ public enum DatasetUtilities {
         case "gz":
             toolName = "gunzip"
             arguments = [archivePath]
-        case "tar.gz":
+        case "tar.gz", "tgz":
             toolName = "tar"
             arguments = ["xzf", archivePath, "-C", resource.localStorageDirectory.path]
         default:

--- a/Datasets/Imagenette/Imagenette.swift
+++ b/Datasets/Imagenette/Imagenette.swift
@@ -21,10 +21,6 @@ import Foundation
 import ModelSupport
 import TensorFlow
 
-#if canImport(FoundationNetworking)
-    import FoundationNetworking
-#endif
-
 public struct Imagenette: ImageClassificationDataset {
     public let trainingDataset: Dataset<LabeledExample>
     public let testDataset: Dataset<LabeledExample>

--- a/Datasets/MNIST/MNIST.swift
+++ b/Datasets/MNIST/MNIST.swift
@@ -64,23 +64,14 @@ fileprivate func fetchDataset(
         fatalError("Failed to create MNIST root url: http://yann.lecun.com/exdb/mnist")
     }
 
-    if !FileManager.default.fileExists(atPath: localStorageDirectory.path) {
-        do {
-            try FileManager.default.createDirectory(
-                at: localStorageDirectory, withIntermediateDirectories: false)
-        } catch {
-            fatalError(
-                "Failed to create storage directory: \(localStorageDirectory.path), error: \(error)"
-            )
-        }
-    }
-
     let imagesData = DatasetUtilities.fetchResource(
         filename: imagesFilename,
+        fileExtension: "gz",
         remoteRoot: remoteRoot,
         localStorageDirectory: localStorageDirectory)
     let labelsData = DatasetUtilities.fetchResource(
         filename: labelsFilename,
+        fileExtension: "gz",
         remoteRoot: remoteRoot,
         localStorageDirectory: localStorageDirectory)
 

--- a/Support/FileManagement.swift
+++ b/Support/FileManagement.swift
@@ -14,10 +14,24 @@
 
 import Foundation
 
+#if canImport(FoundationNetworking)
+    import FoundationNetworking
+#endif
+
 public func createDirectoryIfMissing(at path: String) throws {
     guard !FileManager.default.fileExists(atPath: path) else { return }
     try FileManager.default.createDirectory(
         atPath: path,
-        withIntermediateDirectories: false,
+        withIntermediateDirectories: true,
         attributes: nil)
+}
+
+public func download(from source: URL, to destinationDirectory: URL) throws {
+    try createDirectoryIfMissing(at: destinationDirectory.path)
+
+    let fileName = source.lastPathComponent
+    let destinationFile = destinationDirectory.appendingPathComponent(fileName).path
+
+    let downloadedFile = try Data(contentsOf: source)
+    try downloadedFile.write(to: URL(fileURLWithPath: destinationFile))
 }


### PR DESCRIPTION
This consolidates the downloading code in the MNIST and CIFAR-10 datasets so that they use the same core networking and unarchiving code. It also pulls out the downloading function as a free function for use outside of just the datasets.