### PR TITLE
Changing default download location for BostonHousing and CIFAR-10 datasets

### DIFF
--- a/Datasets/BostonHousing/BostonHousing.swift
+++ b/Datasets/BostonHousing/BostonHousing.swift
@@ -33,7 +33,7 @@ public struct BostonHousing {
     public let yTest: Tensor<Float>
 
     static func downloadBostonHousingIfNotPresent() -> String {
-        let remoteURL = URL(string: "https://archive.ics.uci.edu/ml/machine-learning-databases/housing/")!
+        let remoteURL = URL(string: "https://storage.googleapis.com/s4tf-hosted-binaries/datasets/BostonHousing/")!
         let localURL = DatasetUtilities.defaultDirectory.appendingPathComponent("BostonHousing", isDirectory: true)
 
         let downloadPath = localURL.path

--- a/Datasets/BostonHousing/BostonHousing.swift
+++ b/Datasets/BostonHousing/BostonHousing.swift
@@ -22,7 +22,7 @@ import ModelSupport
 import TensorFlow
 
 public struct BostonHousing {
-    public let trainPercentage:Float = 0.8
+    public let trainPercentage: Float = 0.8
     public let numRecords: Int
     public let numColumns: Int
     public let numTrainRecords: Int
@@ -33,14 +33,16 @@ public struct BostonHousing {
     public let yTest: Tensor<Float>
 
     static func downloadBostonHousingIfNotPresent() -> String {
-        let remoteURL = URL(string: "https://storage.googleapis.com/s4tf-hosted-binaries/datasets/BostonHousing/")!
-        let localURL = DatasetUtilities.defaultDirectory.appendingPathComponent("BostonHousing", isDirectory: true)
+        let remoteURL = URL(
+            string: "https://storage.googleapis.com/s4tf-hosted-binaries/datasets/BostonHousing/")!
+        let localURL = DatasetUtilities.defaultDirectory.appendingPathComponent(
+            "BostonHousing", isDirectory: true)
 
         let downloadPath = localURL.path
         let directoryExists = FileManager.default.fileExists(atPath: downloadPath)
         let contentsOfDir = try? FileManager.default.contentsOfDirectory(atPath: downloadPath)
         let directoryEmpty = (contentsOfDir == nil) || (contentsOfDir!.isEmpty)
-        
+
         if !directoryExists || directoryEmpty {
             let _ = DatasetUtilities.downloadResource(
                 filename: "housing", fileExtension: "data",
@@ -48,20 +50,24 @@ public struct BostonHousing {
                 extract: false)
         }
 
-        return try! String(contentsOf: localURL.appendingPathComponent("housing.data"), encoding: String.Encoding.utf8)
+        return try! String(
+            contentsOf: localURL.appendingPathComponent("housing.data"),
+            encoding: String.Encoding.utf8)
     }
-    
+
     public init() {
         let data = BostonHousing.downloadBostonHousingIfNotPresent()
 
         // Convert Space Separated CSV with no Header
-        let dataRecords: [[Float]] = data.split(separator: "\n").map{ String($0).split(separator: " ").compactMap{ Float(String($0)) } }
+        let dataRecords: [[Float]] = data.split(separator: "\n").map {
+            String($0).split(separator: " ").compactMap { Float(String($0)) }
+        }
 
         let numRecords = dataRecords.count
         let numColumns = dataRecords[0].count
 
-        let dataFeatures = dataRecords.map{ Array($0[0..<numColumns-1]) }
-        let dataLabels = dataRecords.map{ Array($0[(numColumns-1)...]) }
+        let dataFeatures = dataRecords.map { Array($0[0..<numColumns - 1]) }
+        let dataLabels = dataRecords.map { Array($0[(numColumns - 1)...]) }
 
         self.numRecords = numRecords
         self.numColumns = numColumns
@@ -73,15 +79,17 @@ public struct BostonHousing {
         let yTrain = Array(Array(dataLabels[0..<numTrainRecords]).joined())
         let yTest = Array(Array(dataLabels[numTrainRecords...]).joined())
 
-        let xTrainDeNorm = Tensor<Float>(xTrain).reshaped(to: TensorShape([numTrainRecords, numColumns-1]))
-        let xTestDeNorm = Tensor<Float>(xTest).reshaped(to: TensorShape([numTestRecords, numColumns-1]))
+        let xTrainDeNorm = Tensor<Float>(xTrain).reshaped(
+            to: TensorShape([numTrainRecords, numColumns - 1]))
+        let xTestDeNorm = Tensor<Float>(xTest).reshaped(
+            to: TensorShape([numTestRecords, numColumns - 1]))
 
         // Normalize
         let mean = xTrainDeNorm.mean(alongAxes: 0)
         let std = xTrainDeNorm.standardDeviation(alongAxes: 0)
 
-        self.xTrain = (xTrainDeNorm - mean)/std
-        self.xTest = (xTestDeNorm - mean)/std
+        self.xTrain = (xTrainDeNorm - mean) / std
+        self.xTest = (xTestDeNorm - mean) / std
         self.yTrain = Tensor<Float>(yTrain).reshaped(to: TensorShape([numTrainRecords, 1]))
         self.yTest = Tensor<Float>(yTest).reshaped(to: TensorShape([numTestRecords, 1]))
     }

--- a/Datasets/CIFAR10/CIFAR10.swift
+++ b/Datasets/CIFAR10/CIFAR10.swift
@@ -31,7 +31,7 @@ public struct CIFAR10: ImageClassificationDataset {
         self.init(
             batchSize: batchSize,
             remoteBinaryArchiveLocation: URL(
-                string: "https://www.cs.toronto.edu/~kriz/cifar-10-binary.tar.gz")!, 
+                string: "https://storage.googleapis.com/s4tf-hosted-binaries/datasets/CIFAR10/cifar-10-binary.tar.gz")!, 
             normalizing: true)
     }
 

--- a/Models/Text/BERT.swift
+++ b/Models/Text/BERT.swift
@@ -510,7 +510,7 @@ extension BERT {
         /// The URL where this pre-trained model can be downloaded from.
         public var url: URL {
             let bertPrefix = "https://storage.googleapis.com/bert_models/2018_"
-            let robertaPrefix = "https://www.dropbox.com/s"
+            let robertaPrefix = "https://storage.googleapis.com/s4tf-hosted-binaries/checkpoints/Text/RoBERTa"
             let albertPrefix = "https://storage.googleapis.com/tfhub-modules/google/albert"
             switch self {
             case .bertBase(false, false):
@@ -530,9 +530,9 @@ extension BERT {
             case .bertLarge(true, true):
                 return URL(string: "\(bertPrefix)05_30/\(subDirectory).zip")!
             case .robertaBase:
-                return URL(string: "\(robertaPrefix)/12ymhgwbfxm2ozf/base.zip?dl=1")!
+                return URL(string: "\(robertaPrefix)/base.zip")!
             case .robertaLarge:
-                return URL(string: "\(robertaPrefix)/jf6kxmdvxyfl4wz/large.zip?dl=1")!
+                return URL(string: "\(robertaPrefix)/large.zip")!
             case .albertBase, .albertLarge, .albertXLarge, .albertXXLarge:
                 return URL(string: "\(albertPrefix)_\(subDirectory)/1.tar.gz")!
             }


### PR DESCRIPTION
At some point in the last day or so, the certificate for archive.ics.uci.edu expired, and as a result local tests that relied on downloading the BostonHousing dataset from that location are failing. The BostonHousing dataset has been changed to have its download location be on our GCS bucket for datasets and checkpoints. swift-format has been run over BostonHousing.swift.

We have seen some occasional download issues with the CIFAR-10 dataset, so that has also been changed to by default download from our GCS dataset bucket.

Finally, I forgot to update the RoBERTa checkpoint location to our GCS bucket when cleaning up some code there earlier, so I have done that now.
