### PR TITLE
Transformer: attempt to repair the Windows build

### DIFF
--- a/Transformer/CMakeLists.txt
+++ b/Transformer/CMakeLists.txt
@@ -5,12 +5,11 @@ target_link_libraries(TransformerDemo PRIVATE
 
 if(CMAKE_SYSTEM_NAME STREQUAL Windows)
   add_executable(TransformerUI
-    UI/Windows/main.swift
-    main.swift)
+    UI/Windows/main.swift)
   target_link_libraries(TransformerUI PRIVATE
-    SwiftWin32
-    Foundation
     TextModels
+    Foundation
+    SwiftWin32
     User32)
   add_custom_command(TARGET TransformerUI POST_BUILD
     COMMAND

--- a/Transformer/UI/Windows/main.swift
+++ b/Transformer/UI/Windows/main.swift
@@ -18,6 +18,8 @@ import SwiftWin32
 import Dispatch
 import Foundation
 
+import TextModels
+
 class MainWindowDelegate: WindowDelegate {
   func OnDestroy(_ hWnd: HWND?, _ wParam: WPARAM, _ lParam: LPARAM)
       -> LRESULT {


### PR DESCRIPTION
The second `main.swift` injected into the build is absolutely incorrect.
The `main.swift` from the target itself is the main file.

Import the additional TextModels, sort the link dependencies.