### PR TITLE
Models: use explictly typed math operations (NFC)

### DIFF
--- a/Models/Text/Attention.swift
+++ b/Models/Text/Attention.swift
@@ -190,7 +190,7 @@ public struct MultiHeadAttention: Layer, Regularizable {
 
         // Take the dot product between the query and the key to get the raw attention scores.
         var attentionScores = matmul(q, transposed: false, k, transposed: true) // [B, N, F, T]
-        attentionScores = attentionScores / sqrt(Scalar(headSize))
+        attentionScores = attentionScores / sqrtf(Scalar(headSize))
 
         // Since the attention mask is set to 1.0 for positions we want to attend to and 0.0 for
         // masked positions, we create a tensor which is 0.0 for positions we want to attend to and 

--- a/Models/Text/WeightDecayedAdam.swift
+++ b/Models/Text/WeightDecayedAdam.swift
@@ -123,7 +123,7 @@ where Model.TangentVector: VectorProtocol & PointwiseMultiplicative &
         var learningRate = self.learningRate(forStep: step)
         if useBiasCorrection {
             let step = Float(self.step)
-            learningRate *= sqrt(1 - pow(beta2, step)) / (1 - pow(beta1, step))
+            learningRate *= sqrtf(1 - powf(beta2, step)) / (1 - powf(beta1, step))
         }
         model.move(along: update.scaled(by: -learningRate))
     }


### PR DESCRIPTION
Use the typed math operations `powf`, `sqrtf`.  This is required to
ensure that we can build on Windows.