### PR TITLE
build: setup dependencies for the Windows build

### DIFF
--- a/Transformer/CMakeLists.txt
+++ b/Transformer/CMakeLists.txt
@@ -14,7 +14,9 @@ if(CMAKE_SYSTEM_NAME STREQUAL Windows)
     User32)
   add_custom_command(TARGET TransformerUI POST_BUILD
     COMMAND
-      ${CMAKE_COMMAND} -E copy_if_different ${CMAKE_CURRENT_SOURCE_DIR}/UI/Windows/TransformerUI.exe.manifest $<TARGET_FILE_DIR:TransformerUI>)
+      ${CMAKE_COMMAND} -E copy_if_different ${CMAKE_CURRENT_SOURCE_DIR}/UI/Windows/TransformerUI.exe.manifest $<TARGET_FILE_DIR:TransformerUI>
+    DEPENDS
+      ${CMAKE_CURRENT_SOURCE_DIR}/UI/Windows/TransformerUI.exe.manifest )
 endif()
 
 


### PR DESCRIPTION
Although the manifest is unlikely to change, setup a dependency to
ensure that ninja is made aware that it needs to re-copy the file in the
case it does change.