### PR TITLE
Support: add a basic bi-directional mapping utility

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -92,5 +92,6 @@ let package = Package(
         .testTarget(name: "CheckpointTests", dependencies: ["ModelSupport"]),
         .target(
             name: "BERT-CoLA", dependencies: ["TextModels", "Datasets"], path: "Examples/BERT-CoLA"),
+        .testTarget(name: "SupportTests", dependencies: ["ModelSupport"]),
     ]
 )

--- a/Support/BijectiveDictionary.swift
+++ b/Support/BijectiveDictionary.swift
@@ -1,0 +1,94 @@
+// Copyright 2020 The TensorFlow Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/// A bijective mapping behaving similar to dictionary with the additional
+/// ability to lookup the key from the value
+public struct BijectiveDictionary<Key: Hashable, Value: Hashable> {
+  private var valueForKey: [Key:Value] = [:]
+  // TODO: specialize where value is Int32 such that keyForValue is actually an
+  // array?
+  private var keyForValue: [Value:Key] = [:]
+
+  /// The number of of key-value pairs in the dictionary
+  public var count: Int { valueForKey.count }
+
+  /// Initializes the dictionary from a sequence of tuples of key and value.
+  public init<T: Sequence>(_ mapping: T) where T.Element == (Key, Value) {
+    valueForKey = .init(uniqueKeysWithValues: mapping)
+    keyForValue = .init(uniqueKeysWithValues: mapping.lazy.map { ($1, $0) })
+  }
+
+  /// Initializes the dictionary from a dictionary
+  public init(_ dictionary: [Key: Value]) {
+    valueForKey = dictionary
+    keyForValue = .init(uniqueKeysWithValues: dictionary.lazy.map { ($1, $0) })
+  }
+
+  /// Reserves enough space to store the specified number of key-value pairs.
+  ///
+  /// If you are adding a known number of key-value pairs to a bijective
+  /// dictionary, use this method to avoid multiple reallocations.  This method
+  /// ensures that the dictionary has unique, mutable, contiguous storage, for
+  /// space allocated for at least the requested number of key-value pairs.
+  ///
+  /// - Parameter minimumCapacity: the requested number of key-value pairs to
+  ///   store.
+  public mutating func reserveCapacity(_ minimumCapacity: Int) {
+    valueForKey.reserveCapacity(minimumCapacity)
+    keyForValue.reserveCapacity(minimumCapacity)
+  }
+
+  /// Access the value associated with the given key for reading and writing.
+  ///
+  /// The subscript returns the value for the given key if the key is found in
+  /// the dictionary, or `nil` if the key is not found.
+  ///
+  /// The addition of the key-value pair requires that the mapping hold the
+  /// conditions of a bijection: the mapping must remain one-to-one and onto.
+  ///
+  /// - Parameter key: the key to find in the dictionary.
+  /// - Returns: the value associated with `key` if `key` is in the dictionary,
+  ///   or `nil` otherwise.
+  public subscript(key: Key) -> Value? {
+    get { return valueForKey[key] }
+    set(value) {
+      if let value = value {
+        if let k_0 = self.keyForValue.updateValue(key, forKey: value), k_0 != key {
+          self.valueForKey[k_0] = nil
+        }
+        if let v_0 = self.valueForKey.updateValue(value, forKey: key), v_0 != value {
+          self.keyForValue[v_0] = nil
+        }
+      } else {
+        if let oldValue = self.valueForKey[key] {
+          self.keyForValue[oldValue] = nil
+          self.valueForKey[key] = nil
+        }
+      }
+
+      assert(valueForKey.count == keyForValue.count,
+             "forward count: \(valueForKey.count), backward count: \(keyForValue.count), \(self)")
+    }
+  }
+
+  /// Retrieves the key associated with the given value if found in the
+  /// dictionary, or `nil` if the value is not found.
+  ///
+  /// - Parameter value: the value to find in the dictionary.
+  /// - Returns: the key associated with `value` if `value` is in the
+  ///   dictionary, or `nil` otherwise.
+  public func key(_ value: Value) -> Key? {
+    return keyForValue[value]
+  }
+}

--- a/Support/CMakeLists.txt
+++ b/Support/CMakeLists.txt
@@ -1,4 +1,5 @@
 add_library(ModelSupport
+  BijectiveDictionary.swift
   Checkpoints/CheckpointIndexReader.swift
   Checkpoints/CheckpointReader.swift
   Checkpoints/Protobufs/tensor_bundle.pb.swift

--- a/Tests/CMakeLists.txt
+++ b/Tests/CMakeLists.txt
@@ -3,6 +3,7 @@ add_subdirectory(DatasetsTests)
 add_subdirectory(FastStyleTransferTests)
 add_subdirectory(ImageClassificationTests)
 add_subdirectory(MiniGoTests)
+add_subdirectory(SupportTests)
 
 add_executable(ModelTests
   LinuxMain.swift)
@@ -12,6 +13,7 @@ target_link_libraries(ModelTests PRIVATE
   FastStyleTransferTests
   ImageClassificationTests
   MiniGoTests
+  SupportTests
   XCTest)
 
 add_test(NAME ModelTests

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -5,6 +5,7 @@ import MiniGoTests
 import FastStyleTransferTests
 import DatasetsTests
 import CheckpointTests
+import SupportTests
 
 var tests = [XCTestCaseEntry]()
 tests += ImageClassificationTests.allTests()
@@ -12,4 +13,5 @@ tests += MiniGoTests.allTests()
 tests += FastStyleTransferTests.allTests()
 tests += DatasetsTests.allTests()
 tests += CheckpointTests.allTests()
+tests += SupportTests.allTests()
 XCTMain(tests)

--- a/Tests/SupportTests/CMakeLists.txt
+++ b/Tests/SupportTests/CMakeLists.txt
@@ -1,0 +1,8 @@
+add_library(SupportTests
+  SupportTests.swift
+  XCTestManifests.swift)
+set_target_properties(SupportTests PROPERTIES
+  RUNTIME_OUTPUT_DIRECTORY $<TARGET_FILE_DIR:ModelTests>
+  LIBRARY_OUTPUT_DIRECTORY $<TARGET_FILE_DIR:ModelTests>)
+target_link_libraries(SupportTests PUBLIC
+  ModelSupport)

--- a/Tests/SupportTests/SupportTests.swift
+++ b/Tests/SupportTests/SupportTests.swift
@@ -1,0 +1,71 @@
+import XCTest
+import ModelSupport
+
+final class SupportTests: XCTestCase {
+    func testBijectiveDictionaryConstruct() {
+      let _: BijectiveDictionary<Int, String> =
+          BijectiveDictionary([1: "one", 2: "two"])
+
+      let dictionary: [Int:String] = [1: "one", 2: "two"]
+      let _: BijectiveDictionary<Int, String> =
+          BijectiveDictionary(dictionary)
+
+      let array: [(Int, String)] = [(1, "one"), (2, "two")]
+      let _: BijectiveDictionary<Int, String> =
+          BijectiveDictionary(array)
+    }
+
+    func testBijectiveDictionaryCount() {
+      let map: BijectiveDictionary<Int, String> =
+          BijectiveDictionary([1: "one", 2: "two"])
+      XCTAssertEqual(map.count, 2)
+    }
+
+    func testBijectiveDictionarySubscript() {
+      let map: BijectiveDictionary<Int, String> =
+          BijectiveDictionary([1: "one", 2: "two"])
+      XCTAssertEqual(map[1], "one")
+      XCTAssertEqual(map.key("one"), 1)
+    }
+
+    func testBijectiveDictionaryDeletion() {
+      var map: BijectiveDictionary<Int, String> =
+          BijectiveDictionary([1: "one", 2: "two"])
+      XCTAssertEqual(map.count, 2)
+
+      map[2] = nil
+
+      XCTAssertEqual(map.count, 1)
+      XCTAssertEqual(map[1], "one")
+      XCTAssertEqual(map.key("one"), 1)
+    }
+
+    func testBijectiveDictionaryRemapping() {
+      // 1 -> "two", 2 -> "four"
+      var map: BijectiveDictionary<Int, String> =
+          BijectiveDictionary([1: "two", 2: "four"])
+      XCTAssertEqual(map.count, 2)
+
+      // 1 -> "three", 2 -> "four"
+      map[1] = "three"
+
+      XCTAssertEqual(map.count, 2)
+      XCTAssertEqual(map[1], "three")
+      XCTAssertEqual(map[2], "four")
+
+      // 2 -> "three"
+      map[2] = "three"
+
+      XCTAssertEqual(map.count, 1)
+      XCTAssertEqual(map[2], "three")
+    }
+
+    static var allTests = [
+        ("testBijectiveDictionaryConstruct", testBijectiveDictionaryConstruct),
+        ("testBijectiveDictionaryCount", testBijectiveDictionaryCount),
+        ("testBijectiveDictionarySubscript", testBijectiveDictionarySubscript),
+        ("testBijectiveDictionaryDeletion", testBijectiveDictionaryDeletion),
+        ("testBijectiveDictionaryRemapping", testBijectiveDictionaryRemapping),
+    ]
+}
+

--- a/Tests/SupportTests/XCTestManifests.swift
+++ b/Tests/SupportTests/XCTestManifests.swift
@@ -1,0 +1,24 @@
+// Copyright 2019 The TensorFlow Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import XCTest
+
+#if !os(macOS)
+public func allTests() -> [XCTestCaseEntry] {
+    return [
+        testCase(SupportTests.allTests),
+    ]
+}
+#endif
+


### PR DESCRIPTION
This allows us to map from key or value to their respective inverses.
As this is a common operation, place this into the Support module.