### PR TITLE
Update deprecated method-style differential operator usage.

### DIFF
--- a/Examples/Regression-BostonHousing/main.swift
+++ b/Examples/Regression-BostonHousing/main.swift
@@ -66,7 +66,7 @@ for epoch in 1...epochCount {
         
         let batchStart = r * batchSize
         let batchEnd = min(dataset.numTrainRecords, batchStart + batchSize)
-        let (loss, grad) = model.valueWithGradient { (model: RegressionModel) -> Tensor<Float> in
+        let (loss, grad) = valueWithGradient(at: model) { (model: RegressionModel) -> Tensor<Float> in
             let logits = model(dataset.xTrain[batchStart..<batchEnd])
             return meanSquaredError(predicted: logits, expected: dataset.yTrain[batchStart..<batchEnd])
         }


### PR DESCRIPTION
Use top-level `valueWithGradient` differential operator instead.

Method-style differential operators may be removed at any time, since
they were deprecated in the last release.