### PR TITLE
BERT: remove hardcoded path assumption

### DIFF
--- a/Examples/BERT-CoLA/main.swift
+++ b/Examples/BERT-CoLA/main.swift
@@ -18,7 +18,9 @@ import TensorFlow
 import TextModels
 
 let bertPretrained = BERT.PreTrainedModel.bertBase(cased: false, multilingual: false)
-let workspaceURL = URL(fileURLWithPath: "/tmp/bert_models", isDirectory: true)
+let workspaceURL = URL(fileURLWithPath: "bert_models", isDirectory: true,
+                       relativeTo: URL(fileURLWithPath: NSTemporaryDirectory(),
+                                       isDirectory: true))
 let bert = try BERT.PreTrainedModel.load(bertPretrained)(from: workspaceURL)
 var bertClassifier = BERTClassifier(bert: bert, classCount: 1)
 


### PR DESCRIPTION
`/tmp` is not the universal temporary directory.  Construct the path
in a more portable manner by using Foundation.  This also allows the
user to override the temporary path.