### PR TITLE
Adding Swift Package Manager target for macOS Transformer UI demo, update Readme

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -91,7 +91,7 @@ let package = Package(
                     [
                         "-Xlinker", "-sectcreate", "-Xlinker", "__TEXT", "-Xlinker", "__info_plist",
                         "-Xlinker",
-                        "./Transformer/UI/macOS/Info.plist",
+                        "Transformer/UI/macOS/Info.plist",
                     ], .when(platforms: [.macOS]))
             ]),
         .target(

--- a/Package.swift
+++ b/Package.swift
@@ -29,6 +29,7 @@ let package = Package(
         .library(name: "MiniGo", targets: ["MiniGo"]),
         .executable(name: "MiniGoDemo", targets: ["MiniGoDemo"]),
         .executable(name: "TransformerDemo", targets: ["TransformerDemo"]),
+        .executable(name: "TransformerUI", targets: ["TransformerUI"]),
         .executable(name: "GPT2-WikiText2", targets: ["GPT2-WikiText2"]),
     ],
     dependencies: [
@@ -81,6 +82,18 @@ let package = Package(
             path: "Transformer",
             exclude: ["UI/Windows/main.swift", "UI/macOS/main.swift"],
             sources: ["main.swift"]),
+        .target(
+            name: "TransformerUI", dependencies: ["TextModels"], path: "Transformer",
+            exclude: ["UI/Windows/main.swift", "main.swift"],
+            sources: ["UI/macOS/main.swift"],
+            linkerSettings: [
+                .unsafeFlags(
+                    [
+                        "-Xlinker", "-sectcreate", "-Xlinker", "__TEXT", "-Xlinker", "__info_plist",
+                        "-Xlinker",
+                        "./Transformer/UI/macOS/Info.plist",
+                    ], .when(platforms: [.macOS]))
+            ]),
         .target(
             name: "GPT2-WikiText2",
             dependencies: ["Batcher", "Datasets", "TextModels"],

--- a/Transformer/README.md
+++ b/Transformer/README.md
@@ -1,9 +1,10 @@
-# Transformer
+# GPT-2 Text Generation
 
-This is an implementation of [OpenAI's GPT-2 Transformer language model](https://github.com/openai/gpt-2) using [Swift for TensorFlow](https://github.com/tensorflow/swift).
+This is a demonstration of text generation using [OpenAI's GPT-2 Transformer language model](https://github.com/openai/gpt-2) 
+using [Swift for TensorFlow](https://github.com/tensorflow/swift). It is initialized with OpenAI's 117M pretrained 
+checkpoint.
 
-Currently, the model must be run from the root of the swift-models project directory. You can run 
-the model by sampling either unconditionally:
+You can run the model by sampling either unconditionally:
 
 ```sh
 swift run -c release TransformerDemo [temperature]
@@ -48,3 +49,12 @@ library search paths added (`-I` and `-L` with their respective values).
 
 Assuming that the generated DLLs are in the `PATH`, it should be possible to
 then execute the demo as `.\Transformer\TransformerUI.exe`.
+
+# macOS UI
+
+The macOS UI demo must be built and run from the root of the swift-models directory. You can run this example 
+using the following command:
+
+```sh
+swift run -c release TransformerUI
+```

--- a/Transformer/UI/macOS/main.swift
+++ b/Transformer/UI/macOS/main.swift
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#if canImport(AppKit)
 import AppKit
 
 import Dispatch
@@ -189,3 +190,7 @@ extension SwiftApplicationDelegate {
 let delegate: SwiftApplicationDelegate = SwiftApplicationDelegate()
 NSApplication.shared.delegate = delegate
 _ = NSApplicationMain(CommandLine.argc, CommandLine.unsafeArgv)
+
+#else
+fatalError("This demo requires AppKit on macOS to run.")
+#endif


### PR DESCRIPTION
Added a Swift Package Manager target for the new macOS Transformer UI demo. I also updated the Readme to show how to run this new demo, and made some changes to the text there to better reflect the current nature of the overall demo application.