### PR TITLE
FastStyleTransfer: use `roundf` rather than `round`

### DIFF
--- a/FastStyleTransfer/Utility/Resize.swift
+++ b/FastStyleTransfer/Utility/Resize.swift
@@ -9,7 +9,7 @@ public func resizeNearestNeighbor<Scalar: TensorFlowFloatingPoint>(
 ) -> Tensor<Scalar> {
     let size = Tensor<Int32>(
         shape: [2],
-        scalars: [input.shape[1], input.shape[2]].map { Int32(round(Float($0) * scaleFactor)) }
+        scalars: [input.shape[1], input.shape[2]].map { Int32(roundf(Float($0) * scaleFactor)) }
     )
     return _Raw.resizeNearestNeighbor(images: input, size: size)
 }


### PR DESCRIPTION
This is needed to build on Windows.  Without this, the build would fail
as the expression would fail to typecheck.  Windows does not provide the
`round` macro, and requires that we explicitly use the typed macro for
the floating point operation (e.g. `roundf`, `roundl`, `roundll` instead
of `round`).

With this change it is possible to build the models on Windows.