### PR TITLE
Refactored FastStyleTransfer ColabDemo

### DIFF
--- a/FastStyleTransfer/Demo/ColabDemo.ipynb
+++ b/FastStyleTransfer/Demo/ColabDemo.ipynb
@@ -74,13 +74,15 @@
     "import FastStyleTransfer\n",
     "import ModelSupport\n",
     "\n",
-    "// Imaging capabilities\n",
-    "%include \"EnableIPythonDisplay.swift\"\n",
+    "\n",
     "#if canImport(PythonKit)\n",
     "    import PythonKit\n",
-    "#else",
+    "#else\n",
     "    import Python\n",
-    "#endif",
+    "#endif\n",
+    "\n",
+    "// Imaging capabilities\n",
+    "%include \"EnableIPythonDisplay.swift\"\n",
     "let plt = Python.import(\"matplotlib.pyplot\")\n",
     "IPythonDisplay.shell.enable_matplotlib(\"inline\")\n",
     "\n",
@@ -121,7 +123,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "[240, 240, 3]\r\n"
+      "[240, 240, 3]\n"
      ]
     },
     {
@@ -163,7 +165,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Clipping input data to the valid range for imshow with RGB data ([0..1] for floats or [0..255] for integers).\r\n"
+      "Clipping input data to the valid range for imshow with RGB data ([0..1] for floats or [0..255] for integers).\n"
      ]
     },
     {
@@ -360,5 +362,5 @@
   }
  },
  "nbformat": 4,
- "nbformat_minor": 1
+ "nbformat_minor": 4
 }


### PR DESCRIPTION
As discussed in #410, Refactored the ColabDemo notebook with:
 - appropriate indentation for conditional block
 - moved `plt` declaration to newline
 - grouped matplotlib related code under single comment.

Fixes #410 

There are few more suggestions I made in the issue, awaiting for your feedback on them.