### PR TITLE
Using ArgumentParser to parse CLI options for Benchmarks target.

### DIFF
--- a/Benchmarks/main.swift
+++ b/Benchmarks/main.swift
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import Commander
+import ArgumentParser
 import ModelSupport
 
 /// Collect benchmark results and print them to stdout using a given printing style
@@ -49,72 +49,30 @@ func runBenchmark(
     }
 }
 
-let main =
-    Group { group in
-        group.command(
-            "measure-all",
-            Flag("json", description: "Output json instead of plain text."),
-            description: "Run all benchmarks with default settings."
-        ) { useJSON in
-            let style: PrintingStyle = useJSON ? .json : .plainText
-            for (name, benchmarkModel) in benchmarkModels {
-                runBenchmark(
-                    named: name,
-                    settings: benchmarkModel.defaultTrainingSettings,
-                    variety: .trainingTime,
-                    style: style)
-                runBenchmark(
-                    named: name,
-                    settings: benchmarkModel.defaultInferenceSettings,
-                    variety: .inferenceThroughput,
-                    style: style)
-            }
-        }
-        group.command(
-            "measure",
-            Flag("training", description: "Run training benchmark."),
-            Flag("inference", description: "Run inference benchmark."),
-            Option("benchmark", default: "", description: "Name of the benchmark to run."),
-            Option("batches", default: -1, description: "Number of batches."),
-            Option("batchSize", default: -1, description: "Size of a single batch."),
-            Option("iterations", default: -1, description: "Number of benchmark iterations."),
-            Option("epochs", default: -1, description: "Number of training epochs."),
-            Flag("json", description: "Output json instead of plain text."),
-            description: "Run a single benchmark with provided settings."
-        ) { (trainingFlag, inferenceFlag, name, batches, batchSize, iterations, epochs, useJSON) in
-            let style: PrintingStyle = useJSON ? .json : .plainText
-            let settings = BenchmarkSettings(
-                batches: batches,
-                batchSize: batchSize,
-                iterations: iterations,
-                epochs: epochs)
-            if !trainingFlag && !inferenceFlag {
-                printError("Must specify either --training xor --inference benchmark variety.")
-            } else if trainingFlag && inferenceFlag {
-                printError("Can't specify both --training and --inference benchmark variety.")
-            } else if name == "" {
-                printError("Must provide a --benchmark to run.")
-            } else {
-                var variety: BenchmarkVariety
-                if trainingFlag {
-                    variety = .trainingTime
-                } else {
-                    assert(inferenceFlag)
-                    variety = .inferenceThroughput
-                }
-                runBenchmark(
-                    named: name,
-                    settings: settings,
-                    variety: variety,
-                    style: style
-                )
-            }
-        }
-        group.command(
-            "list-defaults",
-            Flag("json"),
-            description: "List all available benchmarks and their default settings."
-        ) { useJSON in
+struct BenchmarkCommand: ParsableCommand {
+    static var configuration = CommandConfiguration(
+        commandName: "Benchmarks",
+        abstract: """
+            Runs series of benchmarks against a variety of models
+            in the swift-models repository.
+            """,
+        subcommands: [
+            ListDefaultsSubcommand.self,
+            MeasureSubcommand.self,
+            MeasureAllSubCommand.self
+        ])
+}
+
+extension BenchmarkCommand {
+    struct ListDefaultsSubcommand: ParsableCommand {
+        static var configuration = CommandConfiguration(
+            commandName: "list-defaults",
+            abstract: "List all available benchmarks and their default settings.")
+
+        @Flag(name: .customLong("json"), help: "Output json instead of plain text.")
+        var useJSON: Bool
+
+        func run() throws {
             let style: PrintingStyle = useJSON ? .json : .plainText
             for (name, benchModel) in benchmarkModels {
                 let trainingConfiguration =
@@ -132,5 +90,101 @@ let main =
             }
         }
     }
+}
 
-main.run()
+extension BenchmarkCommand {
+    struct MeasureSubcommand: ParsableCommand {
+        static var configuration = CommandConfiguration(
+            commandName: "measure",
+            abstract: "Run a single benchmark with provided settings."
+        )
+
+        @Flag(help: "Run training benchmark.")
+        var training: Bool
+
+        @Flag(help: "Run inference benchmark.")
+        var inference: Bool
+
+        @Option(default: "", help: "Name of the benchmark to run.")
+        var benchmark: String
+
+        @Option(default: -1, help: "Number of batches.")
+        var batches: Int
+
+        @Option(default: -1, help: "Size of a single batch.")
+        var batchSize: Int
+
+        @Option(default: -1, help: "Number of benchmark iterations.")
+        var iterations: Int
+
+        @Option(default: -1, help: "Number of training epochs.")
+        var epochs: Int
+
+        @Flag(name: .customLong("json"), help: "Output json instead of plain text.")
+        var useJSON: Bool
+
+        func validate() throws {
+            guard training || inference else {
+                throw ValidationError(
+                    "Must specify either --training or --inference benchmark variety.")
+            }
+
+            guard !(training && inference) else {
+                throw ValidationError(
+                    "Can't specify both --training and --inference benchmark variety.")
+            }
+
+            guard !benchmark.isEmpty else {
+                throw ValidationError("Must provide a --benchmark to run.")
+            }
+        }
+
+        func run() throws {
+            let style: PrintingStyle = useJSON ? .json : .plainText
+            let settings = BenchmarkSettings(
+                batches: batches,
+                batchSize: batchSize,
+                iterations: iterations,
+                epochs: epochs)
+
+            let variety: BenchmarkVariety = training ? .trainingTime : .inferenceThroughput
+            runBenchmark(
+                named: benchmark,
+                settings: settings,
+                variety: variety,
+                style: style
+            )
+        }
+    }
+}
+
+extension BenchmarkCommand {
+    struct MeasureAllSubCommand: ParsableCommand {
+        static var configuration = CommandConfiguration(
+            commandName: "measure-all",
+            abstract: "Run all benchmarks with default settings."
+        )
+
+        @Flag(name: .customLong("json"),
+        help: "Output json instead of plain text.")
+        var useJSON: Bool
+
+        func run() throws {
+            let style: PrintingStyle = useJSON ? .json : .plainText
+            for (name, benchmarkModel) in benchmarkModels {
+                runBenchmark(
+                    named: name,
+                    settings: benchmarkModel.defaultTrainingSettings,
+                    variety: .trainingTime,
+                    style: style)
+                runBenchmark(
+                    named: name,
+                    settings: benchmarkModel.defaultInferenceSettings,
+                    variety: .inferenceThroughput,
+                    style: style)
+            }
+        }
+    }
+}
+
+BenchmarkCommand.main()

--- a/Benchmarks/main.swift
+++ b/Benchmarks/main.swift
@@ -111,7 +111,7 @@ extension BenchmarkCommand {
         @Option(default: -1, help: "Number of batches.")
         var batches: Int
 
-        @Option(default: -1, help: "Size of a single batch.")
+        @Option(name: .customLong("batchSize"), default: -1, help: "Size of a single batch.")
         var batchSize: Int
 
         @Option(default: -1, help: "Number of benchmark iterations.")

--- a/Package.resolved
+++ b/Package.resolved
@@ -2,21 +2,12 @@
   "object": {
     "pins": [
       {
-        "package": "Commander",
-        "repositoryURL": "https://github.com/kylef/Commander.git",
+        "package": "swift-argument-parser",
+        "repositoryURL": "https://github.com/apple/swift-argument-parser",
         "state": {
           "branch": null,
-          "revision": "4b6133c3071d521489a80c38fb92d7983f19d438",
-          "version": "0.9.1"
-        }
-      },
-      {
-        "package": "Spectre",
-        "repositoryURL": "https://github.com/kylef/Spectre.git",
-        "state": {
-          "branch": null,
-          "revision": "f14ff47f45642aa5703900980b014c2e9394b6e5",
-          "version": "0.9.0"
+          "revision": "f6ac7b8118ff5d1bc0faee7f37bf6f8fd8f95602",
+          "version": "0.0.1"
         }
       },
       {

--- a/Package.swift
+++ b/Package.swift
@@ -33,7 +33,7 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/apple/swift-protobuf.git", from: "1.7.0"),
-        .package(url: "https://github.com/kylef/Commander.git", from: "0.9.1"),
+        .package(url: "https://github.com/apple/swift-argument-parser", .upToNextMinor(from: "0.0.1")),
     ],
     targets: [
         .target(name: "Batcher", path: "Batcher"),
@@ -91,7 +91,7 @@ let package = Package(
         .testTarget(name: "FastStyleTransferTests", dependencies: ["FastStyleTransfer"]),
         .target(
             name: "Benchmarks",
-            dependencies: ["Datasets", "ModelSupport", "ImageClassificationModels", "Commander"],
+            dependencies: ["Datasets", "ModelSupport", "ImageClassificationModels", "ArgumentParser"],
             path: "Benchmarks"),
         .testTarget(name: "CheckpointTests", dependencies: ["ModelSupport"]),
         .target(


### PR DESCRIPTION
This PR maintains the same interface that was defined with Commander,
so it is a NFC in a sense.

Resolves #354.