### PR TITLE
Add zero init for last BN and don't use bias

### DIFF
--- a/Models/ImageClassification/ResNet.swift
+++ b/Models/ImageClassification/ResNet.swift
@@ -33,7 +33,7 @@ public struct ConvBN: Layer {
         strides: (Int, Int) = (1, 1),
         padding: Padding = .valid
     ) {
-        self.conv = Conv2D(filterShape: filterShape, strides: strides, padding: padding)
+        self.conv = Conv2D(filterShape: filterShape, strides: strides, padding: padding, useBias: false)
         self.norm = BatchNorm(featureCount: filterShape.3, momentum: 0.9, epsilon: 1e-5)
     }
 


### PR DESCRIPTION
As @pschuh mentioned to me, ResNet V2 did not have the zero init for the last BatchNorm layers, so this PR addresses that.
Also, now that https://github.com/tensorflow/swift-apis/pull/674 has landed in the nightlies, we can set the flag to not use bias in all the convolutional layers of both ResNet.