### PR TITLE
Minor tweaks to the Gym models to allow for easier import internally

### DIFF
--- a/Gym/Blackjack/main.swift
+++ b/Gym/Blackjack/main.swift
@@ -15,15 +15,15 @@
 import Python
 import TensorFlow
 
-// Initialize Python. This comment is a hook for internal use, do not remove.
-
-let gym = Python.import("gym")
-let environment = gym.make("Blackjack-v0")
-
 let iterationCount = 10000
 let learningPhase = iterationCount * 5 / 100
 
 typealias Strategy = Bool
+
+// Initialize Python. This comment is a hook for internal use, do not remove.
+
+let gym = Python.import("gym")
+let environment = gym.make("Blackjack-v0")
 
 class BlackjackState {
     var playerSum: Int = 0

--- a/Gym/CartPole/main.swift
+++ b/Gym/CartPole/main.swift
@@ -15,17 +15,6 @@
 import Python
 import TensorFlow
 
-// Initialize Python. This comment is a hook for internal use, do not remove.
-
-let np = Python.import("numpy")
-let gym = Python.import("gym")
-
-/// Model parameters and hyperparameters.
-let hiddenSize = 128
-let batchSize = 16
-/// Controls the amount of good/long episodes to retain for training.
-let percentile = 70
-
 // Force unwrapping with `!` does not provide source location when unwrapping `nil`, so we instead
 // make a utility function for debuggability.
 fileprivate extension Optional {
@@ -36,6 +25,17 @@ fileprivate extension Optional {
         return unwrapped
     }
 }
+
+// Initialize Python. This comment is a hook for internal use, do not remove.
+
+let np = Python.import("numpy")
+let gym = Python.import("gym")
+
+/// Model parameters and hyperparameters.
+let hiddenSize = 128
+let batchSize = 16
+/// Controls the amount of good/long episodes to retain for training.
+let percentile = 70
 
 /// A simple two layer dense net.
 struct Net: Layer {

--- a/Gym/FrozenLake/main.swift
+++ b/Gym/FrozenLake/main.swift
@@ -15,10 +15,16 @@
 import Python
 import TensorFlow
 
-// Initialize Python. This comment is a hook for internal use, do not remove.
-
-let np = Python.import("numpy")
-let gym = Python.import("gym")
+// Force unwrapping with `!` does not provide source location when unwrapping `nil`, so we instead
+// make a utility function for debuggability.
+fileprivate extension Optional {
+    func unwrapped(file: StaticString = #file, line: UInt = #line) -> Wrapped {
+        guard let unwrapped = self else {
+            fatalError("Value is nil", file: file, line: line)
+        }
+        return unwrapped
+    }
+}
 
 // Solves the FrozenLake RL problem via Q-learning. This model does not use a neural net, and
 // instead demonstrates Swift host-side numeric processing as well as Python integration.
@@ -30,16 +36,10 @@ let testEpisodeCount = 20
 typealias State = Int
 typealias Action = Int
 
-// Force unwrapping with `!` does not provide source location when unwrapping `nil`, so we instead
-// make a utility function for debuggability.
-fileprivate extension Optional {
-    func unwrapped(file: StaticString = #file, line: UInt = #line) -> Wrapped {
-        guard let unwrapped = self else {
-            fatalError("Value is nil", file: file, line: line)
-        }
-        return unwrapped
-    }
-}
+// Initialize Python. This comment is a hook for internal use, do not remove.
+
+let np = Python.import("numpy")
+let gym = Python.import("gym")
 
 // This struct is defined so that `StateAction` can be a dictionary key type. Swift tuples cannot
 // conform to `Hashable`.


### PR DESCRIPTION
This merely moves around some top-level constants and extensions in the Gym examples so that these examples can be cleanly imported internally. The function of the examples is preserved and functionality is not changed.

For context, we need to wrap the code below the `// Initialize Python` comments in a closure when importing internally at Google, and this simplifies the import process for us.