### PR TITLE
Datasets: import FoundationNetworking if possible

### DIFF
--- a/Datasets/CoLA/DataUtilities.swift
+++ b/Datasets/CoLA/DataUtilities.swift
@@ -16,7 +16,7 @@
 
 import Foundation
 
-#if os(Linux)
+#if canImport(FoundationNetworking)
 import FoundationNetworking
 #endif
 


### PR DESCRIPTION
This ensures that we import FoundationNetworking whenever available.
This is needed when using SwiftFoundation on Darwin or building on
Windows.