### PR TITLE
Fix output shape of Image.resized

### DIFF
--- a/Datasets/Imagenette/Imagenette.swift
+++ b/Datasets/Imagenette/Imagenette.swift
@@ -120,7 +120,7 @@ func loadImagenetteDirectory(
     let unwrappedLabelDict = labelDict ?? createLabelDict(urls: urls)
     return urls.lazy.map { (url: URL) -> TensorPair<Float, Int32> in
         TensorPair<Float, Int32>(
-            first: Image(jpeg: url).resized(to: (outputSize, outputSize)).tensor[0] / 255.0,
+            first: Image(jpeg: url).resized(to: (outputSize, outputSize)).tensor / 255.0,
             second: Tensor<Int32>(Int32(unwrappedLabelDict[parentLabel(url: url)]!))
         )    
     }

--- a/Datasets/Imagenette/Imagewoof.swift
+++ b/Datasets/Imagenette/Imagewoof.swift
@@ -108,7 +108,7 @@ func loadImagewoofDirectory(
     let unwrappedLabelDict = labelDict ?? createLabelDict(urls: urls)
     return urls.lazy.map { (url: URL) -> TensorPair<Float, Int32> in
         TensorPair<Float, Int32>(
-            first: Image(jpeg: url).resized(to: (outputSize, outputSize)).tensor[0] / 255.0,
+            first: Image(jpeg: url).resized(to: (outputSize, outputSize)).tensor / 255.0,
             second: Tensor<Int32>(Int32(unwrappedLabelDict[parentLabel(url: url)]!))
         )    
     }

--- a/Support/Image.swift
+++ b/Support/Image.swift
@@ -89,12 +89,12 @@ public struct Image {
             return Image(
                 tensor: _Raw.resizeBilinear(
                     images: Tensor<UInt8>([data]),
-                    size: Tensor<Int32>([Int32(size.0), Int32(size.1)])))
+                    size: Tensor<Int32>([Int32(size.0), Int32(size.1)]))).squeezingShape(at: 0)
         case let .float(data):
             return Image(
                 tensor: _Raw.resizeBilinear(
                     images: Tensor<Float>([data]),
-                    size: Tensor<Int32>([Int32(size.0), Int32(size.1)])))
+                    size: Tensor<Int32>([Int32(size.0), Int32(size.1)]))).squeezingShape(at: 0)
         }
 
     }

--- a/Support/Image.swift
+++ b/Support/Image.swift
@@ -89,12 +89,12 @@ public struct Image {
             return Image(
                 tensor: _Raw.resizeBilinear(
                     images: Tensor<UInt8>([data]),
-                    size: Tensor<Int32>([Int32(size.0), Int32(size.1)]))).squeezingShape(at: 0)
+                    size: Tensor<Int32>([Int32(size.0), Int32(size.1)])).squeezingShape(at: 0))
         case let .float(data):
             return Image(
                 tensor: _Raw.resizeBilinear(
                     images: Tensor<Float>([data]),
-                    size: Tensor<Int32>([Int32(size.0), Int32(size.1)]))).squeezingShape(at: 0)
+                    size: Tensor<Int32>([Int32(size.0), Int32(size.1)])).squeezingShape(at: 0))
         }
 
     }


### PR DESCRIPTION
Hello,

before this update, calling save on resized image would result to

```
Fatal error: image must be 3-dimensional[1,224,224,3]: file /Users/swiftninjas/s4tf/tensorflow-swift-apis/Sources/TensorFlow/Bindings/EagerExecution.swift, line 301
```

because `resized` actually returns a tensor of shape [1, size.0, size.1, channels] and this was saved as a tensor of image.

In loadImagenetteDirectory and loadImagewoofDirectory this was not an issue, because only scalars from the resized image were used. And in ImagenetteBatchers init, it was actually evaded by getting the first dimension from the tensor. 