### PR TITLE
Transformer: use typed `sqrt`

### DIFF
--- a/Transformer/Model.swift
+++ b/Transformer/Model.swift
@@ -113,7 +113,7 @@ struct Attention: ParameterlessLayer {
     @noDerivative let causal: Bool
     
     init(size: Int, causal: Bool = false, dropProbability: Double) {
-        scale = Tensor(sqrt(Float(size)))
+        scale = Tensor(sqrtf(Float(size)))
         dropout = Dropout<Float>(probability: dropProbability)
         self.causal = causal
     }


### PR DESCRIPTION
This switches the `sqrt` to `sqrtf` which explicitly indicates the type.
This is required to enable building the transformer model on Windows.