### PR TITLE
Fixes a compile error when building with a modern toolchain.

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -75,7 +75,7 @@ let package = Package(
             name: "MiniGoDemo", dependencies: ["MiniGo"], path: "MiniGo", sources: ["main.swift"]),
         .testTarget(name: "MiniGoTests", dependencies: ["MiniGo"]),
         .testTarget(name: "ImageClassificationTests", dependencies: ["ImageClassificationModels"]),
-        .testTarget(name: "DatasetsTests", dependencies: ["Datasets"]),
+        .testTarget(name: "DatasetsTests", dependencies: ["Datasets", "TextModels"]),
         .target(
             name: "TransformerDemo", dependencies: ["TextModels"],
             path: "Transformer",


### PR DESCRIPTION
saeta@saeta:~/src/swift-models$ swift test
Fetching https://github.com/apple/swift-protobuf.git
Fetching https://github.com/kylef/Spectre.git
Fetching https://github.com/kylef/Commander.git
Cloning https://github.com/apple/swift-protobuf.git
Resolving https://github.com/apple/swift-protobuf.git at 1.7.0
Cloning https://github.com/kylef/Commander.git
Resolving https://github.com/kylef/Commander.git at 0.9.1
Cloning https://github.com/kylef/Spectre.git
Resolving https://github.com/kylef/Spectre.git at 0.9.0
/usr/local/google/home/saeta/src/swift-models/Datasets/TextUnsupervised/TextUnsupervised.swift:134:34: warning: 'substring(to:)' is deprecated: Please use String slicing subscript with a 'partial range upto' operator.
            rows[rows.count - 1].substring(to: rows[rows.count - 1].index(rows[rows.count - 1].endIndex, offsetBy: -2)))
                                 ^
/usr/local/google/home/saeta/src/swift-models/Tests/DatasetsTests/TextUnsupervised/TextUnsupervisedTests.swift:18:8: error: no such module 'TextModels'
import TextModels
       ^
/usr/local/google/home/saeta/src/swift-models/Tests/DatasetsTests/TextUnsupervised/TextUnsupervisedTests.swift:18:8: error: no such module 'TextModels'
import TextModels
       ^
/usr/local/google/home/saeta/src/swift-models/Tests/DatasetsTests/TextUnsupervised/TextUnsupervisedTests.swift:18:8: error: no such module 'TextModels'
import TextModels
       ^
/usr/local/google/home/saeta/src/swift-models/Tests/DatasetsTests/TextUnsupervised/TextUnsupervisedTests.swift:18:8: error: no such module 'TextModels'
import TextModels
       ^
/usr/local/google/home/saeta/src/swift-models/Tests/DatasetsTests/TextUnsupervised/TextUnsupervisedTests.swift:18:8: error: no such module 'TextModels'
import TextModels
       ^
/usr/local/google/home/saeta/src/swift-models/Tests/DatasetsTests/TextUnsupervised/TextUnsupervisedTests.swift:18:8: error: no such module 'TextModels'
import TextModels
       ^

saeta@saeta:~/src/swift-models$ swift --version
Swift version 5.2-dev (LLVM b3057cffb6, Swift 3e7cb166a6)
Target: x86_64-unknown-linux-gnu