### PR TITLE
Transformer: explicitly indicate encoding

### DIFF
--- a/Transformer/encoder.py
+++ b/Transformer/encoder.py
@@ -1,3 +1,4 @@
+# -*- encoding: utf-8 -*-
 # Tokenizer utilities from github.com/openai/gpt-2
 # licensed under MIT (https://github.com/openai/gpt-2/blob/master/LICENSE)
 # TODO: port these to Swift


### PR DESCRIPTION
When using this on Windows, Python would complain about the UTF-8
encoding in the file:

```
Non-ASCII character '\\xc2' in file ./Transformer\\encoder.py on line 23, but no encoding declared; see http://python.org/dev/peps/pep-0263/ for details
```

Explicitly indicate the encoding in the file.