### PR TITLE
Transformer: link against `TextModels`

### DIFF
--- a/Transformer/CMakeLists.txt
+++ b/Transformer/CMakeLists.txt
@@ -10,6 +10,7 @@ set_target_properties(Transformer PROPERTIES
 add_executable(TransformerDemo
   main.swift)
 target_link_libraries(TransformerDemo PRIVATE
+  TextModels
   Transformer)
 
 


### PR DESCRIPTION
The transformer model uses `TextModels` but did not link against it,
which resulted in dependency issues.  This fixes the build on Windows.