### PR TITLE
Added an optional argument to the function loadCIFARFile making normalization of CIFAR images optional

### DIFF
--- a/Datasets/CIFAR10/CIFAR10.swift
+++ b/Datasets/CIFAR10/CIFAR10.swift
@@ -106,9 +106,9 @@ func loadCIFARFile(named name: String, in directory: URL, normalize: Bool = true
         
 }
 
-func loadCIFARTrainingFiles(localStorageDirectory: URL) -> LabeledExample {
+func loadCIFARTrainingFiles(localStorageDirectory: URL, normalize: Bool = true) -> LabeledExample {
     let data = (1..<6).map {
-        loadCIFARFile(named: "data_batch_\($0).bin", in: localStorageDirectory)
+        loadCIFARFile(named: "data_batch_\($0).bin", in: localStorageDirectory, normalize: normalize)
     }
     return LabeledExample(
         label: Tensor(concatenating: data.map { $0.label }, alongAxis: 0),
@@ -116,6 +116,6 @@ func loadCIFARTrainingFiles(localStorageDirectory: URL) -> LabeledExample {
     )
 }
 
-func loadCIFARTestFile(localStorageDirectory: URL) -> LabeledExample {
-    return loadCIFARFile(named: "test_batch.bin", in: localStorageDirectory)
+func loadCIFARTestFile(localStorageDirectory: URL, normalize: Bool = true) -> LabeledExample {
+    return loadCIFARFile(named: "test_batch.bin", in: localStorageDirectory, normalize: normalize)
 }

--- a/Datasets/CIFAR10/CIFAR10.swift
+++ b/Datasets/CIFAR10/CIFAR10.swift
@@ -88,17 +88,15 @@ func loadCIFARFile(named name: String, in directory: URL, normalizing: Bool = tr
     let images = Tensor<UInt8>(shape: [imageCount, 3, 32, 32], scalars: bytes)
 
     // Transpose from the CIFAR-provided N(CHW) to TF's default NHWC.
-    let imageTensor = Tensor<Float>(images.transposed(permutation: [0, 2, 3, 1]))
+    var imageTensor = Tensor<Float>(images.transposed(permutation: [0, 2, 3, 1]))
 
     if normalizing {
         let mean = Tensor<Float>([0.485, 0.456, 0.406])
         let std = Tensor<Float>([0.229, 0.224, 0.225])
-        let imagesNormalized = ((imageTensor / 255.0) - mean) / std
-        return LabeledExample(label: Tensor<Int32>(labelTensor), data: imagesNormalized)
+        imageTensor = ((imageTensor / 255.0) - mean) / std
     }
-    else {
-        return LabeledExample(label: Tensor<Int32>(labelTensor), data: imageTensor)
-    }
+    
+    return LabeledExample(label: Tensor<Int32>(labelTensor), data: imageTensor)
         
 }
 

--- a/Datasets/CIFAR10/CIFAR10.swift
+++ b/Datasets/CIFAR10/CIFAR10.swift
@@ -62,7 +62,7 @@ func downloadCIFAR10IfNotPresent(from location: URL, to directory: URL) {
         remoteRoot: location.deletingLastPathComponent(), localStorageDirectory: directory)
 }
 
-func loadCIFARFile(named name: String, in directory: URL) -> LabeledExample {
+func loadCIFARFile(named name: String, in directory: URL, normalize: Bool = true) -> LabeledExample {
     let path = directory.appendingPathComponent("cifar-10-batches-bin/\(name)").path
 
     let imageCount = 10000
@@ -94,9 +94,16 @@ func loadCIFARFile(named name: String, in directory: URL) -> LabeledExample {
 
     let mean = Tensor<Float>([0.485, 0.456, 0.406])
     let std = Tensor<Float>([0.229, 0.224, 0.225])
-    let imagesNormalized = ((imageTensor / 255.0) - mean) / std
 
-    return LabeledExample(label: Tensor<Int32>(labelTensor), data: imagesNormalized)
+    // Normalize the images according to the input boolean flag passed (Default to 'true')
+    if normalize {
+        let imagesNormalized = ((imageTensor / 255.0) - mean) / std
+        return LabeledExample(label: Tensor<Int32>(labelTensor), data: imagesNormalized)
+    }
+    else {
+        return LabeledExample(label: Tensor<Int32>(labelTensor), data: imageTensor)
+    }
+        
 }
 
 func loadCIFARTrainingFiles(localStorageDirectory: URL) -> LabeledExample {

--- a/Datasets/CIFAR10/CIFAR10.swift
+++ b/Datasets/CIFAR10/CIFAR10.swift
@@ -28,17 +28,16 @@ public struct CIFAR10: ImageClassificationDataset {
     public let testExampleCount = 10000
 
     public init() {
-        self.init(
-            normalizing: true, 
+        self.init( 
             remoteBinaryArchiveLocation: URL(
-                string: "https://www.cs.toronto.edu/~kriz/cifar-10-binary.tar.gz")!)
+                string: "https://www.cs.toronto.edu/~kriz/cifar-10-binary.tar.gz")!, normalizing: true)
     }
 
-    public init(remoteBinaryArchiveLocation: URL) {
+    public init(remoteBinaryArchiveLocation: URL, normalizing: Bool) {
         self.init(
             remoteBinaryArchiveLocation: remoteBinaryArchiveLocation,
             localStorageDirectory: FileManager.default.temporaryDirectory.appendingPathComponent(
-                "CIFAR10", isDirectory: true))
+                "CIFAR10", isDirectory: true), normalizing: normalizing)
     }
 
     public init(remoteBinaryArchiveLocation: URL, localStorageDirectory: URL, normalizing: Bool) {

--- a/Datasets/CIFAR10/CIFAR10.swift
+++ b/Datasets/CIFAR10/CIFAR10.swift
@@ -36,13 +36,12 @@ public struct CIFAR10: ImageClassificationDataset {
 
     public init(remoteBinaryArchiveLocation: URL) {
         self.init(
-            normalizing: Bool = true, 
             remoteBinaryArchiveLocation: remoteBinaryArchiveLocation,
             localStorageDirectory: FileManager.default.temporaryDirectory.appendingPathComponent(
                 "CIFAR10", isDirectory: true))
     }
 
-    public init(remoteBinaryArchiveLocation: URL, localStorageDirectory: URL) {
+    public init(remoteBinaryArchiveLocation: URL, localStorageDirectory: URL, normalizing: Bool) {
         downloadCIFAR10IfNotPresent(from: remoteBinaryArchiveLocation, to: localStorageDirectory)
         self.trainingDataset = Dataset<LabeledExample>(
             elements: loadCIFARTrainingFiles(localStorageDirectory: localStorageDirectory, normalizing: normalizing))

--- a/Datasets/CIFAR10/CIFAR10.swift
+++ b/Datasets/CIFAR10/CIFAR10.swift
@@ -33,14 +33,12 @@ public struct CIFAR10: ImageClassificationDataset {
                 string: "https://www.cs.toronto.edu/~kriz/cifar-10-binary.tar.gz")!, normalizing: true)
     }
 
-    public init(remoteBinaryArchiveLocation: URL, normalizing: Bool) {
-        self.init(
-            remoteBinaryArchiveLocation: remoteBinaryArchiveLocation,
-            localStorageDirectory: FileManager.default.temporaryDirectory.appendingPathComponent(
-                "CIFAR10", isDirectory: true), normalizing: normalizing)
-    }
-
-    public init(remoteBinaryArchiveLocation: URL, localStorageDirectory: URL, normalizing: Bool) {
+    public init(
+        remoteBinaryArchiveLocation: URL, 
+        localStorageDirectory: URL = FileManager.default.temporaryDirectory.appendingPathComponent(
+                "CIFAR10", isDirectory: true), 
+        normalizing: Bool) 
+    {
         downloadCIFAR10IfNotPresent(from: remoteBinaryArchiveLocation, to: localStorageDirectory)
         self.trainingDataset = Dataset<LabeledExample>(
             elements: loadCIFARTrainingFiles(localStorageDirectory: localStorageDirectory, normalizing: normalizing))

--- a/Tests/DatasetsTests/CIFAR10/CIFAR10Tests.swift
+++ b/Tests/DatasetsTests/CIFAR10/CIFAR10Tests.swift
@@ -16,6 +16,7 @@ final class CIFAR10Tests: XCTestCase {
 
     func testCreateCIFAR10() {
         let dataset = CIFAR10(
+            normalizing: Bool = true, 
             remoteBinaryArchiveLocation:
                 URL(
                     string:

--- a/Tests/DatasetsTests/CIFAR10/CIFAR10Tests.swift
+++ b/Tests/DatasetsTests/CIFAR10/CIFAR10Tests.swift
@@ -15,13 +15,12 @@ final class CIFAR10Tests: XCTestCase {
     }
 
     func testCreateCIFAR10() {
-        let dataset = CIFAR10(
-            normalizing: Bool = true, 
+        let dataset = CIFAR10( 
             remoteBinaryArchiveLocation:
                 URL(
                     string:
                         "https://storage.googleapis.com/s4tf-hosted-binaries/datasets/CIFAR10/cifar-10-binary.tar.gz"
-                )!
+                )!, normalizing: true
         )
         verify(dataset)
     }


### PR DESCRIPTION
 Addressing the request raised in #285 for adding an option to not normalize CIFAR10 images.
Added an optional argument to the function loadCIFARFile making normalization of CIFAR images optional. The default is to normalize the images so that the function is compatible with the previous versions of the code.
I haven't seen a PR for this even though the issue was more than a month older, so I did it myself.
Please review and let me know.