### PR TITLE
Indicate the BERT directory is labeled as such when downloading BERT

### DIFF
--- a/Models/Text/BERT.swift
+++ b/Models/Text/BERT.swift
@@ -639,7 +639,7 @@ extension BERT {
         ///   - directory: Directory to load the pretrained model from.
         public func load(from directory: URL) throws -> BERT {
             print("Loading BERT pre-trained model '\(name)'.")
-            let directory = directory.appendingPathComponent(variant.description)
+            let directory = directory.appendingPathComponent(variant.description, isDirectory: true)
             try maybeDownload(to: directory)
 
             // Load the appropriate vocabulary file.


### PR DESCRIPTION
When downloading the BERT pre-trained model, a directory may not be created (`Extracting archive... unzip:  cannot find or open /tmp/bert_models/bert/uncased_L-12_H-768_A-12.zip, ...
Fatal error: 'try!' expression unexpectedly raised an error: Error Domain=NSPOSIXErrorDomain Code=20 "Not a directory": ...`). 

So, in Colab, `bert` is not recognized as a folder in the `/tmp/` directory. This PR should fix it but there's still work for Xcode, as it throws a different error (see below). Your input, suggestions, any help would be welcome, especially for Xcode. I don't have extensive experience developing cool things with Swift, like the S4TF team.

@BradLarson The PR is based on your idea from https://github.com/tensorflow/swift-models/pull/342 (Thanks for fixing my #341 on Sunday!) - all credit to you 🖖. 

- [x] Colab: tested, it seems to work, and the it is training on CoLA (I'm at step 1330 right now):

```
Loading BERT pre-trained model 'BERT Base Uncased'.
Loading resource: uncased_L-12_H-768_A-12
...
Fetching URL: https://storage.googleapis.com/bert_models/2018_10_18/uncased_L-12_H-768_A-12.zip...
Archive saved to: /tmp/bert_models/bert
Extracting archive...
Archive:  /tmp/bert_models/bert/uncased_L-12_H-768_A-12.zip
...
Extracting file at '/tmp/bert_models/CoLA/data/downloaded-data.zip'.
Archive:  /tmp/bert_models/CoLA/data/downloaded-data.zip
...
Training BERT for the CoLA task!
[Step: 0]	Loss: 0.7064214
[Step: 1]	Loss: 0.8608369
...
```

- [ ] Xcode: tested and getting a different error (if you can help here please do):
```
Fetching URL: https://storage.googleapis.com/bert_models/2018_10_18/uncased_L-12_H-768_A-12.zip...
Fatal error: Failed to fetch and save resource with error: Error Domain=NSCocoaErrorDomain Code=512 "The file “uncased_L-12_H-768_A-12.zip” couldn’t be saved in the folder “bert”."
```