### PR TITLE
Remove custom gelu

### DIFF
--- a/Models/Text/GPT2/Operators.swift
+++ b/Models/Text/GPT2/Operators.swift
@@ -16,14 +16,6 @@ import TensorFlow
 
 // Contains operators needed for Transformer; these will likely be upstreamed into swift-apis
 
-/// Computes the Gaussian error linear unit (GELU) nonlinear activation function
-@differentiable
-public func gelu<Scalar: TensorFlowFloatingPoint>(_ x: Tensor<Scalar>) -> Tensor<Scalar> {
-    let xCubed = x * x * x
-    let polynomial = 0.79788456 * (x + 0.044715 * xCubed)
-    return 0.5 * x * (1.0 + tanh(polynomial))
-}
-
 /// Performs batched matrix multiplication of two tensors. The last two axes of each tensor
 /// are treated as the matrix axes; all others are treated as batch axes.
 @usableFromInline


### PR DESCRIPTION
This version conflicts with what is now in swift-apis and causes
materialization issues when used with x10.