### PR TITLE
Adding option to disable checkpoint data CRC on read, slight optimization of CRC

### DIFF
--- a/Support/Checkpoints/CheckpointReader.swift
+++ b/Support/Checkpoints/CheckpointReader.swift
@@ -39,6 +39,9 @@ open class CheckpointReader {
     /// The names of the tensors stored in the checkpoint.
     public var tensorNames: [String] { [String](metadata.keys) }
 
+    /// A flag to disable CRC verification when loading, primarily for use in debug builds.
+    public var disableCRCVerification: Bool = false
+    
     /// Initializes the checkpoint reader from either a local or remote directory. If remote, 
     /// automatically downloads the checkpoint files into a temporary directory.
     ///
@@ -182,11 +185,13 @@ open class CheckpointReader {
         let tensorData = shardBytes.subdata(
             in: Int(bundleEntry.offset)..<Int(bundleEntry.offset + bundleEntry.size))
 
-        let readCRC32C = bundleEntry.crc32C
-        let calculatedCRC32C = tensorData.maskedCRC32C()
-        guard readCRC32C == calculatedCRC32C else {
-            fatalError(
-                "Tensor \(name) had a bad CRC, expected: \(calculatedCRC32C), read: \(readCRC32C).")
+        if !disableCRCVerification {
+            let readCRC32C = bundleEntry.crc32C
+            let calculatedCRC32C = tensorData.maskedCRC32C()
+            guard readCRC32C == calculatedCRC32C else {
+                fatalError(
+                    "Tensor \(name) had a bad CRC, expected: \(calculatedCRC32C), read: \(readCRC32C).")
+            }
         }
 
         let scalarArray = tensorData.withUnsafeBytes { pointer in
@@ -235,11 +240,18 @@ extension Data {
 
     func crc32C() -> UInt32 {
         var crc32: UInt32 = 0xFFFF_FFFF
-        let bytes = [UInt8](self)
-        for byte in bytes {
-            let lookupIndex = Int((crc32 ^ (UInt32(byte) & 0xFF)) & 0xFF)
-            crc32 = (crc32 >> 8) ^ Data.crc32CLookupTable[lookupIndex]
+
+        self.withUnsafeBytes { buffer in
+            let totalBytes = self.count
+            var index = 0
+            while index < totalBytes {
+                let byte = buffer[index]
+                let lookupIndex = Int((crc32 ^ (UInt32(byte) & 0xFF)) & 0xFF)
+                crc32 = (crc32 >> 8) ^ Data.crc32CLookupTable[lookupIndex]
+                index = index &+ 1
+            }
         }
+
         return crc32 ^ 0xFFFF_FFFF
     }
 

--- a/Support/Checkpoints/CheckpointReader.swift
+++ b/Support/Checkpoints/CheckpointReader.swift
@@ -39,8 +39,9 @@ open class CheckpointReader {
     /// The names of the tensors stored in the checkpoint.
     public var tensorNames: [String] { [String](metadata.keys) }
 
-    /// A flag to disable CRC verification when loading, primarily for use in debug builds.
-    public var disableCRCVerification: Bool = false
+    /// CRC verification during checkpoint loading is enabled by default, but can be selectively
+    /// disabled to speed up reads in debug builds or test cases.
+    public var isCRCVerificationEnabled: Bool = true
     
     /// Initializes the checkpoint reader from either a local or remote directory. If remote, 
     /// automatically downloads the checkpoint files into a temporary directory.
@@ -185,7 +186,7 @@ open class CheckpointReader {
         let tensorData = shardBytes.subdata(
             in: Int(bundleEntry.offset)..<Int(bundleEntry.offset + bundleEntry.size))
 
-        if !disableCRCVerification {
+        if isCRCVerificationEnabled {
             let readCRC32C = bundleEntry.crc32C
             let calculatedCRC32C = tensorData.maskedCRC32C()
             guard readCRC32C == calculatedCRC32C else {


### PR DESCRIPTION
The CRC verification within the CheckpointReader can severely slow down loading checkpoints in debug builds. It involves a tight loop that iterates over every byte in an often multi-megabyte binary representation of a tensor. Without the significant optimizations applied by the Swift compiler in release/optimized builds, this CRC function can be >120X slower in unoptimized builds. This can lead to minutes of loading time just to pull in a checkpoint within a debug build.

This adds the option to disable CRC verification on loading for the CheckpointReader, to be used in cases where you want to quickly iterate or test with an unoptimized build and know that you can rely on the fidelity of the checkpoint files.

Additionally, this performs some slight optimizations to the loop that allow the compiler to emit slightly faster loop code, leading to a ~20% speedup with release/optimized builds in the microbenchmarks I've run and an up to 2X improvement in debug/unoptimized builds.