### PR TITLE
build: remove TransformerDemo from installation

### DIFF
--- a/Transformer/CMakeLists.txt
+++ b/Transformer/CMakeLists.txt
@@ -16,8 +16,3 @@ if(CMAKE_SYSTEM_NAME STREQUAL Windows)
     COMMAND
       ${CMAKE_COMMAND} -E copy_if_different ${CMAKE_CURRENT_SOURCE_DIR}/UI/Windows/TransformerUI.exe.manifest $<TARGET_FILE_DIR:TransformerUI>)
 endif()
-
-
-install(TARGETS TransformerDemo
-  DESTINATION bin)
-get_swift_host_arch(swift_arch)


### PR DESCRIPTION
We do not currently install any of the demos, remove the installation
for this particular demo.  We could introduce a new option to install
the demo programs, but given that they are demo programs, they are not
useful to install for persistence but more as a guide for getting
started.