### PR TITLE
Datasets: quick workaround to repair the macOS build

### DIFF
--- a/Datasets/TextUnsupervised/TextUnsupervised.swift
+++ b/Datasets/TextUnsupervised/TextUnsupervised.swift
@@ -131,7 +131,7 @@ public struct TextUnsupervised {
         rows[0] = String(rows[0].dropFirst())
         // Removing the last '"\n'.
         rows[rows.count - 1] = String(
-            rows[rows.count - 1].substring(to: rows[rows.count - 1].count - 2))
+            rows[rows.count - 1].substring(to: rows[rows.count - 1].index(rows[rows.count - 1].endIndex, offsetBy: -2)))
         return rows
     }
 


### PR DESCRIPTION
This adjusts the construction of the substring to build, even though it
is inefficient and uses a deprecated method:

```
SourceCache/swift-models/Datasets/TextUnsupervised/TextUnsupervised.swift:134:75: error: cannot convert value of type 'Int' to expected argument type 'String.Index'
            rows[rows.count - 1].substring(to: rows[rows.count - 1].count - 2))
                                                                          ^
```