### PR TITLE
Executable for VGG-Imagewoof

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -12,6 +12,7 @@ let package = Package(
         .library(name: "ImageClassificationModels", targets: ["ImageClassificationModels"]),
         .library(name: "Datasets", targets: ["Datasets"]),
         .library(name: "ModelSupport", targets: ["ModelSupport"]),
+        .executable(name: "VGG-Imagewoof", targets: ["VGG-Imagewoof"]),
         .executable(name: "Custom-CIFAR10", targets: ["Custom-CIFAR10"]),
         .executable(name: "ResNet-CIFAR10", targets: ["ResNet-CIFAR10"]),
         .executable(name: "LeNet-MNIST", targets: ["LeNet-MNIST"]),
@@ -37,6 +38,9 @@ let package = Package(
         .target(name: "Gym-FrozenLake", path: "Gym/FrozenLake"),
         .target(name: "Gym-CartPole", path: "Gym/CartPole"),
         .target(name: "Gym-Blackjack", path: "Gym/Blackjack"),
+        .target(
+            name: "VGG-Imagewoof", dependencies: ["ImageClassificationModels", "Datasets"],
+            path: "Examples/VGG-Imagewoof"),
         .target(
             name: "Custom-CIFAR10", dependencies: ["Datasets"],
             path: "Examples/Custom-CIFAR10"),


### PR DESCRIPTION
While investigating example for VGG-Imagewoof I found that there is a line about how to execute it:

```sh
cd swift-models
swift run -c release VGG-Imagewoof
```

but actually no executable for that in `Package.swift`. So just a simple PR that adds it.