### PR TITLE
Restructuring the ResNet model to merge large and small variants, choose v1 vs. v1.5

### DIFF
--- a/Examples/ResNet-CIFAR10/main.swift
+++ b/Examples/ResNet-CIFAR10/main.swift
@@ -22,7 +22,7 @@ let dataset = CIFAR10()
 let testBatches = dataset.testDataset.batched(batchSize)
 
 // Use the network sized for CIFAR-10
-var model = ResNet(classCount: 10, depth: .resNet50, imageSize: .cifar)
+var model = ResNet(classCount: 10, depth: .resNet50, downsamplingInFirstStage: true)
 
 // the classic ImageNet optimizer setting diverges on CIFAR-10
 // let optimizer = SGD(for: model, learningRate: 0.1, momentum: 0.9)

--- a/Tests/ImageClassificationTests/Inference.swift
+++ b/Tests/ImageClassificationTests/Inference.swift
@@ -85,6 +85,11 @@ final class ImageClassificationInferenceTests: XCTestCase {
         let resNet34CIFARResult = resNet34CIFAR(inputCIFAR)
         XCTAssertEqual(resNet34CIFARResult.shape, [1, 10])
 
+        let resNet50CIFARV1 = ResNet(
+            classCount: 10, depth: .resNet50, imageSize: .cifar, useLaterStride: false)
+        let resNet50CIFARV1Result = resNet50CIFARV1(inputCIFAR)
+        XCTAssertEqual(resNet50CIFARV1Result.shape, [1, 10])
+
         let resNet50CIFAR = ResNet(classCount: 10, depth: .resNet50, imageSize: .cifar)
         let resNet50CIFARResult = resNet50CIFAR(inputCIFAR)
         XCTAssertEqual(resNet50CIFARResult.shape, [1, 10])
@@ -107,6 +112,11 @@ final class ImageClassificationInferenceTests: XCTestCase {
         let resNet34ImageNet = ResNet(classCount: 1000, depth: .resNet34, imageSize: .imagenet)
         let resNet34ImageNetResult = resNet34ImageNet(inputImageNet)
         XCTAssertEqual(resNet34ImageNetResult.shape, [1, 1000])
+
+        let resNet50ImageNetV1 = ResNet(
+            classCount: 1000, depth: .resNet50, imageSize: .imagenet, useLaterStride: false)
+        let resNet50ImageNetV1Result = resNet50ImageNetV1(inputImageNet)
+        XCTAssertEqual(resNet50ImageNetV1Result.shape, [1, 1000])
 
         let resNet50ImageNet = ResNet(classCount: 1000, depth: .resNet50, imageSize: .imagenet)
         let resNet50ImageNetResult = resNet50ImageNet(inputImageNet)

--- a/Tests/ImageClassificationTests/Inference.swift
+++ b/Tests/ImageClassificationTests/Inference.swift
@@ -77,56 +77,57 @@ final class ImageClassificationInferenceTests: XCTestCase {
         let inputCIFAR = Tensor<Float>(
             randomNormal: [1, 32, 32, 3], mean: Tensor<Float>(0.5),
             standardDeviation: Tensor<Float>(0.1), seed: (0xffeffe, 0xfffe))
-        let resNet18CIFAR = ResNet(classCount: 10, depth: .resNet18, imageSize: .cifar)
+        let resNet18CIFAR = ResNet(classCount: 10, depth: .resNet18, downsamplingInFirstStage: true)
         let resNet18CIFARResult = resNet18CIFAR(inputCIFAR)
         XCTAssertEqual(resNet18CIFARResult.shape, [1, 10])
 
-        let resNet34CIFAR = ResNet(classCount: 10, depth: .resNet34, imageSize: .cifar)
+        let resNet34CIFAR = ResNet(classCount: 10, depth: .resNet34, downsamplingInFirstStage: true)
         let resNet34CIFARResult = resNet34CIFAR(inputCIFAR)
         XCTAssertEqual(resNet34CIFARResult.shape, [1, 10])
 
         let resNet50CIFARV1 = ResNet(
-            classCount: 10, depth: .resNet50, imageSize: .cifar, useLaterStride: false)
+            classCount: 10, depth: .resNet50, downsamplingInFirstStage: true, useLaterStride: false)
         let resNet50CIFARV1Result = resNet50CIFARV1(inputCIFAR)
         XCTAssertEqual(resNet50CIFARV1Result.shape, [1, 10])
 
-        let resNet50CIFAR = ResNet(classCount: 10, depth: .resNet50, imageSize: .cifar)
+        let resNet50CIFAR = ResNet(classCount: 10, depth: .resNet50, downsamplingInFirstStage: true)
         let resNet50CIFARResult = resNet50CIFAR(inputCIFAR)
         XCTAssertEqual(resNet50CIFARResult.shape, [1, 10])
 
-        let resNet101CIFAR = ResNet(classCount: 10, depth: .resNet101, imageSize: .cifar)
+        let resNet101CIFAR = ResNet(
+            classCount: 10, depth: .resNet101, downsamplingInFirstStage: true)
         let resNet101CIFARResult = resNet101CIFAR(inputCIFAR)
         XCTAssertEqual(resNet101CIFARResult.shape, [1, 10])
 
-        let resNet152CIFAR = ResNet(classCount: 10, depth: .resNet152, imageSize: .cifar)
+        let resNet152CIFAR = ResNet(
+            classCount: 10, depth: .resNet152, downsamplingInFirstStage: true)
         let resNet152CIFARResult = resNet152CIFAR(inputCIFAR)
         XCTAssertEqual(resNet152CIFARResult.shape, [1, 10])
 
         let inputImageNet = Tensor<Float>(
             randomNormal: [1, 224, 224, 3], mean: Tensor<Float>(0.5),
             standardDeviation: Tensor<Float>(0.1), seed: (0xffeffe, 0xfffe))
-        let resNet18ImageNet = ResNet(classCount: 1000, depth: .resNet18, imageSize: .imagenet)
+        let resNet18ImageNet = ResNet(classCount: 1000, depth: .resNet18)
         let resNet18ImageNetResult = resNet18ImageNet(inputImageNet)
         XCTAssertEqual(resNet18ImageNetResult.shape, [1, 1000])
 
-        let resNet34ImageNet = ResNet(classCount: 1000, depth: .resNet34, imageSize: .imagenet)
+        let resNet34ImageNet = ResNet(classCount: 1000, depth: .resNet34)
         let resNet34ImageNetResult = resNet34ImageNet(inputImageNet)
         XCTAssertEqual(resNet34ImageNetResult.shape, [1, 1000])
 
-        let resNet50ImageNetV1 = ResNet(
-            classCount: 1000, depth: .resNet50, imageSize: .imagenet, useLaterStride: false)
+        let resNet50ImageNetV1 = ResNet(classCount: 1000, depth: .resNet50, useLaterStride: false)
         let resNet50ImageNetV1Result = resNet50ImageNetV1(inputImageNet)
         XCTAssertEqual(resNet50ImageNetV1Result.shape, [1, 1000])
 
-        let resNet50ImageNet = ResNet(classCount: 1000, depth: .resNet50, imageSize: .imagenet)
+        let resNet50ImageNet = ResNet(classCount: 1000, depth: .resNet50)
         let resNet50ImageNetResult = resNet50ImageNet(inputImageNet)
         XCTAssertEqual(resNet50ImageNetResult.shape, [1, 1000])
 
-        let resNet101ImageNet = ResNet(classCount: 1000, depth: .resNet101, imageSize: .imagenet)
+        let resNet101ImageNet = ResNet(classCount: 1000, depth: .resNet101)
         let resNet101ImageNetResult = resNet101ImageNet(inputImageNet)
         XCTAssertEqual(resNet101ImageNetResult.shape, [1, 1000])
 
-        let resNet152ImageNet = ResNet(classCount: 1000, depth: .resNet152, imageSize: .imagenet)
+        let resNet152ImageNet = ResNet(classCount: 1000, depth: .resNet152)
         let resNet152ImageNetResult = resNet152ImageNet(inputImageNet)
         XCTAssertEqual(resNet152ImageNetResult.shape, [1, 1000])
     }

--- a/Tests/ImageClassificationTests/Inference.swift
+++ b/Tests/ImageClassificationTests/Inference.swift
@@ -77,11 +77,11 @@ final class ImageClassificationInferenceTests: XCTestCase {
         let inputCIFAR = Tensor<Float>(
             randomNormal: [1, 32, 32, 3], mean: Tensor<Float>(0.5),
             standardDeviation: Tensor<Float>(0.1), seed: (0xffeffe, 0xfffe))
-        let resNet18CIFAR = ResNetBasic(classCount: 10, depth: .resNet18, imageSize: .cifar)
+        let resNet18CIFAR = ResNet(classCount: 10, depth: .resNet18, imageSize: .cifar)
         let resNet18CIFARResult = resNet18CIFAR(inputCIFAR)
         XCTAssertEqual(resNet18CIFARResult.shape, [1, 10])
 
-        let resNet34CIFAR = ResNetBasic(classCount: 10, depth: .resNet34, imageSize: .cifar)
+        let resNet34CIFAR = ResNet(classCount: 10, depth: .resNet34, imageSize: .cifar)
         let resNet34CIFARResult = resNet34CIFAR(inputCIFAR)
         XCTAssertEqual(resNet34CIFARResult.shape, [1, 10])
 
@@ -100,11 +100,11 @@ final class ImageClassificationInferenceTests: XCTestCase {
         let inputImageNet = Tensor<Float>(
             randomNormal: [1, 224, 224, 3], mean: Tensor<Float>(0.5),
             standardDeviation: Tensor<Float>(0.1), seed: (0xffeffe, 0xfffe))
-        let resNet18ImageNet = ResNetBasic(classCount: 1000, depth: .resNet18, imageSize: .imagenet)
+        let resNet18ImageNet = ResNet(classCount: 1000, depth: .resNet18, imageSize: .imagenet)
         let resNet18ImageNetResult = resNet18ImageNet(inputImageNet)
         XCTAssertEqual(resNet18ImageNetResult.shape, [1, 1000])
 
-        let resNet34ImageNet = ResNetBasic(classCount: 1000, depth: .resNet34, imageSize: .imagenet)
+        let resNet34ImageNet = ResNet(classCount: 1000, depth: .resNet34, imageSize: .imagenet)
         let resNet34ImageNetResult = resNet34ImageNet(inputImageNet)
         XCTAssertEqual(resNet34ImageNetResult.shape, [1, 1000])
 


### PR DESCRIPTION
This is an alternative to PR #281, in an attempt to restructure the ResNet model to simplify its overall structure and unify the 18 and 34 layer network architectures with the 50+ layer ones. It significantly reduces the overall lines of code when compared to the original model, lets one network be used for all sizes, and adds the flexibility of choosing both v1 and v1.5 variants.

The [implementation of ResNet within the Flax library](https://github.com/google-research/flax/blob/prerelease/examples/imagenet/models.py) was the source for the basic implementation structure, but this expands upon that by adding the basic blocks for ResNet 18 and 34, as well as support for both ResNet v1 and v1.5 variants.

A workaround is currently used to handle the differences between blocks that require projection and those that don't (a dummy tiny convolution / batchnorm pair is allocated but never used in non-projection case). That will eventually be removed when differentiation support for optionals is added.