### PR TITLE
Adds the ability to drop the last batch

### DIFF
--- a/Datasets/LanguageModelDataset.swift
+++ b/Datasets/LanguageModelDataset.swift
@@ -116,22 +116,24 @@ extension LanguageModelDataset: Collection {
 
 //Extension when Item is [Int] and openItem is not needed
 extension LanguageModelDataset where Item == [Int] {
-  public init(batchSize: Int, sequenceLength: Int, items: [Item], lengths: [Int]) {
+  public init(batchSize: Int, sequenceLength: Int, items: [Item], lengths: [Int], dropLast: Bool = false) {
     self.init(
       openItem: { $0 },
       batchSize: batchSize,
       sequenceLength: sequenceLength,
       items: items,
-      lengths: lengths)
+      lengths: lengths,
+      dropLast: dropLast)
   }
 
-  public init(batchSize: Int, sequenceLength: Int, items: [Item]) {
+  public init(batchSize: Int, sequenceLength: Int, items: [Item], dropLast: Bool = false) {
     self.init(
       openItem: { $0 },
       batchSize: batchSize,
       sequenceLength: sequenceLength,
       items: items,
-      lengths: items.map { $0.count })
+      lengths: items.map { $0.count },
+      dropLast: dropLast)
   }
 }
 

--- a/Datasets/TextUnsupervised/TextUnsupervised.swift
+++ b/Datasets/TextUnsupervised/TextUnsupervised.swift
@@ -77,7 +77,7 @@ public struct TextUnsupervised {
     public init(
         bpe: BytePairEncoder,
         variant: TextUnsupervisedVariant = TextUnsupervisedVariant.wikiText2,
-        batchSize: Int = 64, sequenceLength: Int = 1024
+        trainingBatchSize: Int = 8, validationBatchSize: Int = 4, sequenceLength: Int = 1024
     ) {
         do {
             self.bpe = bpe
@@ -97,11 +97,11 @@ public struct TextUnsupervised {
                     variant.rawValue, isDirectory: true)
             self.trainingDataset = try TextUnsupervised.loadTraining(
                 localStorageDirectory: localStorageDirectory, bpe: bpe,
-                variantDetails: variantDetails, batchSize: batchSize,
+                variantDetails: variantDetails, batchSize: trainingBatchSize,
                 sequenceLength: sequenceLength)
             self.validationDataset = try TextUnsupervised.loadValidation(
                 localStorageDirectory: localStorageDirectory, bpe: bpe,
-                variantDetails: variantDetails, batchSize: batchSize,
+                variantDetails: variantDetails, batchSize: validationBatchSize,
                 sequenceLength: sequenceLength)
         } catch {
             fatalError("Could not load dataset for \(variant): \(error)")
@@ -161,7 +161,8 @@ public struct TextUnsupervised {
             batchSize: batchSize,
             sequenceLength: sequenceLength,
             items: embeddings,
-            lengths: lengths
+            lengths: lengths,
+            dropLast: true
         )
     }
 

--- a/Examples/GPT2-WikiText2/main.swift
+++ b/Examples/GPT2-WikiText2/main.swift
@@ -20,15 +20,17 @@ import TextModels
 var gpt = try GPT2()
 
 let sequenceLength = gpt.contextSize
-let batchSize = 64
+let trainingBatchSize = 8
+let validationBatchSize = 4
 let numWorkers = 8
 // Use default WikiText2 dataset.
-let dataset = TextUnsupervised(bpe: gpt.bpe, variant: .wikiText2, batchSize: batchSize,
+let dataset = TextUnsupervised(bpe: gpt.bpe, variant: .wikiText2,
+    trainingBatchSize: trainingBatchSize, validationBatchSize: validationBatchSize,
     sequenceLength: sequenceLength)
 let trainingBatcher = Batcher(
-    on: dataset.trainingDataset, batchSize: batchSize, numWorkers: numWorkers, shuffle: true)
+    on: dataset.trainingDataset, batchSize: trainingBatchSize, numWorkers: numWorkers, shuffle: true)
 let validationBatcher = Batcher(
-    on: dataset.validationDataset, batchSize: batchSize, numWorkers: numWorkers)
+    on: dataset.validationDataset, batchSize: validationBatchSize, numWorkers: numWorkers)
 
 print("Dataset acquired.")
 

--- a/Tests/DatasetsTests/TextUnsupervised/TextUnsupervisedTests.swift
+++ b/Tests/DatasetsTests/TextUnsupervised/TextUnsupervisedTests.swift
@@ -26,11 +26,16 @@ final class TextUnsupervisedTests: XCTestCase {
 
             var totalCount = 0
             for example in dataset.trainingDataset {
-                XCTAssertEqual(example.first.shape[0], 299)
-                XCTAssertEqual(example.second.shape[0], 299)
+                XCTAssertEqual(example.first.shape[0], 1024)
+                XCTAssertEqual(example.second.shape[0], 1024)
                 totalCount += 1
             }
-            XCTAssertEqual(totalCount, 64)
+            for example in dataset.validationDataset {
+                XCTAssertEqual(example.first.shape[0], 1024)
+                XCTAssertEqual(example.second.shape[0], 1024)
+                totalCount += 1
+            }
+            XCTAssertEqual(totalCount, 24)
         } catch {
             XCTFail(error.localizedDescription)
         }
@@ -41,8 +46,13 @@ final class TextUnsupervisedTests: XCTestCase {
 
         var totalCount = 0
         for example in dataset.trainingDataset {
-            XCTAssert(example.first.shape[0] > 336)
-            XCTAssert(example.second.shape[0] > 336)
+            XCTAssertEqual(example.first.shape[0], 1024)
+            XCTAssertEqual(example.second.shape[0], 1024)
+            totalCount += 1
+        }
+        for example in dataset.validationDataset {
+            XCTAssertEqual(example.first.shape[0], 1024)
+            XCTAssertEqual(example.second.shape[0], 1024)
             totalCount += 1
         }
         XCTAssertEqual(totalCount, 128)
@@ -55,11 +65,16 @@ final class TextUnsupervisedTests: XCTestCase {
 
             var totalCount = 0
             for example in dataset.trainingDataset {
-                XCTAssertEqual(example.first.shape[0], 143)
-                XCTAssertEqual(example.second.shape[0], 143)
+                XCTAssertEqual(example.first.shape[0], 1024)
+                XCTAssertEqual(example.second.shape[0], 1024)
                 totalCount += 1
             }
-            XCTAssertEqual(totalCount, 64)
+            for example in dataset.validationDataset {
+                XCTAssertEqual(example.first.shape[0], 1024)
+                XCTAssertEqual(example.second.shape[0], 1024)
+                totalCount += 1
+            }
+            XCTAssertEqual(totalCount, 12)
         } catch {
             XCTFail(error.localizedDescription)
         }
@@ -70,8 +85,13 @@ final class TextUnsupervisedTests: XCTestCase {
 
         var totalCount = 0
         for example in dataset.trainingDataset {
-            XCTAssertEqual(example.first.shape[0], 612)
-            XCTAssertEqual(example.second.shape[0], 612)
+            XCTAssertEqual(example.first.shape[0], 1024)
+            XCTAssertEqual(example.second.shape[0], 1024)
+            totalCount += 1
+        }
+        for example in dataset.validationDataset {
+            XCTAssertEqual(example.first.shape[0], 1024)
+            XCTAssertEqual(example.second.shape[0], 1024)
             totalCount += 1
         }
         XCTAssertEqual(totalCount, 64)


### PR DESCRIPTION
This PR adds a flag to optionally drop the last batch when it does not have `sequenceLength` elements. I think this will help fix #374 and in general be beneficial for training with fixed shapes on TPU.