### PR TITLE
Make `Image` more flexible

### DIFF
--- a/Autoencoder/main.swift
+++ b/Autoencoder/main.swift
@@ -53,11 +53,11 @@ for epoch in 1...epochCount {
 
         do {
             try saveImage(
-                sampleImage, size: (imageWidth, imageHeight), directory: outputFolder,
-                name: "epoch-\(epoch)-input")
+                sampleImage, shape: (imageWidth, imageHeight), format: .grayscale,
+                directory: outputFolder, name: "epoch-\(epoch)-input")
             try saveImage(
-                testImage, size: (imageWidth, imageHeight), directory: outputFolder,
-                name: "epoch-\(epoch)-output")
+                testImage, shape: (imageWidth, imageHeight), format: .grayscale,
+                directory: outputFolder, name: "epoch-\(epoch)-output")
         } catch {
             print("Could not save image with error: \(error)")
         }

--- a/DCGAN/main.swift
+++ b/DCGAN/main.swift
@@ -153,8 +153,8 @@ for epoch in 0 ... epochs {
     // Render images.
     let generatedImage = generator(noise)
     try saveImage(
-        generatedImage, size: (28, 28), directory: outputFolder,
-        name: "\(epoch).jpg")
+        generatedImage, shape: (28, 28), format: .grayscale, directory: outputFolder,
+        name: "\(epoch)")
 
     // Print loss.
     let generatorLoss_ = generatorLoss(fakeLabels: generatedImage)
@@ -165,5 +165,5 @@ for epoch in 0 ... epochs {
 let noise1 = Tensor<Float>(randomNormal: TensorShape(1, 100))
 let generatedImage = generator(noise1)
 try saveImage(
-        generatedImage, size: (28, 28), directory: outputFolder,
-        name: "final.jpg")
+    generatedImage, shape: (28, 28), format: .grayscale, directory: outputFolder,
+    name: "final")

--- a/GAN/main.swift
+++ b/GAN/main.swift
@@ -136,8 +136,8 @@ func saveImageGrid(_ testImage: Tensor<Float>, name: String) throws {
     gridImage = (gridImage + 1) / 2
 
     try saveImage(
-        gridImage, size: (gridImage.shape[0], gridImage.shape[1]), directory: outputFolder,
-        name: name)
+        gridImage, shape: (gridImage.shape[0], gridImage.shape[1]), format: .grayscale,
+        directory: outputFolder, name: name)
 }
 
 print("Start training...")

--- a/Support/File.swift
+++ b/Support/File.swift
@@ -1,8 +1,0 @@
-//
-//  File.swift
-//  
-//
-//  Created by Rahul Bhalley on 19/02/20.
-//
-
-import Foundation

--- a/Support/File.swift
+++ b/Support/File.swift
@@ -1,0 +1,8 @@
+//
+//  File.swift
+//  
+//
+//  Created by Rahul Bhalley on 19/02/20.
+//
+
+import Foundation

--- a/Support/Image.swift
+++ b/Support/Image.swift
@@ -20,29 +20,29 @@ public struct Image {
         case bgr
         case rgb
     }
-    
+
     enum ImageTensor {
         case float(data: Tensor<Float>)
         case uint8(data: Tensor<UInt8>)
     }
-    
+
     let imageData: ImageTensor
-    
+
     public var tensor: Tensor<Float> {
         switch self.imageData {
         case let .float(data): return data
         case let .uint8(data): return Tensor<Float>(data)
         }
     }
-    
+
     public init(tensor: Tensor<UInt8>) {
         self.imageData = .uint8(data: tensor)
     }
-    
+
     public init(tensor: Tensor<Float>) {
         self.imageData = .float(data: tensor)
     }
-    
+
     public init(jpeg url: URL, byteOrdering: ByteOrdering = .rgb) {
         let loadedFile = _Raw.readFile(filename: StringTensor(url.absoluteString))
         let loadedJpeg = _Raw.decodeJpeg(contents: loadedFile, channels: 3, dctMethod: "")
@@ -53,7 +53,7 @@ public struct Image {
             self.imageData = .uint8(data: loadedJpeg)
         }
     }
-    
+
     public func save(to url: URL, format: _Raw.Format = .rgb, quality: Int64 = 95) {
         let outputImageData: Tensor<UInt8>
         switch format {
@@ -77,12 +77,12 @@ public struct Image {
             print("Image saving isn't supported for the format \(format).")
             exit(-1)
         }
-        
+
         let encodedJpeg = _Raw.encodeJpeg(
             image: outputImageData, format: format, quality: quality, xmpMetadata: "")
         _Raw.writeFile(filename: StringTensor(url.absoluteString), contents: encodedJpeg)
     }
-    
+
     public func resized(to size: (Int, Int)) -> Image {
         switch self.imageData {
         case let .uint8(data):

--- a/Support/Image.swift
+++ b/Support/Image.swift
@@ -100,11 +100,20 @@ public struct Image {
     }
 }
 
-public func saveImage(_ tensor: Tensor<Float>, size: (Int, Int)? = nil,
+public func saveImage(_ tensor: Tensor<Float>, shape: (Int, Int), size: (Int, Int)? = nil,
                       format: _Raw.Format = .rgb, directory: String, name: String,
                       quality: Int64 = 95) throws {
     try createDirectoryIfMissing(at: directory)
-    let image = Image(tensor: tensor)
+    let channels: Int
+    switch format {
+    case .rgb: channels = 3
+    case .grayscale: channels = 1
+    default:
+        print("\(format) is not supported yet.")
+        exit(-1)
+    }
+    let reshapedTensor = tensor.reshaped(to: [shape.0, shape.1, channels])
+    let image = Image(tensor: reshapedTensor)
     let resizedImage = size != nil ? image.resized(to: (size!.0, size!.1)) : image
     let outputURL = URL(fileURLWithPath: "\(directory)\(name).jpg")
     resizedImage.save(to: outputURL, format: format, quality: quality)

--- a/Support/Image.swift
+++ b/Support/Image.swift
@@ -44,8 +44,8 @@ public struct Image {
     }
     
     public init(jpeg url: URL, byteOrdering: ByteOrdering = .rgb) {
-        let loadedData = _Raw.readFile(filename: StringTensor(url.absoluteString))
-        let loadedJpeg = _Raw.decodeJpeg(contents: loadedData, channels: 3, dctMethod: "")
+        let loadedFile = _Raw.readFile(filename: StringTensor(url.absoluteString))
+        let loadedJpeg = _Raw.decodeJpeg(contents: loadedFile, channels: 3, dctMethod: "")
         if byteOrdering == .bgr {
             self.imageData = .uint8(
                 data: _Raw.reverse(loadedJpeg, dims: Tensor<Bool>([false, false, false, true])))

--- a/Support/Image.swift
+++ b/Support/Image.swift
@@ -1,4 +1,4 @@
-// Copyright 2019 The TensorFlow Authors. All Rights Reserved.
+// Copyright 2020 The TensorFlow Authors. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -20,32 +20,32 @@ public struct Image {
         case bgr
         case rgb
     }
-
+    
     enum ImageTensor {
         case float(data: Tensor<Float>)
         case uint8(data: Tensor<UInt8>)
     }
-
+    
     let imageData: ImageTensor
-
+    
     public var tensor: Tensor<Float> {
         switch self.imageData {
         case let .float(data): return data
         case let .uint8(data): return Tensor<Float>(data)
         }
     }
-
+    
     public init(tensor: Tensor<UInt8>) {
         self.imageData = .uint8(data: tensor)
     }
-
+    
     public init(tensor: Tensor<Float>) {
         self.imageData = .float(data: tensor)
     }
-
+    
     public init(jpeg url: URL, byteOrdering: ByteOrdering = .rgb) {
-        let loadedFile = _Raw.readFile(filename: StringTensor(url.absoluteString))
-        let loadedJpeg = _Raw.decodeJpeg(contents: loadedFile, channels: 3, dctMethod: "")
+        let loadedData = _Raw.readFile(filename: StringTensor(url.absoluteString))
+        let loadedJpeg = _Raw.decodeJpeg(contents: loadedData, channels: 3, dctMethod: "")
         if byteOrdering == .bgr {
             self.imageData = .uint8(
                 data: _Raw.reverse(loadedJpeg, dims: Tensor<Bool>([false, false, false, true])))
@@ -53,8 +53,8 @@ public struct Image {
             self.imageData = .uint8(data: loadedJpeg)
         }
     }
-
-    public func save(to url: URL, format: _Raw.Format = .grayscale, quality: Int64 = 95) {
+    
+    public func save(to url: URL, format: _Raw.Format = .rgb, quality: Int64 = 95) {
         let outputImageData: Tensor<UInt8>
         switch format {
         case .grayscale:
@@ -77,35 +77,35 @@ public struct Image {
             print("Image saving isn't supported for the format \(format).")
             exit(-1)
         }
-
+        
         let encodedJpeg = _Raw.encodeJpeg(
             image: outputImageData, format: format, quality: quality, xmpMetadata: "")
         _Raw.writeFile(filename: StringTensor(url.absoluteString), contents: encodedJpeg)
     }
-
+    
     public func resized(to size: (Int, Int)) -> Image {
         switch self.imageData {
         case let .uint8(data):
             return Image(
                 tensor: _Raw.resizeBilinear(
-                    images: Tensor<UInt8>([data]),
-                    size: Tensor<Int32>([Int32(size.0), Int32(size.1)])))
+                    images: Tensor<UInt8>(data.rankLifted()),
+                    size: Tensor<Int32>([Int32(size.0), Int32(size.1)])).squeezingShape(at: 0))
         case let .float(data):
             return Image(
                 tensor: _Raw.resizeBilinear(
-                    images: Tensor<Float>([data]),
-                    size: Tensor<Int32>([Int32(size.0), Int32(size.1)])))
+                    images: Tensor<Float>(data.rankLifted()),
+                    size: Tensor<Int32>([Int32(size.0), Int32(size.1)])).squeezingShape(at: 0))
         }
 
     }
 }
 
-public func saveImage(_ tensor: Tensor<Float>, size: (Int, Int), directory: String, name: String)
-    throws
-{
+public func saveImage(_ tensor: Tensor<Float>, size: (Int?, Int?) = (nil, nil),
+                      format: _Raw.Format = .rgb, directory: String, name: String,
+                      quality: Int64 = 95) throws {
     try createDirectoryIfMissing(at: directory)
-    let reshapedTensor = tensor.reshaped(to: [size.0, size.1, 1])
-    let image = Image(tensor: reshapedTensor)
+    let image = Image(tensor: tensor)
+    let resizedImage = size.0 != nil && size.1 != nil ? image.resized(to: (size.0!, size.1!)) : image
     let outputURL = URL(fileURLWithPath: "\(directory)\(name).jpg")
-    image.save(to: outputURL)
+    resizedImage.save(to: outputURL, format: format, quality: quality)
 }

--- a/Support/Image.swift
+++ b/Support/Image.swift
@@ -100,12 +100,12 @@ public struct Image {
     }
 }
 
-public func saveImage(_ tensor: Tensor<Float>, size: (Int?, Int?) = (nil, nil),
+public func saveImage(_ tensor: Tensor<Float>, size: (Int, Int)? = nil,
                       format: _Raw.Format = .rgb, directory: String, name: String,
                       quality: Int64 = 95) throws {
     try createDirectoryIfMissing(at: directory)
     let image = Image(tensor: tensor)
-    let resizedImage = size.0 != nil && size.1 != nil ? image.resized(to: (size.0!, size.1!)) : image
+    let resizedImage = size != nil ? image.resized(to: (size!.0, size!.1)) : image
     let outputURL = URL(fileURLWithPath: "\(directory)\(name).jpg")
     resizedImage.save(to: outputURL, format: format, quality: quality)
 }

--- a/Support/Image.swift
+++ b/Support/Image.swift
@@ -88,13 +88,13 @@ public struct Image {
         case let .uint8(data):
             return Image(
                 tensor: _Raw.resizeBilinear(
-                    images: Tensor<UInt8>(data.rankLifted()),
-                    size: Tensor<Int32>([Int32(size.0), Int32(size.1)])).squeezingShape(at: 0))
+                    images: Tensor<UInt8>([data]),
+                    size: Tensor<Int32>([Int32(size.0), Int32(size.1)])))
         case let .float(data):
             return Image(
                 tensor: _Raw.resizeBilinear(
-                    images: Tensor<Float>(data.rankLifted()),
-                    size: Tensor<Int32>([Int32(size.0), Int32(size.1)])).squeezingShape(at: 0))
+                    images: Tensor<Float>([data]),
+                    size: Tensor<Int32>([Int32(size.0), Int32(size.1)])))
         }
 
     }


### PR DESCRIPTION
Following changes have been proposed on `Image` structure:

1. Exposed `format` and `quality` argument labels to `saveImage(_:size:format:directory:name:quality:)` public function with default values of `format: .rgb` (because there's high probability the image will be RGB), `quality: 95`.
2. `size` is now used to resize the `tensor` instead of reshaping it. (There doesn't seem to be a requirement of reshaping image tensor.) But if it does seem important to community I think of renaming `size` to `newShape` for `reshaped(to:)` and `newSize` for resizing `tensor`.
3. `size` argument label is now `(Int?, Int?)` with default values `(nil, nil)`. If new argument value is provided during call then image tensor is resized otherwise original size is maintained.
4. `resized(to:)` instance method now uses `rankLifted()` and `squeezingShape(at:)` for more legibility. 

Suggestion(s) for further improvement:

1. Add `_Raw.rGBToGrayscale()` (akin to Pythonic [`tf.image.rgb_to_grayscale`](https://www.tensorflow.org/api_docs/python/tf/image/rgb_to_grayscale?version=nightly)) method inside `save(to:format:quality)` at beginning. Currently this method is not available under `_Raw` enumeration. Using this method will automatically convert RGB to grayscale using `format` value from `saveImage(_:size:format:directory:name:quality:)` to save image.
2. In similar context to previous point add `_Raw.GrayscaleToRGB()` (akin to [`tf.image.grayscale_to_rgb`](https://www.tensorflow.org/api_docs/python/tf/image/grayscale_to_rgb)).