### PR TITLE
Restructuring benchmarks to be batch-based in training, use warmup

### DIFF
--- a/Benchmarks/Benchmark.swift
+++ b/Benchmarks/Benchmark.swift
@@ -16,7 +16,7 @@ import Foundation
 
 protocol Benchmark {
     var exampleCount: Int { get }
-    func run()
+    func run() -> [Double]
 }
 
 /// Performs the specified benchmark over a certain number of iterations and provides the result to a callback function.
@@ -25,21 +25,32 @@ func measure(
     benchmark: Benchmark
 ) -> BenchmarkResults {
     var timings: [Double] = []
-    for _ in 0..<configuration.settings.iterations {
-        let timing = time(benchmark.run)
-        timings.append(timing)
+    let iterations = configuration.settings.iterations
+    for _ in 0..<iterations {
+        var timedSteps = benchmark.run()
+        timedSteps.removeFirst(configuration.settings.warmupBatches)
+        timings.append(contentsOf: timedSteps)
     }
 
     return BenchmarkResults(
         configuration: configuration, timings: timings, exampleCount: benchmark.exampleCount)
 }
 
+// Returns an uptime-based timestamp in milliseconds.
+func timestampInMilliseconds() -> Double {
+    let divisor: Double = 1_000_000
+    return Double(DispatchTime.now().uptimeNanoseconds) / divisor
+}
+
+/// Calculates and returns the time in milliseconds since the given timestamp.
+func durationInMilliseconds(since timestamp: Double) -> Double {
+    let now = timestampInMilliseconds()
+    return now - timestamp
+}
+
 /// Returns the time elapsed while running `body` in milliseconds.
 func time(_ body: () -> Void) -> Double {
-    let divisor: Double = 1_000_000
-    let start = Double(DispatchTime.now().uptimeNanoseconds) / divisor
+    let start = timestampInMilliseconds()
     body()
-    let end = Double(DispatchTime.now().uptimeNanoseconds) / divisor
-    let elapsed = end - start
-    return elapsed
+    return durationInMilliseconds(since: start)
 }

--- a/Benchmarks/Benchmark.swift
+++ b/Benchmarks/Benchmark.swift
@@ -27,16 +27,19 @@ func measure(
     var timings: [Double] = []
     var warmup: [Double] = []
     let iterations = configuration.settings.iterations
+    let start = timestampInMilliseconds()
     for _ in 0..<iterations {
         var timedSteps = benchmark.run()
         warmup.append(contentsOf: timedSteps.prefix(configuration.settings.warmupBatches))
         timedSteps.removeFirst(configuration.settings.warmupBatches)
         timings.append(contentsOf: timedSteps)
     }
+    let warmupTime = warmup.reduce(0.0, +)
+    let totalTime = durationInMilliseconds(since: start)
 
     return BenchmarkResults(
-        configuration: configuration, warmup: warmup, timings: timings,
-        batchSize: benchmark.batchSize)
+        configuration: configuration, timings: timings, warmupTime: warmupTime,
+        totalTime: totalTime, batchSize: benchmark.batchSize)
 }
 
 // Returns an uptime-based timestamp in milliseconds.

--- a/Benchmarks/Benchmark.swift
+++ b/Benchmarks/Benchmark.swift
@@ -15,7 +15,7 @@
 import Foundation
 
 protocol Benchmark {
-    var exampleCount: Int { get }
+    var batchSize: Int { get }
     func run() -> [Double]
 }
 
@@ -25,15 +25,18 @@ func measure(
     benchmark: Benchmark
 ) -> BenchmarkResults {
     var timings: [Double] = []
+    var warmup: [Double] = []
     let iterations = configuration.settings.iterations
     for _ in 0..<iterations {
         var timedSteps = benchmark.run()
+        warmup.append(contentsOf: timedSteps.prefix(configuration.settings.warmupBatches))
         timedSteps.removeFirst(configuration.settings.warmupBatches)
         timings.append(contentsOf: timedSteps)
     }
 
     return BenchmarkResults(
-        configuration: configuration, timings: timings, exampleCount: benchmark.exampleCount)
+        configuration: configuration, warmup: warmup, timings: timings,
+        batchSize: benchmark.batchSize)
 }
 
 // Returns an uptime-based timestamp in milliseconds.

--- a/Benchmarks/BenchmarkModel.swift
+++ b/Benchmarks/BenchmarkModel.swift
@@ -14,15 +14,18 @@
 
 /// Protocol that contains benchmark factory methods for a given model. 
 protocol BenchmarkModel {
-    /// Settings to use in inference benchmark if no custom flags are given.
-    var defaultInferenceSettings: BenchmarkSettings { get }
+    /// A string identifier for this model, to be used in logging and at the command line.
+    static var name: String { get }
+    
+    /// The number of examples per epoch in the training or test dataset for this benchmark.
+    static func examplesPerEpoch(for variety: BenchmarkVariety) -> Int
+
+    /// Settings to use in a specific benchmark if no custom flags are given.
+    static func defaults(for variety: BenchmarkVariety) -> BenchmarkSettings
 
     /// Create an instance of inference  benchmark with given settings.
-    func makeInferenceBenchmark(settings: BenchmarkSettings) -> Benchmark
-
-    /// Settings to use in training benchmark if no custom flags are given.
-    var defaultTrainingSettings: BenchmarkSettings { get }
+    static func makeInferenceBenchmark(settings: BenchmarkSettings) -> Benchmark
 
     /// Create an instance of training benchmark with given settings.
-    func makeTrainingBenchmark(settings: BenchmarkSettings) -> Benchmark
+    static func makeTrainingBenchmark(settings: BenchmarkSettings) -> Benchmark
 }

--- a/Benchmarks/BenchmarkResults.swift
+++ b/Benchmarks/BenchmarkResults.swift
@@ -14,7 +14,8 @@
 
 struct BenchmarkResults: Codable {
     let configuration: BenchmarkConfiguration
-    let warmup: [Double]
     let timings: [Double]
+    let warmupTime: Double
+    let totalTime: Double
     let batchSize: Int
 }

--- a/Benchmarks/BenchmarkResults.swift
+++ b/Benchmarks/BenchmarkResults.swift
@@ -14,19 +14,7 @@
 
 struct BenchmarkResults: Codable {
     let configuration: BenchmarkConfiguration
+    let warmup: [Double]
     let timings: [Double]
-    let exampleCount: Int
-}
-
-extension BenchmarkResults {
-    var interpretedTimings: [Double] {
-        switch configuration.variety {
-        case .inferenceThroughput:
-            let batches = configuration.settings.batches
-            let batchSize = configuration.settings.batchSize
-            return timings.map { Double(batches * batchSize) / ($0 / 1000.0) }
-        case .trainingThroughput:
-            return timings
-        }
-    }
+    let batchSize: Int
 }

--- a/Benchmarks/BenchmarkResults.swift
+++ b/Benchmarks/BenchmarkResults.swift
@@ -25,7 +25,7 @@ extension BenchmarkResults {
             let batches = configuration.settings.batches
             let batchSize = configuration.settings.batchSize
             return timings.map { Double(batches * batchSize) / ($0 / 1000.0) }
-        case .trainingTime:
+        case .trainingThroughput:
             return timings
         }
     }

--- a/Benchmarks/BenchmarkSettings.swift
+++ b/Benchmarks/BenchmarkSettings.swift
@@ -17,4 +17,5 @@ struct BenchmarkSettings: Codable {
     let batchSize: Int
     let iterations: Int
     let warmupBatches: Int
+    let synthetic: Bool
 }

--- a/Benchmarks/BenchmarkSettings.swift
+++ b/Benchmarks/BenchmarkSettings.swift
@@ -16,15 +16,5 @@ struct BenchmarkSettings: Codable {
     let batches: Int
     let batchSize: Int
     let iterations: Int
-    let epochs: Int
-
-    func withDefaults(_ defaults: BenchmarkSettings) -> BenchmarkSettings {
-        let newBatches = batches == -1 ? defaults.batches : batches
-        let newBatchSize = batchSize == -1 ? defaults.batchSize : batchSize
-        let newIterations = iterations == -1 ? defaults.iterations : iterations
-        let newEpochs = epochs == -1 ? defaults.epochs : epochs
-        return BenchmarkSettings(
-            batches: newBatches, batchSize: newBatchSize,
-            iterations: newIterations, epochs: newEpochs)
-    }
+    let warmupBatches: Int
 }

--- a/Benchmarks/BenchmarkVariety.swift
+++ b/Benchmarks/BenchmarkVariety.swift
@@ -14,5 +14,5 @@
 
 enum BenchmarkVariety: String, Codable {
     case inferenceThroughput = "inference"
-    case trainingTime = "training"
+    case trainingThroughput = "training"
 }

--- a/Benchmarks/Models.swift
+++ b/Benchmarks/Models.swift
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-let benchmarkModelList: [BenchmarkModel.Type] = [
+let benchmarkModelTypes: [BenchmarkModel.Type] = [
     LeNetMNIST.self,
     ResNetCIFAR10.self,
 ]
-let benchmarkModels = Dictionary(uniqueKeysWithValues: benchmarkModelList.map { ($0.name, $0) })
+let benchmarkModels = Dictionary(uniqueKeysWithValues: benchmarkModelTypes.map { ($0.name, $0) })

--- a/Benchmarks/Models.swift
+++ b/Benchmarks/Models.swift
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-let benchmarkModels: [String: BenchmarkModel] = [
-    "LeNetMNIST": LeNetMNIST(),
-    "ResNetCIFAR10": ResNetCIFAR10(),
+let benchmarkModels: [String: BenchmarkModel.Type] = [
+    LeNetMNIST.name: LeNetMNIST.self,
+    ResNetCIFAR10.name: ResNetCIFAR10.self,
 ]

--- a/Benchmarks/Models.swift
+++ b/Benchmarks/Models.swift
@@ -12,7 +12,5 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-let benchmarkModels: [String: BenchmarkModel.Type] = [
-    LeNetMNIST.name: LeNetMNIST.self,
-    ResNetCIFAR10.name: ResNetCIFAR10.self,
+let benchmarkModels = Dictionary([LeNetMNIST.self, ResNetCIFAR10.self].map { ($0.name, $0) })
 ]

--- a/Benchmarks/Models.swift
+++ b/Benchmarks/Models.swift
@@ -12,5 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-let benchmarkModels = Dictionary([LeNetMNIST.self, ResNetCIFAR10.self].map { ($0.name, $0) })
+let benchmarkModelList: [BenchmarkModel.Type] = [
+    LeNetMNIST.self,
+    ResNetCIFAR10.self,
 ]
+let benchmarkModels = Dictionary(uniqueKeysWithValues: benchmarkModelList.map { ($0.name, $0) })

--- a/Benchmarks/Models/ImageClassificationInference.swift
+++ b/Benchmarks/Models/ImageClassificationInference.swift
@@ -49,9 +49,14 @@ where Model: ImageClassificationModel, ClassificationDataset: ImageClassificatio
         }
     }
 
-    func run() {
+    func run() -> [Double] {
+        var batchTimings: [Double] = []
         for _ in 0..<batches {
-            let _ = model(images)
+            let batchTime = time{
+                let _ = model(images)
+            }
+            batchTimings.append(batchTime)
         }
+        return batchTimings
     }
 }

--- a/Benchmarks/Models/ImageClassificationTraining.swift
+++ b/Benchmarks/Models/ImageClassificationTraining.swift
@@ -35,6 +35,8 @@ where
     }
 
     func run() -> [Double] {
+        // Include model and optimizer initialization time in first batch, to be part of warmup.
+        var beforeBatch = timestampInMilliseconds()
         var model = Model()
         // TODO: Split out the optimizer as a separate specification.
         let optimizer = SGD(for: model, learningRate: 0.1)
@@ -45,7 +47,6 @@ where
         while (currentBatch < self.batches) {
             for batch in dataset.training.sequenced() {
                 if (currentBatch >= self.batches) { break }
-                let beforeBatch = timestampInMilliseconds()
                 let (images, labels) = (batch.first, batch.second)
                 
                 // Discard remainder batches that are not the same size as the others 
@@ -58,6 +59,7 @@ where
                 optimizer.update(&model, along: 𝛁model)
                 batchTimings.append(durationInMilliseconds(since: beforeBatch))
                 currentBatch += 1
+                beforeBatch = timestampInMilliseconds()
             }
         }
         return batchTimings

--- a/Benchmarks/Models/ImageClassificationTraining.swift
+++ b/Benchmarks/Models/ImageClassificationTraining.swift
@@ -21,32 +21,45 @@ where
     ClassificationDataset: ImageClassificationDataset
 {
     let dataset: ClassificationDataset
-    let epochs: Int
+    let batches: Int
+    let batchSize: Int
 
     var exampleCount: Int {
-        return epochs * dataset.training.dataset.count
+        return batches * batchSize
     }
 
     init(settings: BenchmarkSettings) {
-        self.epochs = settings.epochs
+        self.batches = settings.batches
+        self.batchSize = settings.batchSize
         self.dataset = ClassificationDataset(batchSize: settings.batchSize)
     }
 
-    func run() {
+    func run() -> [Double] {
         var model = Model()
         // TODO: Split out the optimizer as a separate specification.
         let optimizer = SGD(for: model, learningRate: 0.1)
-
+        var batchTimings: [Double] = []
+        var currentBatch = 0
+        
         Context.local.learningPhase = .training
-        for _ in 1...epochs {
+        while (currentBatch < self.batches) {
             for batch in dataset.training.sequenced() {
+                if (currentBatch >= self.batches) { break }
+                let beforeBatch = timestampInMilliseconds()
                 let (images, labels) = (batch.first, batch.second)
+                
+                // Discard remainder batches that are not the same size as the others 
+                guard images.shape[0] == self.batchSize else { continue }
+                
                 let 𝛁model = TensorFlow.gradient(at: model) { model -> Tensor<Float> in
                     let logits = model(images)
                     return softmaxCrossEntropy(logits: logits, labels: labels)
                 }
                 optimizer.update(&model, along: 𝛁model)
+                batchTimings.append(durationInMilliseconds(since: beforeBatch))
+                currentBatch += 1
             }
         }
+        return batchTimings
     }
 }

--- a/Benchmarks/Models/LeNetMnist.swift
+++ b/Benchmarks/Models/LeNetMnist.swift
@@ -28,9 +28,11 @@ enum LeNetMNIST: BenchmarkModel {
     static func defaults(for variety: BenchmarkVariety) -> BenchmarkSettings {
         switch(variety) {
         case .inferenceThroughput:
-            return BenchmarkSettings(batches: 1000, batchSize: 128, iterations: 10, warmupBatches: 1)
+            return BenchmarkSettings(batches: 1000, batchSize: 128, iterations: 10,
+                                     warmupBatches: 1, synthetic: false)
         case .trainingThroughput:
-            return BenchmarkSettings(batches: 110, batchSize: 128, iterations: 1, warmupBatches: 1)
+            return BenchmarkSettings(batches: 110, batchSize: 128, iterations: 1, warmupBatches: 1,
+                                     synthetic: false)
         }
     }
 
@@ -41,4 +43,9 @@ enum LeNetMNIST: BenchmarkModel {
     static func makeTrainingBenchmark(settings: BenchmarkSettings) -> Benchmark {
         return ImageClassificationTraining<LeNet, MNIST>(settings: settings)
     }
+}
+
+extension LeNet: ImageClassificationModel {
+    static var preferredInputDimensions: [Int] { [28, 28, 1] }
+    static var outputLabels: Int { 10 }
 }

--- a/Benchmarks/Models/LeNetMnist.swift
+++ b/Benchmarks/Models/LeNetMnist.swift
@@ -28,7 +28,7 @@ enum LeNetMNIST: BenchmarkModel {
     static func defaults(for variety: BenchmarkVariety) -> BenchmarkSettings {
         switch(variety) {
         case .inferenceThroughput:
-            return BenchmarkSettings(batches: 1000, batchSize: 1, iterations: 10, warmupBatches: 1)
+            return BenchmarkSettings(batches: 1000, batchSize: 128, iterations: 10, warmupBatches: 1)
         case .trainingThroughput:
             return BenchmarkSettings(batches: 110, batchSize: 128, iterations: 1, warmupBatches: 1)
         }

--- a/Benchmarks/Models/LeNetMnist.swift
+++ b/Benchmarks/Models/LeNetMnist.swift
@@ -15,21 +15,30 @@
 import Datasets
 import ImageClassificationModels
 
-struct LeNetMNIST: BenchmarkModel {
+enum LeNetMNIST: BenchmarkModel {
+    static var name: String { "LeNetMNIST" }
 
-    var defaultInferenceSettings: BenchmarkSettings {
-        return BenchmarkSettings(batches: 1000, batchSize: 1, iterations: 10, epochs: -1)
+    static func examplesPerEpoch(for variety: BenchmarkVariety) -> Int {
+        switch(variety) {
+        case .inferenceThroughput: return 10000
+        case .trainingThroughput: return 60000
+        }
     }
 
-    func makeInferenceBenchmark(settings: BenchmarkSettings) -> Benchmark {
+    static func defaults(for variety: BenchmarkVariety) -> BenchmarkSettings {
+        switch(variety) {
+        case .inferenceThroughput:
+            return BenchmarkSettings(batches: 1000, batchSize: 1, iterations: 10, warmupBatches: 1)
+        case .trainingThroughput:
+            return BenchmarkSettings(batches: 110, batchSize: 128, iterations: 1, warmupBatches: 1)
+        }
+    }
+
+    static func makeInferenceBenchmark(settings: BenchmarkSettings) -> Benchmark {
         return ImageClassificationInference<LeNet, MNIST>(settings: settings)
     }
 
-    var defaultTrainingSettings: BenchmarkSettings {
-        return BenchmarkSettings(batches: -1, batchSize: 128, iterations: 10, epochs: 1)
-    }
-
-    func makeTrainingBenchmark(settings: BenchmarkSettings) -> Benchmark {
+    static func makeTrainingBenchmark(settings: BenchmarkSettings) -> Benchmark {
         return ImageClassificationTraining<LeNet, MNIST>(settings: settings)
     }
 }

--- a/Benchmarks/Models/ResNetCIFAR10.swift
+++ b/Benchmarks/Models/ResNetCIFAR10.swift
@@ -29,7 +29,7 @@ enum ResNetCIFAR10: BenchmarkModel {
     static func defaults(for variety: BenchmarkVariety) -> BenchmarkSettings {
         switch(variety) {
         case .inferenceThroughput:
-            return BenchmarkSettings(batches: 1000, batchSize: 1, iterations: 10, warmupBatches: 1)
+            return BenchmarkSettings(batches: 1000, batchSize: 128, iterations: 10, warmupBatches: 1)
         case .trainingThroughput:
             return BenchmarkSettings(batches: 110, batchSize: 128, iterations: 1, warmupBatches: 1)
         }

--- a/Benchmarks/Models/ResNetCIFAR10.swift
+++ b/Benchmarks/Models/ResNetCIFAR10.swift
@@ -16,21 +16,30 @@ import Datasets
 import ImageClassificationModels
 import TensorFlow
 
-struct ResNetCIFAR10: BenchmarkModel {
+enum ResNetCIFAR10: BenchmarkModel {
+    static var name: String { "ResNetCIFAR10" }
 
-    var defaultInferenceSettings: BenchmarkSettings {
-        return BenchmarkSettings(batches: 1000, batchSize: 1, iterations: 10, epochs: -1)
+    static func examplesPerEpoch(for variety: BenchmarkVariety) -> Int {
+        switch(variety) {
+        case .inferenceThroughput: return 10000
+        case .trainingThroughput: return 50000
+        }
     }
 
-    func makeInferenceBenchmark(settings: BenchmarkSettings) -> Benchmark {
+    static func defaults(for variety: BenchmarkVariety) -> BenchmarkSettings {
+        switch(variety) {
+        case .inferenceThroughput:
+            return BenchmarkSettings(batches: 1000, batchSize: 1, iterations: 10, warmupBatches: 1)
+        case .trainingThroughput:
+            return BenchmarkSettings(batches: 110, batchSize: 128, iterations: 1, warmupBatches: 1)
+        }
+    }
+
+    static func makeInferenceBenchmark(settings: BenchmarkSettings) -> Benchmark {
         return ImageClassificationInference<ResNet56, CIFAR10>(settings: settings)
     }
 
-    var defaultTrainingSettings: BenchmarkSettings {
-        return BenchmarkSettings(batches: -1, batchSize: 128, iterations: 10, epochs: 1)
-    }
-
-    func makeTrainingBenchmark(settings: BenchmarkSettings) -> Benchmark {
+    static func makeTrainingBenchmark(settings: BenchmarkSettings) -> Benchmark {
         return ImageClassificationTraining<ResNet56, CIFAR10>(settings: settings)
     }
 }

--- a/Benchmarks/Models/ResNetCIFAR10.swift
+++ b/Benchmarks/Models/ResNetCIFAR10.swift
@@ -29,9 +29,11 @@ enum ResNetCIFAR10: BenchmarkModel {
     static func defaults(for variety: BenchmarkVariety) -> BenchmarkSettings {
         switch(variety) {
         case .inferenceThroughput:
-            return BenchmarkSettings(batches: 1000, batchSize: 128, iterations: 10, warmupBatches: 1)
+            return BenchmarkSettings(batches: 1000, batchSize: 128, iterations: 10,
+                                     warmupBatches: 1, synthetic: false)
         case .trainingThroughput:
-            return BenchmarkSettings(batches: 110, batchSize: 128, iterations: 1, warmupBatches: 1)
+            return BenchmarkSettings(batches: 110, batchSize: 128, iterations: 1, warmupBatches: 1,
+                                     synthetic: false)
         }
     }
 
@@ -55,4 +57,9 @@ struct ResNet56: Layer {
     public func callAsFunction(_ input: Tensor<Float>) -> Tensor<Float> {
         return model(input)
     }
+}
+
+extension ResNet56: ImageClassificationModel {
+    static var preferredInputDimensions: [Int] { [32, 32, 3] }
+    static var outputLabels: Int { 10 }
 }

--- a/Benchmarks/Models/SyntheticImageDataset.swift
+++ b/Benchmarks/Models/SyntheticImageDataset.swift
@@ -1,0 +1,47 @@
+// Copyright 2020 The TensorFlow Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import Batcher
+import Datasets
+import TensorFlow
+
+public struct SyntheticImageDataset: ImageClassificationDataset {
+    public typealias SourceDataSet = [TensorPair<Float, Int32>]
+    public let training: Batcher<SourceDataSet>
+    public let test: Batcher<SourceDataSet>
+
+    public init(batchSize: Int) {
+        self.init(batchSize: batchSize, batches: 110, labels: 10, dimensions: [224, 224, 3])
+    }
+    
+    // TODO: Use a random seed to create deterministic examples here.
+    public init(batchSize: Int, batches: Int, labels: Int, dimensions: [Int]) {
+        precondition(labels > 0)
+        precondition(dimensions.count == 3)
+        let totalExamples = batchSize * batches
+        
+        let syntheticDataset = (0..<totalExamples).map {_ -> TensorPair<Float, Int32> in
+            let syntheticImage = Tensor<Float>(
+                randomNormal: TensorShape(dimensions), mean: Tensor<Float>(0.5),
+                standardDeviation: Tensor<Float>(0.1))
+            let syntheticLabel = Tensor<Int32>(Int32.random(in: 0..<Int32(labels)))
+            return TensorPair(first: syntheticImage, second: syntheticLabel)
+        }
+
+        training = Batcher<SourceDataSet>(
+            on: syntheticDataset, batchSize: batchSize, numWorkers: 1, shuffle: true)
+        
+        test = Batcher<SourceDataSet>(on: syntheticDataset, batchSize: batchSize, numWorkers: 1)
+    }
+}

--- a/Benchmarks/PrintingStyle.swift
+++ b/Benchmarks/PrintingStyle.swift
@@ -79,6 +79,11 @@ extension BenchmarkConfiguration {
         case .inferenceThroughput:
             result += "--inference "
         }
+        if self.settings.synthetic {
+            result += "--synthetic "
+        } else {
+            result += "--real "
+        }
         result += "--batches \(settings.batches) "
         result += "--batchSize \(settings.batchSize) "
         result += "--iterations \(settings.iterations) "

--- a/Benchmarks/PrintingStyle.swift
+++ b/Benchmarks/PrintingStyle.swift
@@ -32,26 +32,19 @@ extension BenchmarkResults {
     private func printAsPlainText() {
         let configuration = self.configuration
         let settings = configuration.settings
-
-        switch configuration.variety {
-        case .inferenceThroughput:
-            Swift.print("Benchmark: \(configuration.name)")
-            Swift.print("\tVariety: \(configuration.variety.rawValue)")
-            Swift.print("\tAfter \(settings.iterations) iteration(s):")
-            Swift.print("\tSamples per second:")
-            self.interpretedTimings.printStatistics(indentation: 2)
-        case .trainingThroughput:
-            Swift.print("Benchmark: \(configuration.name)")
-            Swift.print("\tVariety: \(configuration.variety.rawValue)")
-            Swift.print("\tAfter \(settings.iterations) iteration(s):")
-            Swift.print("\tStep time:")
-            self.interpretedTimings.printStatistics(indentation: 2)
-            Swift.print("\tSamples per second:")
-            let samplesPerSecond = self.interpretedTimings.map {
-                Double(settings.batchSize) / ($0 / 1000.0)
-            }
-            samplesPerSecond.printStatistics(indentation: 2)
+        
+        Swift.print("Benchmark: \(configuration.name)")
+        Swift.print("\tVariety: \(configuration.variety.rawValue)")
+        Swift.print("\tAfter \(settings.iterations) iteration(s) of \(settings.batches) batches:")
+        Swift.print("\tSamples per second:")
+        let samplesPerSecond = self.timings.map {
+            Double(settings.batchSize) / ($0 / 1000.0)
         }
+        samplesPerSecond.printStatistics(indentation: 2)
+        Swift.print("\tStep time:")
+        self.timings.printStatistics(indentation: 2)
+        Swift.print("\tWarmup time:")
+        self.warmup.printStatistics(indentation: 2)
     }
 
     private func printAsJSON() {
@@ -124,9 +117,9 @@ extension Array where Element == Double {
     
     func printStatistics(indentation: Int) {
         let tabs = String(repeating: "\t", count: indentation)
-        Swift.print("\(tabs)Min\(String(format: "%.2f", self.min()!))")
-        Swift.print("\(tabs)Max\(String(format: "%.2f", self.max()!))")
-        Swift.print("\(tabs)Average\(String(format: "%.2f", self.average))")
+        Swift.print("\(tabs)Average: \(String(format: "%.2f", self.average))")
+        Swift.print("\(tabs)Min: \(String(format: "%.2f", self.min()!))")
+        Swift.print("\(tabs)Max: \(String(format: "%.2f", self.max()!))")
         Swift.print("\(tabs)Standard deviation: \(String(format: "%.2f", self.standardDeviation))")
     }
 }

--- a/Benchmarks/PrintingStyle.swift
+++ b/Benchmarks/PrintingStyle.swift
@@ -35,16 +35,22 @@ extension BenchmarkResults {
         
         Swift.print("Benchmark: \(configuration.name)")
         Swift.print("\tVariety: \(configuration.variety.rawValue)")
-        Swift.print("\tAfter \(settings.iterations) iteration(s) of \(settings.batches) batches:")
-        Swift.print("\tSamples per second:")
-        let samplesPerSecond = self.timings.map {
+        Swift.print("\tAfter \(settings.iterations) iteration(s) of \(self.timings.count) batches:")
+        let timeAfterWarmup = self.totalTime - self.warmupTime
+        let totalExamples = self.timings.count * settings.batchSize
+        let averageExamplesPerSecond = Double(totalExamples) / (Double(timeAfterWarmup) / 1000.0)
+        Swift.print(
+            "\tAverage examples per second: \(String(format: "%.2f", averageExamplesPerSecond))")
+        Swift.print("\tInstantaneous examples per second:")
+        let examplesPerSecond = self.timings.map {
             Double(settings.batchSize) / ($0 / 1000.0)
         }
-        samplesPerSecond.printStatistics(indentation: 2)
-        Swift.print("\tStep time:")
+        examplesPerSecond.printStatistics(indentation: 2)
+        Swift.print("\tStep time (ms):")
         self.timings.printStatistics(indentation: 2)
-        Swift.print("\tWarmup time:")
-        self.warmup.printStatistics(indentation: 2)
+        Swift.print("\tTotal time: \(String(format: "%.2f", self.totalTime)) ms")
+        Swift.print("\tWarmup time: \(String(format: "%.2f", self.warmupTime)) ms")
+        Swift.print("\tTime after warmup: \(String(format: "%.2f", timeAfterWarmup)) ms")
     }
 
     private func printAsJSON() {

--- a/Benchmarks/__init__.py
+++ b/Benchmarks/__init__.py
@@ -79,7 +79,8 @@ def extract_metrics(result, variety):
   """
 
   timings = result['timings']
-  example_count = result['exampleCount']
+  warmup = result['warmup']
+  batch_size = result['batchSize']
 
   # 50th percentile of a single iteration's running time in seconds.
   timings_s = np.array(timings) / 1000
@@ -87,17 +88,15 @@ def extract_metrics(result, variety):
 
   # Average examples per second across the entire
   # benchmark run. Doesn't account for warm-up.
-  total_time_s = sum(timings_s)
-  total_num_examples = example_count * len(timings_s)
+  total_time_s = sum(timings_s) + sum(warmup)
+  total_num_examples = batch_size * (len(timings_s) + len(warmup))
   average_examples_per_second = total_num_examples / total_time_s
 
-  # Examples per second across the second half
+  # Examples per second, calculated after warmup period
   # of the measurements. First half of measurements
   # is dropped to account for warm-up.
-  warmup = int(len(timings_s) / 2 if len(timings_s) > 1 else 0)
-  warm_timings_s = timings_s[warmup:]
-  warm_time_s = sum(warm_timings_s)
-  warm_num_examples = example_count * len(warm_timings_s)
+  warm_time_s = sum(timings_s)
+  warm_num_examples = batch_size * len(timings_s)
   examples_per_second = warm_num_examples / warm_time_s
 
   metrics = [{

--- a/Benchmarks/main.swift
+++ b/Benchmarks/main.swift
@@ -110,7 +110,8 @@ extension BenchmarkCommand {
         @Option(help: "Number of training epochs.")
         var epochs: Int?
 
-        @Option(help: "Number of batches to use as a warmup period.")
+        @Option(name: .customLong("warmupBatches"),
+                help: "Number of batches to use as a warmup period.")
         var warmupBatches: Int?
 
         @Flag(name: .customLong("json"), help: "Output json instead of plain text.")

--- a/Benchmarks/main.swift
+++ b/Benchmarks/main.swift
@@ -95,6 +95,12 @@ extension BenchmarkCommand {
         @Flag(help: "Run inference benchmark.")
         var inference: Bool
 
+        @Flag(help: "Use synthetic data.")
+        var synthetic: Bool
+
+        @Flag(help: "Use real data.")
+        var real: Bool
+
         @Option(help: "Name of the benchmark to run.")
         var benchmark: String?
 
@@ -128,6 +134,11 @@ extension BenchmarkCommand {
                     "Can't specify both --training and --inference benchmark variety.")
             }
             
+            guard !(real && synthetic) else {
+                throw ValidationError(
+                    "Can't specify both --real and --synthetic data sources.")
+            }
+
             guard !((batches != nil) && (epochs != nil)) else {
                 throw ValidationError(
                     "Can't specify both the number of batches and epochs.")
@@ -161,7 +172,8 @@ extension BenchmarkCommand {
                 batches: specifiedBatches ?? defaults.batches,
                 batchSize: batchSizeToUse,
                 iterations: iterations ?? defaults.iterations,
-                warmupBatches: warmupBatches ?? defaults.warmupBatches)
+                warmupBatches: warmupBatches ?? defaults.warmupBatches,
+                synthetic: synthetic)
 
             runBenchmark(
                 benchmarkModel,

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.2
+// swift-tools-version:5.1
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription
@@ -36,7 +36,7 @@ let package = Package(
         .executable(name: "CycleGAN", targets: ["CycleGAN"])
     ],
     dependencies: [
-        .package(name: "SwiftProtobuf", url: "https://github.com/apple/swift-protobuf.git", from: "1.7.0"),
+        .package(url: "https://github.com/apple/swift-protobuf.git", from: "1.7.0"),
         .package(url: "https://github.com/apple/swift-argument-parser", .upToNextMinor(from: "0.0.1")),
     ],
     targets: [


### PR DESCRIPTION
In order to better align the training and inference throughput benchmarks with the ones used for tf.keras, I've converted the training benchmarks to use batches as the fundamental unit of measure, not epochs. I've also introduced a specified warmup period (defaulting to one batch) before batches are counted for throughput.

Logging has been improved, so that you get statistics on examples / second, warmup time, and step time right at the command line. This includes minimum, maximum, and standard deviation so that anomalous outliers can be detected.

Internal setting values have been switched from using magic constants to relying on optionals early and then materializing these into concrete values closer to where options are specified. This should hopefully catch problematic cases earlier in the process.

Finally, the inference benchmarks have been adjusted to use the actual test part of the dataset by default, fixing a crash in the ResNet56 inference benchmark and providing a more realistic measure of inference throughput.