### PR TITLE
Update download link for MNIST

### DIFF
--- a/Datasets/MNIST/MNIST.swift
+++ b/Datasets/MNIST/MNIST.swift
@@ -60,8 +60,8 @@ fileprivate func fetchDataset(
     flattening: Bool,
     normalizing: Bool
 ) -> LabeledExample {
-    guard let remoteRoot = URL(string: "http://yann.lecun.com/exdb/mnist") else {
-        fatalError("Failed to create MNIST root url: http://yann.lecun.com/exdb/mnist")
+    guard let remoteRoot = URL(string: "https://storage.googleapis.com/cvdf-datasets/mnist") else {
+        fatalError("Failed to create MNIST root url: https://storage.googleapis.com/cvdf-datasets/mnist")
     }
 
     let imagesData = DatasetUtilities.fetchResource(


### PR DESCRIPTION
We should use the Google storage api link to load the MNIST dataset to avoid server overload. TFDS also uses this approach. (see [here](https://github.com/tensorflow/datasets/blob/master/tensorflow_datasets/image/mnist.py))

cc: @rickwierenga 