### PR TITLE
GPT2: make `TranformerLM` conform to `KeyPathIterable`

### DIFF
--- a/Models/Text/GPT2/TransformerLM.swift
+++ b/Models/Text/GPT2/TransformerLM.swift
@@ -355,3 +355,6 @@ public struct TransformerLM: Differentiable {
         return logits
     }
 }
+
+extension TransformerLM: KeyPathIterable {
+}


### PR DESCRIPTION
Add a conformance to `KeyPathIterable` for `TransformerML`.  This would
identified as missing when building the GPT2 model:

```
/Users/abdulras/SourceCache/swift-models/Examples/GPT2-WikiText2/main.swift:35:17: error: generic class 'Adam' requires that 'TransformerLM.TangentVector' conform to 'KeyPathIterable'
var optimizer = Adam(for: gpt.model, learningRate: 0.001)
                ^
TensorFlow.Adam:1:14: note: where 'Model.TangentVector' = 'TransformerLM.TangentVector'
public class Adam<Model> : Optimizer where Model : Differentiable, Model.TangentVector : ElementaryFunctions, Model.TangentVector : KeyPathIterable, Model.TangentVector : PointwiseMultiplicative, Model.TangentVector : VectorProtocol, Model.TangentVector.VectorSpaceScalar == Float {
             ^
```