### PR TITLE
Fixed collectURLs extensions filtering

### DIFF
--- a/Support/FileManagement.swift
+++ b/Support/FileManagement.swift
@@ -75,7 +75,7 @@ public func collectURLs(
                 files += collectURLs(under: content, recurse: recurse, filtering: extensions)
             } else if content.isFileURL
                 && (extensions == nil
-                    || extensions!.contains(dirContents[0].pathExtension.lowercased()))
+                    || extensions!.contains(content.pathExtension.lowercased()))
             {
                 files.append(content)
             }


### PR DESCRIPTION
A minor bug rendered the extension filtering ineffective as the function repeatedly checks only the first file of the directory.