### PR TITLE
docs: update command

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,13 +17,13 @@ Use Swift Package Manager to develop Swift for TensorFlow models.
 ### Build
 
 ```bash
-swift build -Xlinker -ltensorflow
+swift build
 ```
 
 ### Test
 
 ```bash
-swift test -Xlinker -ltensorflow
+swift test
 ```
 
 ## Bugs


### PR DESCRIPTION
The explicit link against tensorflow has not been needed for a while.
Update the instructions accordingly.