### PR TITLE
Transformer: merge pair fixes

### DIFF
--- a/Support/Text/BytePairEncoder.swift
+++ b/Support/Text/BytePairEncoder.swift
@@ -24,7 +24,8 @@ public struct BytePairEncoder {
     /// A cache used to store encoded tokens and thus speed up encoding.
     //  private var cache: [String: [String]]
 
-    public init(vocabularyFile: URL, mergesFile: URL,
+    public init(
+        vocabularyFile: URL, mergesFile: URL,
         encoding: String.Encoding = .utf8
     ) throws {
         let vocabulary: Vocabulary = try Vocabulary(fromJSONFile: vocabularyFile)

--- a/Support/Text/BytePairEncoder.swift
+++ b/Support/Text/BytePairEncoder.swift
@@ -72,7 +72,7 @@ public struct BytePairEncoder {
         switch variant {
         case .gpt2:
             // Split into parts before encoding.
-            let unencodedTokens: [String] = BytePairEncoder.splittingWithDelimiters(
+            let unencodedTokens = BytePairEncoder.splittingWithDelimiters(
                 token: token,
                 glossaryRegex: BytePairEncoder.gpt2GlossaryRegex,
                 variant: .gpt2)
@@ -107,7 +107,7 @@ public struct BytePairEncoder {
         }
 
         // Check if the new word parts are in the vocabulary, and backtrack if necessary.
-        let encoded: [String] = parts.flatMap { part -> [String] in
+        let encoded = parts.flatMap { part -> [String] in
             if vocabulary.contains(part) { return [part] }
             return splitRecursively(part)
         }

--- a/Support/Text/BytePairEncoder.swift
+++ b/Support/Text/BytePairEncoder.swift
@@ -24,21 +24,25 @@ public struct BytePairEncoder {
     /// A cache used to store encoded tokens and thus speed up encoding.
     //  private var cache: [String: [String]]
 
-    public init(fromVocabularyFileURL vocabularyFile: URL, fromMergesFileURL mergesFile: URL,
-        encoding: String.Encoding = .utf8) throws {
+    public init(
+        fromVocabularyFileURL vocabularyFile: URL, fromMergesFileURL mergesFile: URL,
+        encoding: String.Encoding = .utf8
+    ) throws {
         let vocabulary: Vocabulary = try Vocabulary(fromJSONFile: vocabularyFile)
 
         let lines: ArraySlice<String> =
             try String(contentsOfFile: mergesFile.path, encoding: encoding)
-                .components(separatedBy: .newlines)
-                .dropFirst()
+            .components(separatedBy: .newlines)
+            .dropFirst()
 
-        let pairs: [BytePairEncoder.Pair:Int] =
-            Dictionary<BytePairEncoder.Pair,Int>(uniqueKeysWithValues: lines.enumerated().compactMap { (index, line) -> (BytePairEncoder.Pair, Int)? in
-          let tokens = line.split(separator: " ")
-          guard tokens.count >= 2 else { return nil }
-          return (BytePairEncoder.Pair(String(tokens[0]), String(tokens[1])), index)
-        })
+        let pairs: [BytePairEncoder.Pair: Int] =
+            [BytePairEncoder.Pair: Int](
+                uniqueKeysWithValues: lines.enumerated().compactMap {
+                    (index, line) -> (BytePairEncoder.Pair, Int)? in
+                    let tokens = line.split(separator: " ")
+                    guard tokens.count >= 2 else { return nil }
+                    return (BytePairEncoder.Pair(String(tokens[0]), String(tokens[1])), index)
+                })
 
         self.init(vocabulary: vocabulary, mergePairs: pairs)
     }

--- a/Support/Text/BytePairEncoder.swift
+++ b/Support/Text/BytePairEncoder.swift
@@ -24,11 +24,12 @@ public struct BytePairEncoder {
     /// A cache used to store encoded tokens and thus speed up encoding.
     //  private var cache: [String: [String]]
 
-    public init(fromFileURL file: URL, encoding: String.Encoding = .utf8) throws {
-        let vocabulary: Vocabulary = try Vocabulary(fromJSONFile: file)
+    public init(fromVocabularyFileURL vocabularyFile: URL, fromMergesFileURL mergesFile: URL,
+        encoding: String.Encoding = .utf8) throws {
+        let vocabulary: Vocabulary = try Vocabulary(fromJSONFile: vocabularyFile)
 
         let lines: ArraySlice<String> =
-            try String(contentsOfFile: file.path, encoding: encoding)
+            try String(contentsOfFile: mergesFile.path, encoding: encoding)
                 .components(separatedBy: .newlines)
                 .dropFirst()
 
@@ -62,21 +63,25 @@ public struct BytePairEncoder {
     public func encode(token: String, variant: Variant? = .roberta) -> [String] {
         // if let cached = cache[token] { return cached }
         // let token = " " + token
-        var parts: [String]
-        var encodedParts: [String]
-        var encoded: [String]
+        var parts = [String]()
 
         switch variant {
         case .gpt2:
             // Split into parts before encoding.
-            parts = BytePairEncoder.splittingWithDelimiters(
+            let unencodedTokens: [String] = BytePairEncoder.splittingWithDelimiters(
                 token: token,
                 glossaryRegex: BytePairEncoder.gpt2GlossaryRegex,
                 variant: .gpt2)
-            if parts.count < 2 {
-                // Encode the full token and return.
-                return parts.map { BytePairEncoder.encodedToken($0) }
+            // Encode each token.
+            let tokens = unencodedTokens.map({ BytePairEncoder.encodedToken($0) })
+            // Separate each character.
+            for token in tokens {
+                for i in (0..<token.count) {
+                    let index = token.index(token.startIndex, offsetBy: i)
+                    parts.append(String(token[index]))
+                }
             }
+            if parts.count < 2 { return parts }
         case .roberta, .none:
             // Encode before splitting into parts.
             let encodedToken = BytePairEncoder.encodedToken(token)
@@ -97,18 +102,8 @@ public struct BytePairEncoder {
             pairs = (0..<parts.count - 1).map { index in Pair(parts[index], parts[index + 1]) }
         }
 
-        switch variant {
-        case .gpt2:
-            // Encode each token.
-            encodedParts = parts.map({ BytePairEncoder.encodedToken($0) })
-
-        case .roberta, .none:
-            // Encoding has already occurred.
-            encodedParts = parts
-
-        }
         // Check if the new word parts are in the vocabulary, and backtrack if necessary.
-        encoded = encodedParts.flatMap { part -> [String] in
+        let encoded: [String] = parts.flatMap { part -> [String] in
             if vocabulary.contains(part) { return [part] }
             return splitRecursively(part)
         }

--- a/Support/Text/BytePairEncoder.swift
+++ b/Support/Text/BytePairEncoder.swift
@@ -24,8 +24,7 @@ public struct BytePairEncoder {
     /// A cache used to store encoded tokens and thus speed up encoding.
     //  private var cache: [String: [String]]
 
-    public init(
-        fromVocabularyFileURL vocabularyFile: URL, fromMergesFileURL mergesFile: URL,
+    public init(vocabularyFile: URL, mergesFile: URL,
         encoding: String.Encoding = .utf8
     ) throws {
         let vocabulary: Vocabulary = try Vocabulary(fromJSONFile: vocabularyFile)

--- a/Transformer/TransformerLoop.swift
+++ b/Transformer/TransformerLoop.swift
@@ -89,9 +89,9 @@ internal class GPT2 {
     }
 
     func embedding(for string: String) -> Tensor<Int32> {
-        let tokens: [String] = bpe.encode(token: string, variant: .gpt2)
+        let tokens = bpe.encode(token: string, variant: .gpt2)
         // TODO(michellecasbon): Decide how to prevent OOV or choose a better ID (probably not 0).
-        let ids: [Int32] = tokens.map { Int32(bpe.vocabulary.id(forToken: $0) ?? 0) }
+        let ids = tokens.map { Int32(bpe.vocabulary.id(forToken: $0) ?? 0) }
         return Tensor(shape: [1, ids.count], scalars: ids)
     }
 
@@ -108,7 +108,7 @@ internal class GPT2 {
             randomCategorialLogits: logits.squeezingShape(at: 1),
             sampleCount: 1)
 
-        let id: Int32 = Int32(seed[0][0])!
+        let id = Int32(seed[0][0])!
         if let token: String = bpe.vocabulary.token(forId: Int(id)) {
             return BytePairEncoder.decode(token: token)
         }

--- a/Transformer/TransformerLoop.swift
+++ b/Transformer/TransformerLoop.swift
@@ -73,12 +73,12 @@ internal class GPT2 {
 
         // Create bytepair encoder with loaded token mappings
         bpe = try BytePairEncoder(
-            fromVocabularyFileURL: vocabulary.file, fromMergesFileURL: merges.file)
+            vocabularyFile: vocabulary.file, mergesFile: merges.file)
 
         // ...
-        let seedId: Int32 = Int32(bpe.vocabulary.id(forToken: "<|endoftext|>")!)
+        let seedId = Int32(bpe.vocabulary.id(forToken: "<|endoftext|>")!)
         seed = Tensor(shape: [1, 1], scalars: [seedId])
-        let empty: Tensor<Float> =
+        let empty =
             Tensor<Float>(zeros: [
                 parameters.headCount, 0,
                 parameters.embeddingSize / parameters.headCount,


### PR DESCRIPTION
- Import merge pairs from the correct file
- Fix merge pair functionality to operate on characters instead of tokens
- Use vocabulary inside BytePairEncoder rather than a local variable
- Minor cleanup in TransformerLoop
- Lint