### PR TITLE
Minor correction to Imagenette Batcher downloading to indicate directory

### DIFF
--- a/Datasets/Imagenette/Imagenette.swift
+++ b/Datasets/Imagenette/Imagenette.swift
@@ -178,7 +178,7 @@ public struct ImagenetteBatchers {
     public init(
         inputSize: Imagenette.ImageSize, outputSize: Int, batchSize: Int = 64, numWorkers: Int = 8, 
         localStorageDirectory: URL = FileManager.default.temporaryDirectory.appendingPathComponent(
-            "Imagenette")
+            "Imagenette", isDirectory: true)
     ) {
         do {
             let trainUrls = try exploreDirectory(


### PR DESCRIPTION
PR #328 changed the core downloading function to automatically detect if a download destination was a file or directory. In order for a directory to be detected, it must be labeled as such when constructed, otherwise it will be treated as a file.

This fixes the Batcher pathway in Imagenette to download to a directory named Imagenette, not a file by that name. This should address issue #341.