### PR TITLE
[AutoDiff] Fix Transformer CMake build linker error.

### DIFF
--- a/Transformer/Operators.swift
+++ b/Transformer/Operators.swift
@@ -26,6 +26,7 @@ func gelu<Scalar: TensorFlowFloatingPoint>(_ x: Tensor<Scalar>) -> Tensor<Scalar
 
 /// Performs batched matrix multiplication of two tensors. The last two axes of each tensor
 /// are treated as the matrix axes; all others are treated as batch axes.
+@usableFromInline
 @differentiable(wrt: (left, right) where Scalar : Differentiable & TensorFlowFloatingPoint)
 func batchedMatmul<Scalar : Numeric>(
     _ left: Tensor<Scalar>,


### PR DESCRIPTION
Fix Transformer linker error due to original/derivative declaration access level
mismatch: derivative is `@usableFromInline` but original is not.

Issue tracked at TF-1160.

Robust fix is TF-1099: require `@derivative` declarations to have same access
level as original declaration.

---

Unblocks https://github.com/tensorflow/swift-models/pull/324: add Transformer to CMake build.