### PR TITLE
Fixed BERT.

### DIFF
--- a/Models/Text/Architecture.swift
+++ b/Models/Text/Architecture.swift
@@ -1,9 +1,0 @@
-// Adapted from: https://github.com/eaplatanios/nca/blob/master/Sources/NCA/Architecture.swift
-
-public struct ArchitectureInput {
-  public let text: TextBatch?
-
-  public init(text: TextBatch? = nil) {
-    self.text = text
-  }
-}

--- a/Models/Text/BERTClassifier.swift
+++ b/Models/Text/BERTClassifier.swift
@@ -20,6 +20,6 @@ public struct BERTClassifier: Module, Regularizable {
   /// Returns: logits with shape `[batchSize, classCount]`.
   @differentiable(wrt: self)
   public func callAsFunction(_ input: TextBatch) -> Tensor<Float> {
-    dense(bert(input)[0..., 0])
+    dense(bert(input)[0])
   }
 }

--- a/Models/Text/BERTClassifier.swift
+++ b/Models/Text/BERTClassifier.swift
@@ -20,6 +20,6 @@ public struct BERTClassifier: Module, Regularizable {
   /// Returns: logits with shape `[batchSize, classCount]`.
   @differentiable(wrt: self)
   public func callAsFunction(_ input: TextBatch) -> Tensor<Float> {
-    dense(bert(input)[0])
+    dense(bert(input)[0..., 0])
   }
 }

--- a/Models/Text/CoLA.swift
+++ b/Models/Text/CoLA.swift
@@ -37,7 +37,7 @@ public struct CoLA {
     return withLearningPhase(.training) {
       let (loss, gradient) = valueWithGradient(at: classifier) {
         sigmoidCrossEntropy(
-          logits: $0(input),
+          logits: $0(input).squeezingShape(at: -1),
           labels: labels,
           reduction: { $0.mean() })
       }

--- a/Models/Text/Evaluation.swift
+++ b/Models/Text/Evaluation.swift
@@ -23,6 +23,7 @@ public func matthewsCorrelationCoefficient(predictions: [Bool], groundTruth: [Bo
     }
   }
   // NOTE: Consider removing these debug print statements later.
+  print("Total predictions: \(predictions.count)")
   print("True positives: \(tp)")
   print("True negatives: \(tn)")
   print("False positives: \(fp)")

--- a/Models/Text/main.swift
+++ b/Models/Text/main.swift
@@ -11,8 +11,8 @@ var bertClassifier = BERTClassifier(bert: bert, classCount: 1)
 // second 11 to 20, etc.). We then keep processing examples in the input data pipeline until a 
 // bucket contains enough sequences to form a batch. The batch size specified in the task
 // constructor specifies the *total number of tokens in the batch* and not the total number of 
-// sequences. So, if the batch size is set to 128 * 32, the first bucket (i.e., lengths 1 to 10)
-// will need 128 * 32 / 10 = 409 examples to form a batch (every sentence in the bucket is padded
+// sequences. So, if the batch size is set to 1024, the first bucket (i.e., lengths 1 to 10)
+// will need 1024 / 10 = 102 examples to form a batch (every sentence in the bucket is padded
 // to the max length of the bucket). This kind of bucketing is common practice with NLP models and
 // it is done to improve memory usage and computational efficiency when dealing with sequences of
 // varied lengths. Note that this is not used in the original BERT implementation released by
@@ -21,17 +21,22 @@ var colaTask = try CoLA(
   for: bertClassifier,
   taskDirectoryURL: workspaceURL,
   maxSequenceLength: 128,
-  batchSize: 128 * 32)
+  batchSize: 1024)
 
+// var optimizer = WeightDecayedAdam(
+//   for: bertClassifier,
+//   learningRate: LinearlyDecayedParameter(
+//     baseParameter: LinearlyWarmedUpParameter(
+//       baseParameter: FixedParameter<Float>(2e-5),
+//       warmUpStepCount: 10,
+//       warmUpOffset: 0),
+//     slope: -5e-7, // The LR decays linearly to zero in 100 steps.
+//     startStep: 10),
+//   weightDecayRate: 0.01,
+//   maxGradientGlobalNorm: 1)
 var optimizer = WeightDecayedAdam(
   for: bertClassifier,
-  learningRate: LinearlyDecayedParameter(
-    baseParameter: LinearlyWarmedUpParameter(
-      baseParameter: FixedParameter<Float>(2e-5),
-      warmUpStepCount: 10,
-      warmUpOffset: 0),
-    slope: -5e-7, // The LR decays linearly to zero in 100 steps.
-    startStep: 10),
+  learningRate: FixedParameter<Float>(2e-5),
   weightDecayRate: 0.01,
   maxGradientGlobalNorm: 1)
 

--- a/Models/Text/main.swift
+++ b/Models/Text/main.swift
@@ -23,20 +23,15 @@ var colaTask = try CoLA(
   maxSequenceLength: 128,
   batchSize: 1024)
 
-// var optimizer = WeightDecayedAdam(
-//   for: bertClassifier,
-//   learningRate: LinearlyDecayedParameter(
-//     baseParameter: LinearlyWarmedUpParameter(
-//       baseParameter: FixedParameter<Float>(2e-5),
-//       warmUpStepCount: 10,
-//       warmUpOffset: 0),
-//     slope: -5e-7, // The LR decays linearly to zero in 100 steps.
-//     startStep: 10),
-//   weightDecayRate: 0.01,
-//   maxGradientGlobalNorm: 1)
 var optimizer = WeightDecayedAdam(
   for: bertClassifier,
-  learningRate: FixedParameter<Float>(2e-5),
+  learningRate: LinearlyDecayedParameter(
+    baseParameter: LinearlyWarmedUpParameter(
+      baseParameter: FixedParameter<Float>(2e-5),
+      warmUpStepCount: 10,
+      warmUpOffset: 0),
+    slope: -5e-7, // The LR decays linearly to zero in 100 steps.
+    startStep: 10),
   weightDecayRate: 0.01,
   maxGradientGlobalNorm: 1)
 

--- a/Models/Text/main.swift
+++ b/Models/Text/main.swift
@@ -4,15 +4,21 @@ import Foundation
 let bertPretrained = BERT.PreTrainedModel.bertBase(cased: false, multilingual: false)
 let workspaceURL = URL(fileURLWithPath: "/tmp/bert_models", isDirectory: true)
 let bert = try BERT.PreTrainedModel.load(bertPretrained)(from: workspaceURL)
-var bertClassifier = BERTClassifier(bert: bert, classCount: 2)
+var bertClassifier = BERTClassifier(bert: bert, classCount: 1)
 
-var colaTask = try CoLA(for: bertClassifier, taskDirectoryURL: workspaceURL, maxSequenceLength: 50, batchSize: 32)
+var colaTask = try CoLA(
+  for: bertClassifier,
+  taskDirectoryURL: workspaceURL,
+  maxSequenceLength: 512,
+  batchSize: 32)
 
-let lr = FixedParameter<Float>(2e-5)
-let pivotStepCount: UInt64 = 1000
-let lr2 = LinearlyWarmedUpParameter(baseParameter: lr, warmUpStepCount: pivotStepCount, warmUpOffset: 0)
-let lr3 =  LinearlyDecayedParameter(baseParameter: lr2, slope: 3, startStep: pivotStepCount)
-var optimizer = WeightDecayedAdam(for: bertClassifier, learningRate: lr3, maxGradientGlobalNorm: 1)
+var optimizer = WeightDecayedAdam(
+  for: bertClassifier,
+  learningRate: LinearlyDecayedParameter(
+    baseParameter: FixedParameter<Float>(2e-5),
+    slope: -2e-8, // The LR decays linearly to zero in 1000 steps.
+    startStep: 0),
+  maxGradientGlobalNorm: 1)
 
 print("Training BERT for the CoLA task!")
 let epochCount = 1000

--- a/Models/Text/main.swift
+++ b/Models/Text/main.swift
@@ -6,23 +6,38 @@ let workspaceURL = URL(fileURLWithPath: "/tmp/bert_models", isDirectory: true)
 let bert = try BERT.PreTrainedModel.load(bertPretrained)(from: workspaceURL)
 var bertClassifier = BERTClassifier(bert: bert, classCount: 1)
 
+// Regarding the batch size, note that the way batching is performed currently is that we bucket
+// input sequences based on their length (e.g., first bucket contains sequences of length 1 to 10,
+// second 11 to 20, etc.). We then keep processing examples in the input data pipeline until a 
+// bucket contains enough sequences to form a batch. The batch size specified in the task
+// constructor specifies the *total number of tokens in the batch* and not the total number of 
+// sequences. So, if the batch size is set to 128 * 32, the first bucket (i.e., lengths 1 to 10)
+// will need 128 * 32 / 10 = 409 examples to form a batch (every sentence in the bucket is padded
+// to the max length of the bucket). This kind of bucketing is common practice with NLP models and
+// it is done to improve memory usage and computational efficiency when dealing with sequences of
+// varied lengths. Note that this is not used in the original BERT implementation released by
+// Google and so the batch size setting here is expected to differ from that one.
 var colaTask = try CoLA(
   for: bertClassifier,
   taskDirectoryURL: workspaceURL,
-  maxSequenceLength: 512,
-  batchSize: 32)
+  maxSequenceLength: 128,
+  batchSize: 128 * 32)
 
 var optimizer = WeightDecayedAdam(
   for: bertClassifier,
   learningRate: LinearlyDecayedParameter(
-    baseParameter: FixedParameter<Float>(2e-5),
-    slope: -2e-8, // The LR decays linearly to zero in 1000 steps.
-    startStep: 0),
+    baseParameter: LinearlyWarmedUpParameter(
+      baseParameter: FixedParameter<Float>(2e-5),
+      warmUpStepCount: 10,
+      warmUpOffset: 0),
+    slope: -5e-7, // The LR decays linearly to zero in 100 steps.
+    startStep: 10),
+  weightDecayRate: 0.01,
   maxGradientGlobalNorm: 1)
 
 print("Training BERT for the CoLA task!")
 for step in 0... {
-  let loss = colaTask.update(architecture: &bertClassifier, using: &optimizer)
+  let loss = colaTask.update(classifier: &bertClassifier, using: &optimizer)
   print("[Step: \(step)]\tLoss: \(loss)")
   if step > 0 && step.isMultiple(of: 10) {
     print("Evaluate BERT for the CoLA task:")


### PR DESCRIPTION
There were a couple of issues that seem fixed now:
1. The sigmoid cross entropy loss was applied on logits of shape [B, 1] and labels of shape [B]. This forced a silent broadcast of logits to shape [B, B], which resulted in the loss not being informative for training.
2. The batch size was too small. I added a comment in the main script code explaining how batching works in my data pipelines.
3. This is a minor one but there is bug with how I was copying the prefetching iterator. This was a temporary solution but I just disabled prefetching for the dev and test sets so that the dev set is the same across runs.

This is not currently tuned but it's working. After ~20 steps MCC should be at about 0.28 and after ~200 steps it should be getting close to 0.50.

cc @dan-zheng 
