### PR TITLE
STBImage: build with `-fPIC`

### DIFF
--- a/Support/STBImage/CMakeLists.txt
+++ b/Support/STBImage/CMakeLists.txt
@@ -1,5 +1,7 @@
 add_library(STBImage STATIC
   stb_image_write.c
   stb_image.c)
+set_target_properties(STBImage PROPERTIES
+  POSITION_INDEPENDENT_CODE YES)
 target_include_directories(STBImage PUBLIC
   include)


### PR DESCRIPTION
Mark the library to be built as position independent code.