### PR TITLE
build: add a CMake based build for the tensorflow-swift-models

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,18 @@
+cmake_minimum_required(VERSION 3.16)
+project(Models
+  LANGUAGES Swift)
+
+list(APPEND CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/cmake/modules)
+
+set(CMAKE_Swift_MODULE_DIRECTORY ${CMAKE_BINARY_DIR}/swift)
+
+include(SwiftSupport)
+
+add_subdirectory(Support)
+add_subdirectory(Datasets)
+add_subdirectory(Models)
+add_subdirectory(MiniGo)
+add_subdirectory(GAN)
+add_subdirectory(DCGAN)
+add_subdirectory(FastStyleTransfer)
+add_subdirectory(Examples)

--- a/DCGAN/CMakeLists.txt
+++ b/DCGAN/CMakeLists.txt
@@ -1,0 +1,9 @@
+add_executable(DCGAN
+  main.swift)
+target_link_libraries(DCGAN PRIVATE
+  Datasets
+  ModelSupport)
+
+
+install(TARGETS DCGAN
+  DESTINATION bin)

--- a/Datasets/CMakeLists.txt
+++ b/Datasets/CMakeLists.txt
@@ -1,0 +1,23 @@
+add_library(Datasets
+  CIFAR10/CIFAR10.swift
+  DatasetUtilities.swift
+  ImageClassificationDataset.swift
+  Imagenette/Imagenette.swift
+  Imagenette/Imagewoof.swift
+  LabeledExample.swift
+  MNIST/MNIST.swift)
+target_link_libraries(Datasets PUBLIC
+  ModelSupport)
+set_target_properties(Datasets PROPERTIES
+  INTERFACE_INCLUDE_DIRECTORIES ${CMAKE_Swift_MODULE_DIRECTORY})
+
+
+install(TARGETS Datasets
+  ARCHIVE DESTINATION lib/swift/$<LOWER_CASE:${CMAKE_SYSTEM_NAME}>
+  LIBRARY DESTINATION lib/swift/$<LOWER_CASE:${CMAKE_SYSTEM_NAME}>
+  RUNTIME DESTINATION bin)
+get_swift_host_arch(swift_arch)
+install(FILES
+  $<TARGET_PROPERTY:Datasets,Swift_MODULE_DIRECTORY>/Datasets.swiftdoc
+  $<TARGET_PROPERTY:Datasets,Swift_MODULE_DIRECTORY>/Datasets.swiftmodule
+  DESTINATION lib/swift$<$<NOT:$<BOOL:${BUILD_SHARED_LIBS}>>:_static>/$<LOWER_CASE:${CMAKE_SYSTEM_NAME}>/${swift_arch})

--- a/Examples/CMakeLists.txt
+++ b/Examples/CMakeLists.txt
@@ -1,0 +1,4 @@
+add_subdirectory(Custom-CIFAR10)
+add_subdirectory(ResNet-CIFAR10)
+add_subdirectory(LeNet-MNIST)
+add_subdirectory(MobileNet-Imagenette)

--- a/Examples/Custom-CIFAR10/CMakeLists.txt
+++ b/Examples/Custom-CIFAR10/CMakeLists.txt
@@ -1,0 +1,10 @@
+add_executable(Custom-CIFAR10
+  Models.swift
+  main.swift)
+target_link_libraries(Custom-CIFAR10 PRIVATE
+  ImageClassificationModels
+  Datasets)
+
+
+install(TARGETS Custom-CIFAR10
+  DESTINATION bin)

--- a/Examples/LeNet-MNIST/CMakeLists.txt
+++ b/Examples/LeNet-MNIST/CMakeLists.txt
@@ -1,0 +1,9 @@
+add_executable(LeNet-MNIST
+  main.swift)
+target_link_libraries(LeNet-MNIST PRIVATE
+  ImageClassificationModels
+  Datasets)
+
+
+install(TARGETS LeNet-MNIST
+  DESTINATION bin)

--- a/Examples/MobileNet-Imagenette/CMakeLists.txt
+++ b/Examples/MobileNet-Imagenette/CMakeLists.txt
@@ -1,0 +1,9 @@
+add_executable(MobileNet-Imagenette
+  main.swift)
+target_link_libraries(MobileNet-Imagenette PRIVATE
+  ImageClassificationModels
+  Datasets)
+
+
+install(TARGETS MobileNet-Imagenette
+  DESTINATION bin)

--- a/Examples/ResNet-CIFAR10/CMakeLists.txt
+++ b/Examples/ResNet-CIFAR10/CMakeLists.txt
@@ -1,0 +1,9 @@
+add_executable(ResNet-CIFAR10
+  main.swift)
+target_link_libraries(ResNet-CIFAR10 PRIVATE
+  ImageClassificationModels
+  Datasets)
+
+
+install(TARGETS ResNet-CIFAR10
+  DESTINATION bin)

--- a/FastStyleTransfer/CMakeLists.txt
+++ b/FastStyleTransfer/CMakeLists.txt
@@ -1,0 +1,32 @@
+add_library(FastStyleTransfer
+  Layers/Helpers.swift
+  Layers/Normalization.swift
+
+  Models/TransformerNet.swift
+
+  Utility/ImportableLayer.swift
+  Utility/Resize.swift)
+target_link_libraries(FastStyleTransfer PUBLIC
+  ModelSupport)
+set_target_properties(FastStyleTransfer PROPERTIES
+  INTERFACE_INCLUDE_DIRECTORIES ${CMAKE_Swift_MODULE_DIRECTORY})
+
+add_executable(FastStyleTransferDemo
+  Demo/ColabDemo.ipynb
+  Demo/Helpers.swift
+  Demo/main.swift)
+target_link_libraries(FastStyleTransferDemo PRIVATE
+  FastStyleTransfer)
+
+
+install(TARGETS FastStyleTransfer
+  ARCHIVE DESTINATION lib/swift/$<LOWER_CASE:${CMAKE_SYSTEM_NAME}>
+  LIBRARY DESTINATION lib/swift/$<LOWER_CASE:${CMAKE_SYSTEM_NAME}>
+  RUNTIME DESTINATION bin)
+install(TARGETS FastStyleTransferDemo
+  DESTINATION bin)
+get_swift_host_arch(swift_arch)
+install(FILES
+  $<TARGET_PROPERTY:FastStyleTransfer,Swift_MODULE_DIRECTORY>/FastStyleTransfer.swiftdoc
+  $<TARGET_PROPERTY:FastStyleTransfer,Swift_MODULE_DIRECTORY>/FastStyleTransfer.swiftmodule
+  DESTINATION lib/swift$<$<NOT:$<BOOL:${BUILD_SHARED_LIBS}>>:_static>/$<LOWER_CASE:${CMAKE_SYSTEM_NAME}>/${swift_arch})

--- a/GAN/CMakeLists.txt
+++ b/GAN/CMakeLists.txt
@@ -1,0 +1,9 @@
+add_executable(GAN
+  main.swift)
+target_link_libraries(GAN PRIVATE
+  Datasets
+  ModelSupport)
+
+
+install(TARGETS GAN
+  DESTINATION bin)

--- a/MiniGo/CMakeLists.txt
+++ b/MiniGo/CMakeLists.txt
@@ -1,0 +1,46 @@
+add_library(MiniGo
+  GameLib/Board.swift
+  GameLib/BoardState.swift
+  GameLib/Color.swift
+  GameLib/GameConfiguration.swift
+  GameLib/LibertyTracker.swift
+  GameLib/Position.swift
+
+  Models/GoModel.swift
+  Models/MiniGoCheckpointReader.swift
+
+  Play/PlayOneGame.swift
+
+  Strategies/HumanPolicy.swift
+  Strategies/Policy.swift
+  Strategies/RandomPolicy.swift
+
+  Strategies/MCTS/MCTSConfiguration.swift
+  Strategies/MCTS/MCTSModelBasePredictor.swift
+  Strategies/MCTS/MCTSNode.swift
+  Strategies/MCTS/MCTSPolicy.swift
+  Strategies/MCTS/MCTSPredictor.swift
+  Strategies/MCTS/MCTSRandomPredictor.swift
+  Strategies/MCTS/MCTSTree.swift)
+target_link_libraries(MiniGo PUBLIC
+  ModelSupport)
+set_target_properties(MiniGo PROPERTIES
+  INTERFACE_INCLUDE_DIRECTORIES ${CMAKE_Swift_MODULE_DIRECTORY})
+
+add_executable(MiniGoDemo
+  main.swift)
+target_link_libraries(MiniGoDemo PRIVATE
+  MiniGo)
+
+
+install(TARGETS MiniGo
+  ARCHIVE DESTINATION lib/swift/$<LOWER_CASE:${CMAKE_SYSTEM_NAME}>
+  LIBRARY DESTINATION lib/swift/$<LOWER_CASE:${CMAKE_SYSTEM_NAME}>
+  RUNTIME DESTINATION bin)
+install(TARGETS MiniGoDemo
+  DESTINATION bin)
+get_swift_host_arch(swift_arch)
+install(FILES
+  $<TARGET_PROPERTY:MiniGo,Swift_MODULE_DIRECTORY>/MiniGo.swiftdoc
+  $<TARGET_PROPERTY:MiniGo,Swift_MODULE_DIRECTORY>/MiniGo.swiftmodule
+  DESTINATION lib/swift$<$<NOT:$<BOOL:${BUILD_SHARED_LIBS}>>:_static>/$<LOWER_CASE:${CMAKE_SYSTEM_NAME}>/${swift_arch})

--- a/Models/CMakeLists.txt
+++ b/Models/CMakeLists.txt
@@ -1,0 +1,1 @@
+add_subdirectory(ImageClassification)

--- a/Models/ImageClassification/CMakeLists.txt
+++ b/Models/ImageClassification/CMakeLists.txt
@@ -1,0 +1,22 @@
+add_library(ImageClassificationModels
+  DenseNet121.swift
+  LeNet-5.swift
+  MobileNet.swift
+  ResNet.swift
+  ResNetV2.swift
+  SqueezeNet.swift
+  VGG.swift
+  WideResNet.swift)
+set_target_properties(ImageClassificationModels PROPERTIES
+  INTERFACE_INCLUDE_DIRECTORIES ${CMAKE_Swift_MODULE_DIRECTORY})
+
+
+install(TARGETS ImageClassificationModels
+  ARCHIVE DESTINATION lib/swift/$<LOWER_CASE:${CMAKE_SYSTEM_NAME}>
+  LIBRARY DESTINATION lib/swift/$<LOWER_CASE:${CMAKE_SYSTEM_NAME}>
+  RUNTIME DESTINATION bin)
+get_swift_host_arch(swift_arch)
+install(FILES
+  $<TARGET_PROPERTY:ImageClassificationModels,Swift_MODULE_DIRECTORY>/ImageClassificationModels.swiftdoc
+  $<TARGET_PROPERTY:ImageClassificationModels,Swift_MODULE_DIRECTORY>/ImageClassificationModels.swiftmodule
+  DESTINATION lib/swift$<$<NOT:$<BOOL:${BUILD_SHARED_LIBS}>>:_static>/$<LOWER_CASE:${CMAKE_SYSTEM_NAME}>/${swift_arch})

--- a/Support/CMakeLists.txt
+++ b/Support/CMakeLists.txt
@@ -1,0 +1,18 @@
+add_library(ModelSupport
+  Checkpoints/CheckpointReader.swift
+  FileManagement.swift
+  Image.swift
+  Stderr.swift)
+set_target_properties(ModelSupport PROPERTIES
+  INTERFACE_INCLUDE_DIRECTORIES ${CMAKE_Swift_MODULE_DIRECTORY})
+
+
+install(TARGETS ModelSupport
+  ARCHIVE DESTINATION lib/swift/$<LOWER_CASE:${CMAKE_SYSTEM_NAME}>
+  LIBRARY DESTINATION lib/swift/$<LOWER_CASE:${CMAKE_SYSTEM_NAME}>
+  RUNTIME DESTINATION bin)
+get_swift_host_arch(swift_arch)
+install(FILES
+  $<TARGET_PROPERTY:ModelSupport,Swift_MODULE_DIRECTORY>/ModelSupport.swiftdoc
+  $<TARGET_PROPERTY:ModelSupport,Swift_MODULE_DIRECTORY>/ModelSupport.swiftmodule
+  DESTINATION lib/swift$<$<NOT:$<BOOL:${BUILD_SHARED_LIBS}>>:_static>/$<LOWER_CASE:${CMAKE_SYSTEM_NAME}>/${swift_arch})

--- a/cmake/modules/SwiftSupport.cmake
+++ b/cmake/modules/SwiftSupport.cmake
@@ -1,0 +1,36 @@
+# Returns the current architecture name in a variable
+#
+# Usage:
+#   get_swift_host_arch(result_var_name)
+#
+# If the current architecture is supported by Swift, sets ${result_var_name}
+# with the sanitized host architecture name derived from CMAKE_SYSTEM_PROCESSOR.
+function(get_swift_host_arch result_var_name)
+  if("${CMAKE_SYSTEM_PROCESSOR}" STREQUAL "x86_64")
+    set("${result_var_name}" "x86_64" PARENT_SCOPE)
+  elseif("${CMAKE_SYSTEM_PROCESSOR}" STREQUAL "aarch64")
+    set("${result_var_name}" "aarch64" PARENT_SCOPE)
+  elseif("${CMAKE_SYSTEM_PROCESSOR}" STREQUAL "ppc64")
+    set("${result_var_name}" "powerpc64" PARENT_SCOPE)
+  elseif("${CMAKE_SYSTEM_PROCESSOR}" STREQUAL "ppc64le")
+    set("${result_var_name}" "powerpc64le" PARENT_SCOPE)
+  elseif("${CMAKE_SYSTEM_PROCESSOR}" STREQUAL "s390x")
+    set("${result_var_name}" "s390x" PARENT_SCOPE)
+  elseif("${CMAKE_SYSTEM_PROCESSOR}" STREQUAL "armv6l")
+    set("${result_var_name}" "armv6" PARENT_SCOPE)
+  elseif("${CMAKE_SYSTEM_PROCESSOR}" STREQUAL "armv7l")
+    set("${result_var_name}" "armv7" PARENT_SCOPE)
+  elseif("${CMAKE_SYSTEM_PROCESSOR}" STREQUAL "armv7-a")
+    set("${result_var_name}" "armv7" PARENT_SCOPE)
+  elseif("${CMAKE_SYSTEM_PROCESSOR}" STREQUAL "AMD64")
+    set("${result_var_name}" "x86_64" PARENT_SCOPE)
+  elseif("${CMAKE_SYSTEM_PROCESSOR}" STREQUAL "IA64")
+    set("${result_var_name}" "itanium" PARENT_SCOPE)
+  elseif("${CMAKE_SYSTEM_PROCESSOR}" STREQUAL "x86")
+    set("${result_var_name}" "i686" PARENT_SCOPE)
+  elseif("${CMAKE_SYSTEM_PROCESSOR}" STREQUAL "i686")
+    set("${result_var_name}" "i686" PARENT_SCOPE)
+  else()
+    message(FATAL_ERROR "Unrecognized architecture on host system: ${CMAKE_SYSTEM_PROCESSOR}")
+  endif()
+endfunction()


### PR DESCRIPTION
This adds a CMake based build system for the models, enabling building
the models on platforms where swift-package-manager does not currently
function properly.