### PR TITLE
Drop last smaller batch in Cola-BERT

### DIFF
--- a/Datasets/CoLA/CoLA.swift
+++ b/Datasets/CoLA/CoLA.swift
@@ -115,7 +115,8 @@ extension CoLA {
         exampleMap: @escaping (Example) -> DataBatch,
         taskDirectoryURL: URL,
         maxSequenceLength: Int,
-        batchSize: Int
+        batchSize: Int,
+        dropRemainder: Bool
     ) throws {
         self.directoryURL = taskDirectoryURL.appendingPathComponent("CoLA")
         let dataURL = directoryURL.appendingPathComponent("data")
@@ -168,7 +169,8 @@ extension CoLA {
                         inputs: padAndBatch(
                             textBatches: $0.map { $0.inputs }, maxLength: maxSequenceLength),
                         labels: Tensor.batch($0.map { $0.labels! }))
-                }
+                },
+                dropRemainder: dropRemainder
             )
             .prefetched(count: 2)
         self.devDataIterator = devExamples.makeIterator()
@@ -181,7 +183,9 @@ extension CoLA {
                         inputs: padAndBatch(
                             textBatches: $0.map { $0.inputs }, maxLength: maxSequenceLength),
                         labels: Tensor.batch($0.map { $0.labels! }))
-                })
+                },
+                dropRemainder: dropRemainder
+            )
         self.testDataIterator = testExamples.makeIterator()
             .map(exampleMap)
             .grouped(
@@ -192,6 +196,8 @@ extension CoLA {
                         inputs: padAndBatch(
                             textBatches: $0.map { $0.inputs }, maxLength: maxSequenceLength),
                         labels: nil)
-                })
+                },
+                dropRemainder : dropRemainder
+            )
     }
 }

--- a/Datasets/CoLA/DataUtilities.swift
+++ b/Datasets/CoLA/DataUtilities.swift
@@ -210,9 +210,7 @@ public struct GroupedIterator<Base: IteratorProtocol>: IteratorProtocol {
       }
     }
     guard let elementsToReduce = elements else {
-      if dropRemainder {
-        return nil
-      }
+      if dropRemainder { return nil }
       if currentGroup == nil { currentGroup = groups.values.startIndex }
       if currentGroup! >= groups.values.endIndex { return nil }
       while groups.values[currentGroup!].isEmpty {

--- a/Datasets/CoLA/DataUtilities.swift
+++ b/Datasets/CoLA/DataUtilities.swift
@@ -48,9 +48,10 @@ extension IteratorProtocol {
   public func grouped(
     keyFn: @escaping (Element) -> Int,
     sizeFn: @escaping (Int) -> Int,
-    reduceFn: @escaping ([Element]) -> Element
+    reduceFn: @escaping ([Element]) -> Element,
+    dropRemainder: Bool = false
   ) -> GroupedIterator<Self> {
-    GroupedIterator(self, keyFn: keyFn, sizeFn: sizeFn, reduceFn: reduceFn)
+    GroupedIterator(self, keyFn: keyFn, sizeFn: sizeFn, reduceFn: reduceFn, dropRemainder: dropRemainder)
   }
 
   // TODO: [DOC] Add documentation string.
@@ -171,6 +172,7 @@ public struct GroupedIterator<Base: IteratorProtocol>: IteratorProtocol {
   private let keyFn: (Base.Element) -> Int
   private let sizeFn: (Int) -> Int
   private let reduceFn: ([Base.Element]) -> Base.Element
+  private let dropRemainder: Bool
   private var iterator: Base
   private var groups: [Int: [Base.Element]]
   private var currentGroup: Dictionary<Int, [Base.Element]>.Index? = nil
@@ -179,11 +181,13 @@ public struct GroupedIterator<Base: IteratorProtocol>: IteratorProtocol {
     _ iterator: Base,
     keyFn: @escaping (Base.Element) -> Int,
     sizeFn: @escaping (Int) -> Int,
-    reduceFn: @escaping ([Base.Element]) -> Base.Element
+    reduceFn: @escaping ([Base.Element]) -> Base.Element,
+    dropRemainder: Bool = false
   ) {
     self.keyFn = keyFn
     self.sizeFn = sizeFn
     self.reduceFn = reduceFn
+    self.dropRemainder = dropRemainder
     self.iterator = iterator
     self.groups = [Int: [Base.Element]]()
   }
@@ -206,6 +210,9 @@ public struct GroupedIterator<Base: IteratorProtocol>: IteratorProtocol {
       }
     }
     guard let elementsToReduce = elements else {
+      if dropRemainder {
+        return nil
+      }
       if currentGroup == nil { currentGroup = groups.values.startIndex }
       if currentGroup! >= groups.values.endIndex { return nil }
       while groups.values[currentGroup!].isEmpty {

--- a/Examples/BERT-CoLA/CoLATraining.swift
+++ b/Examples/BERT-CoLA/CoLATraining.swift
@@ -74,6 +74,6 @@ extension CoLA {
 
         try self.init(
             exampleMap: exampleMapFn, taskDirectoryURL: taskDirectoryURL,
-            maxSequenceLength: maxSequenceLength, batchSize: batchSize)
+            maxSequenceLength: maxSequenceLength, batchSize: batchSize, dropRemainder: true)
     }
 }


### PR DESCRIPTION
When training models on TPU, dynamic shape can cause recompilation overhead when input shape changes between steps. In Cola-BERT this can happen in Embedding layer where sequence length as well as batch size may vary if don't handle them carefully.

To prevent sequence length varying, we should pad sequences to maximum length. And we already did it by calling padAndBatch function [here](https://github.com/tensorflow/swift-models/blob/master/Datasets/CoLA/CoLA.swift#L168)

To prevent varying batch size we should drop the last batch where there aren't enough examples in there. And this PR is doing this.

Here is a brief explanation on how varying batch size happens: 
1. Our Cola data set has 8551 training examples and 1043 dev examples and we use batch 8 (1024/128). Apparently 8551=8x1068+7, 1043=8x130+3
2. Each step we process 8(a batch) training examples, then at 1069th step we only process 7 examples if we keep the last batch. Whereas each 10 steps we run an evaluation through ALL the dev dataset, thus at the end of the evaluation we are doomed to encounter the 3-examples batch. Hence, the recompilation happens every 10 steps aside of the very last step (1068th step)
