### PR TITLE
build: build swift-protobuf and SwiftWin32

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,7 +7,55 @@ list(APPEND CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/cmake/modules)
 set(CMAKE_Swift_MODULE_DIRECTORY ${CMAKE_BINARY_DIR}/swift)
 
 include(CTest)
+include(ExternalProject)
 include(SwiftSupport)
+
+# Dependencies
+if(CMAKE_SYSTEM_NAME STREQUAL Windows)
+  ExternalProject_Add(swift-win32
+    GIT_REPOSITORY git://github.com/compnerd/swift-win32.git
+    GIT_TAG 91ad76252c5ea7be992d23c8ca7710c81fc9dca8
+    CMAKE_ARGS
+      -DBUILD_SHARED_LIBS=YES
+      -DCMAKE_Swift_FLAGS=${CMAKE_Swift_FLAGS}
+    INSTALL_COMMAND
+      ""
+    BUILD_BYPRODUCTS
+      <BINARY_DIR>/${CMAKE_SHARED_LIBRARY_PREFIX}SwiftWin32${CMAKE_SHARED_LIBRARY_SUFFIX}
+      <BINARY_DIR>/${CMAKE_IMPORT_LIBRARY_PREFIX}SwiftWin32${CMAKE_IMPORT_LIBRARY_SUFFIX}
+    STEP_TARGETS build)
+  ExternalProject_Get_Property(swift-win32 BINARY_DIR)
+
+  add_library(SwiftWin32 SHARED IMPORTED)
+  file(MAKE_DIRECTORY ${BINARY_DIR}/swift)
+  set_target_properties(SwiftWin32 PROPERTIES
+    IMPORTED_LOCATION ${BINARY_DIR}/${CMAKE_SHARED_LIBRARY_PREFIX}SwiftWin32${CMAKE_SHARED_LIBRARY_SUFFIX}
+    IMPORTED_IMPLIB ${BINARY_DIR}/${CMAKE_IMPORT_LIBRARY_PREFIX}SwiftWin32${CMAKE_IMPORT_LIBRARY_SUFFIX}
+    INTERFACE_INCLUDE_DIRECTORIES ${BINARY_DIR}/swift)
+  add_dependencies(SwiftWin32 swift-win32-build)
+endif()
+
+ExternalProject_Add(swift-protobuf
+  GIT_REPOSITORY git://github.com/apple/swift-protobuf.git
+  GIT_TAG master
+  CMAKE_ARGS
+    -DBUILD_SHARED_LIBS=YES
+    -DCMAKE_Swift_FLAGS=${CMAKE_Swift_FLAGS}
+  INSTALL_COMMAND
+    ""
+  BUILD_BYPRODUCTS
+    <BINARY_DIR>/Sources/SwiftProtobuf/${CMAKE_SHARED_LIBRARY_PREFIX}SwiftProtobuf${CMAKE_SHARED_LIBRARY_SUFFIX}
+    <BINARY_DIR>/Sources/SwiftProtobuf/${CMAKE_IMPORT_LIBRARY_PREFIX}SwiftProtobuf${CMAKE_IMPORT_LIBRARY_SUFFIX}
+  STEP_TARGETS build)
+ExternalProject_Get_Property(swift-protobuf BINARY_DIR)
+
+add_library(SwiftProtobuf SHARED IMPORTED)
+file(MAKE_DIRECTORY ${BINARY_DIR}/swift)
+set_target_properties(SwiftProtobuf PROPERTIES
+  IMPORTED_LOCATION ${BINARY_DIR}/Sources/SwiftProtobuf/${CMAKE_SHARED_LIBRARY_PREFIX}SwiftProtobuf${CMAKE_SHARED_LIBRARY_SUFFIX}
+  IMPORTED_IMPLIB ${BINARY_DIR}/Sources/SwiftProtobuf/${CMAKE_IMPORT_LIBRARY_PREFIX}SwiftProtobuf${CMAKE_IMPORT_LIBRARY_SUFFIX}
+  INTERFACE_INCLUDE_DIRECTORIES ${BINARY_DIR}/swift)
+add_dependencies(SwiftProtobuf swift-protobuf-build)
 
 add_subdirectory(Support)
 add_subdirectory(Batcher)

--- a/Support/CMakeLists.txt
+++ b/Support/CMakeLists.txt
@@ -21,6 +21,8 @@ set_target_properties(ModelSupport PROPERTIES
   INTERFACE_INCLUDE_DIRECTORIES ${CMAKE_Swift_MODULE_DIRECTORY})
 target_compile_options(ModelSupport PRIVATE
   $<$<BOOL:${BUILD_TESTING}>:-enable-testing>)
+target_link_libraries(ModelSupport PUBLIC
+  SwiftProtobuf)
 
 
 install(TARGETS ModelSupport

--- a/Transformer/CMakeLists.txt
+++ b/Transformer/CMakeLists.txt
@@ -20,6 +20,7 @@ if(CMAKE_SYSTEM_NAME STREQUAL Windows)
     UI/Windows/main.swift
     TransformerLoop.swift)
   target_link_libraries(TransformerUI PRIVATE
+    SwiftWin32
     Foundation
     TextModels
     Transformer


### PR DESCRIPTION
Use CMake to fetch and build the dependencies.  This allows us to build
the demos without having to manually build the dependencies and alter
the flags.