### PR TITLE
Preventing Datasets from re-downloading.

### DIFF
--- a/Datasets/BostonHousing/BostonHousing.swift
+++ b/Datasets/BostonHousing/BostonHousing.swift
@@ -35,10 +35,18 @@ public struct BostonHousing {
     static func downloadBostonHousingIfNotPresent() -> String {
         let remoteURL = URL(string: "https://archive.ics.uci.edu/ml/machine-learning-databases/housing/")!
         let localURL = DatasetUtilities.defaultDirectory.appendingPathComponent("BostonHousing", isDirectory: true)
-        let _ = DatasetUtilities.downloadResource(
-            filename: "housing", fileExtension: "data",
-            remoteRoot: remoteURL, localStorageDirectory: localURL,
-            extract: false)
+
+        let downloadPath = localURL.path
+        let directoryExists = FileManager.default.fileExists(atPath: downloadPath)
+        let contentsOfDir = try? FileManager.default.contentsOfDirectory(atPath: downloadPath)
+        let directoryEmpty = (contentsOfDir == nil) || (contentsOfDir!.isEmpty)
+        
+        if !directoryExists || directoryEmpty {
+            let _ = DatasetUtilities.downloadResource(
+                filename: "housing", fileExtension: "data",
+                remoteRoot: remoteURL, localStorageDirectory: localURL,
+                extract: false)
+        }
 
         return try! String(contentsOf: localURL.appendingPathComponent("housing.data"), encoding: String.Encoding.utf8)
     }

--- a/Datasets/BostonHousing/BostonHousing.swift
+++ b/Datasets/BostonHousing/BostonHousing.swift
@@ -34,7 +34,7 @@ public struct BostonHousing {
 
     static func downloadBostonHousingIfNotPresent() -> String {
         let remoteURL = URL(string: "https://archive.ics.uci.edu/ml/machine-learning-databases/housing/")!
-        let localURL = FileManager.default.temporaryDirectory.appendingPathComponent("BostonHousing", isDirectory: true)
+        let localURL = DatasetUtilities.defaultDirectory.appendingPathComponent("BostonHousing", isDirectory: true)
         let _ = DatasetUtilities.downloadResource(
             filename: "housing", fileExtension: "data",
             remoteRoot: remoteURL, localStorageDirectory: localURL,

--- a/Datasets/CIFAR10/CIFAR10.swift
+++ b/Datasets/CIFAR10/CIFAR10.swift
@@ -35,8 +35,8 @@ public struct CIFAR10: ImageClassificationDataset {
 
     public init(
         remoteBinaryArchiveLocation: URL, 
-        localStorageDirectory: URL = FileManager.default.temporaryDirectory.appendingPathComponent(
-                "CIFAR10", isDirectory: true), 
+        localStorageDirectory: URL = DatasetUtilities.defaultDirectory
+                .appendingPathComponent("CIFAR10", isDirectory: true), 
         normalizing: Bool) 
     {
         downloadCIFAR10IfNotPresent(from: remoteBinaryArchiveLocation, to: localStorageDirectory)

--- a/Datasets/DatasetUtilities.swift
+++ b/Datasets/DatasetUtilities.swift
@@ -23,8 +23,8 @@ public enum DatasetUtilities {
     public static let currentWorkingDirectoryURL = URL(
         fileURLWithPath: FileManager.default.currentDirectoryPath)
         
-    public static let defaultDirectory = FileManager.default.urls(
-            for: .applicationSupportDirectory, in: .userDomainMask).first!
+    public static let defaultDirectory = try! FileManager.default.url(
+            for: .cachesDirectory, in: .userDomainMask, appropriateFor: nil, create: true)
             .appendingPathComponent("swift-models").appendingPathComponent("datasets")
 
     @discardableResult

--- a/Datasets/DatasetUtilities.swift
+++ b/Datasets/DatasetUtilities.swift
@@ -22,6 +22,9 @@ import ModelSupport
 public enum DatasetUtilities {
     public static let currentWorkingDirectoryURL = URL(
         fileURLWithPath: FileManager.default.currentDirectoryPath)
+    
+    public static let defaultDirectory = FileManager.default.homeDirectoryForCurrentUser
+            .appendingPathComponent(".s4tf").appendingPathComponent("datasets")
 
     @discardableResult
     public static func downloadResource(

--- a/Datasets/DatasetUtilities.swift
+++ b/Datasets/DatasetUtilities.swift
@@ -22,9 +22,10 @@ import ModelSupport
 public enum DatasetUtilities {
     public static let currentWorkingDirectoryURL = URL(
         fileURLWithPath: FileManager.default.currentDirectoryPath)
-    
-    public static let defaultDirectory = FileManager.default.homeDirectoryForCurrentUser
-            .appendingPathComponent(".s4tf").appendingPathComponent("datasets")
+        
+    public static let defaultDirectory = FileManager.default.urls(
+            for: .applicationSupportDirectory, in: .userDomainMask).first!
+            .appendingPathComponent("swift-models").appendingPathComponent("datasets")
 
     @discardableResult
     public static func downloadResource(

--- a/Datasets/Imagenette/Imagenette.swift
+++ b/Datasets/Imagenette/Imagenette.swift
@@ -48,8 +48,8 @@ public struct Imagenette: ImageClassificationDataset {
 
     public init(
         inputSize: ImageSize, outputSize: Int,
-        localStorageDirectory: URL = FileManager.default.temporaryDirectory.appendingPathComponent(
-            "Imagenette", isDirectory: true)
+        localStorageDirectory: URL = DatasetUtilities.defaultDirectory
+                .appendingPathComponent("Imagenette", isDirectory: true)
     ) {
         do {
             self.trainingDataset = Dataset<LabeledExample>(
@@ -177,7 +177,7 @@ public struct ImagenetteBatchers {
 
     public init(
         inputSize: Imagenette.ImageSize, outputSize: Int, batchSize: Int = 64, numWorkers: Int = 8, 
-        localStorageDirectory: URL = FileManager.default.temporaryDirectory.appendingPathComponent(
+        localStorageDirectory: URL = DatasetUtilities.defaultDirectory.appendingPathComponent(
             "Imagenette", isDirectory: true)
     ) {
         do {

--- a/Datasets/Imagenette/Imagewoof.swift
+++ b/Datasets/Imagenette/Imagewoof.swift
@@ -47,8 +47,8 @@ public struct Imagewoof: ImageClassificationDataset {
 
     public init(
         inputSize: ImageSize, outputSize: Int,
-        localStorageDirectory: URL = FileManager.default.temporaryDirectory.appendingPathComponent(
-            "Imagewoof", isDirectory: true)
+        localStorageDirectory: URL = DatasetUtilities.defaultDirectory
+            .appendingPathComponent("Imagewoof", isDirectory: true)
     ) {
         do {
             self.trainingDataset = Dataset<LabeledExample>(

--- a/Datasets/MNIST/FashionMNIST.swift
+++ b/Datasets/MNIST/FashionMNIST.swift
@@ -32,8 +32,8 @@ public struct FashionMNIST: ImageClassificationDataset {
 
     public init(
         flattening: Bool = false, normalizing: Bool = false,
-        localStorageDirectory: URL = FileManager.default.temporaryDirectory.appendingPathComponent(
-            "FashionMNIST", isDirectory: true)
+        localStorageDirectory: URL = DatasetUtilities.defaultDirectory
+            .appendingPathComponent("FashionMNIST", isDirectory: true)
     ) {
         self.trainingDataset = Dataset<LabeledExample>(
             elements: fetchMNISTDataset(

--- a/Datasets/MNIST/KuzushijiMNIST.swift
+++ b/Datasets/MNIST/KuzushijiMNIST.swift
@@ -31,8 +31,8 @@ public struct KuzushijiMNIST: ImageClassificationDataset {
 
     public init(
         flattening: Bool = false, normalizing: Bool = false,
-        localStorageDirectory: URL = FileManager.default.temporaryDirectory.appendingPathComponent(
-            "KuzushijiMNIST", isDirectory: true)
+        localStorageDirectory: URL = DatasetUtilities.defaultDirectory
+            .appendingPathComponent("KuzushijiMNIST", isDirectory: true)
     ) {
         self.trainingDataset = Dataset<LabeledExample>(
             elements: fetchMNISTDataset(

--- a/Datasets/MNIST/MNIST.swift
+++ b/Datasets/MNIST/MNIST.swift
@@ -32,8 +32,8 @@ public struct MNIST: ImageClassificationDataset {
 
     public init(
         flattening: Bool = false, normalizing: Bool = false,
-        localStorageDirectory: URL = FileManager.default.temporaryDirectory.appendingPathComponent(
-            "MNIST", isDirectory: true)
+        localStorageDirectory: URL = DatasetUtilities.defaultDirectory
+            .appendingPathComponent("MNIST", isDirectory: true)
     ) {
         self.trainingDataset = Dataset<LabeledExample>(
             elements: fetchMNISTDataset(

--- a/Tests/DatasetsTests/CIFAR10/CIFAR10Tests.swift
+++ b/Tests/DatasetsTests/CIFAR10/CIFAR10Tests.swift
@@ -4,16 +4,6 @@ import TensorFlow
 import XCTest
 
 final class CIFAR10Tests: XCTestCase {
-    override func setUp() {
-        super.setUp()
-        // Force downloading of the dataset during tests by removing any pre-existing local files.
-        let path = FileManager.default.temporaryDirectory.appendingPathComponent(
-            "CIFAR10/cifar-10-batches-bin").path
-        if FileManager.default.fileExists(atPath: path) {
-            try! FileManager.default.removeItem(atPath: path)
-        }
-    }
-
     func testCreateCIFAR10() {
         let dataset = CIFAR10( 
             remoteBinaryArchiveLocation:


### PR DESCRIPTION
fixes #381

All datasets will be downloaded into "~/.s4tf/datasets" and not into a temporary directory like before.