### PR TITLE
Pad sequences to maxSequenceLength for BERT

### DIFF
--- a/Examples/BERT-CoLA/main.swift
+++ b/Examples/BERT-CoLA/main.swift
@@ -38,7 +38,7 @@ var bertClassifier = BERTClassifier(bert: bert, classCount: 1)
 var colaTask = try CoLA(
     for: bertClassifier,
     taskDirectoryURL: workspaceURL,
-    maxSequenceLength: 128,
+    maxSequenceLength: 64,
     batchSize: 1024)
 
 var optimizer = WeightDecayedAdam(

--- a/Models/Text/BERT.swift
+++ b/Models/Text/BERT.swift
@@ -279,11 +279,18 @@ public struct BERT: Module, Regularizable {
                 tokenTypeIds.append(Int32(sequenceId))
             }
         }
-        let tokenIds = tokens.map { Int32(vocabulary.id(forToken: $0)!) }
+        var tokenIds = tokens.map { Int32(vocabulary.id(forToken: $0)!) }
 
         // The mask is set to `true` for real tokens and `false` for padding tokens. This is so
         // that only real tokens are attended to.
-        let mask = [Int32](repeating: 1, count: tokenIds.count)
+        var mask = [Int32](repeating: 1, count: tokenIds.count)
+
+        // Zero-pad up to the max sequence length.
+        while tokenIds.count < maxSequenceLength {
+            tokenIds.append(Int32(0))
+            tokenTypeIds.append(Int32(0))
+            mask.append(Int32(0))
+        }
 
         return TextBatch(
             tokenIds: Tensor(tokenIds).expandingShape(at: 0),

--- a/Models/Text/BERT.swift
+++ b/Models/Text/BERT.swift
@@ -286,11 +286,10 @@ public struct BERT: Module, Regularizable {
         var mask = [Int32](repeating: 1, count: tokenIds.count)
 
         // Zero-pad up to the max sequence length.
-        while tokenIds.count < maxSequenceLength {
-            tokenIds.append(Int32(0))
-            tokenTypeIds.append(Int32(0))
-            mask.append(Int32(0))
-        }
+        let zeroPadding = [Int32](repeating: 0, count: maxSequenceLength - tokenIds.count)        
+        tokenIds.append(contentsOf: zeroPadding)
+        tokenTypeIds.append(contentsOf: zeroPadding)
+        mask.append(contentsOf: zeroPadding)
 
         return TextBatch(
             tokenIds: Tensor(tokenIds).expandingShape(at: 0),


### PR DESCRIPTION
This will avoid dynamic shape and enable training well on TPU.
Take Bert python implementation for reference: https://github.com/google-research/bert/blob/master/run_classifier.py#L449