### PR TITLE
Convert #file -> #filePath

### DIFF
--- a/Gym/CartPole/main.swift
+++ b/Gym/CartPole/main.swift
@@ -22,7 +22,7 @@ import TensorFlow
 // Force unwrapping with `!` does not provide source location when unwrapping `nil`, so we instead
 // make a utility function for debuggability.
 fileprivate extension Optional {
-    func unwrapped(file: StaticString = #file, line: UInt = #line) -> Wrapped {
+    func unwrapped(file: StaticString = #filePath, line: UInt = #line) -> Wrapped {
         guard let unwrapped = self else {
             fatalError("Value is nil", file: file, line: line)
         }

--- a/Gym/FrozenLake/main.swift
+++ b/Gym/FrozenLake/main.swift
@@ -22,7 +22,7 @@ import TensorFlow
 // Force unwrapping with `!` does not provide source location when unwrapping `nil`, so we instead
 // make a utility function for debuggability.
 fileprivate extension Optional {
-    func unwrapped(file: StaticString = #file, line: UInt = #line) -> Wrapped {
+    func unwrapped(file: StaticString = #filePath, line: UInt = #line) -> Wrapped {
         guard let unwrapped = self else {
             fatalError("Value is nil", file: file, line: line)
         }

--- a/Tests/CheckpointTests/CheckpointIndexReaderTests.swift
+++ b/Tests/CheckpointTests/CheckpointIndexReaderTests.swift
@@ -18,7 +18,7 @@ import XCTest
 @testable import ModelSupport
 
 final class CheckpointIndexReaderTests: XCTestCase {
-    let resourceBaseLocation = URL(fileURLWithPath: #file).deletingLastPathComponent()
+    let resourceBaseLocation = URL(fileURLWithPath: #filePath).deletingLastPathComponent()
         .appendingPathComponent("IndexFiles")
 
     func testLoadingMiniGo() {

--- a/Tests/CheckpointTests/CheckpointReaderTests.swift
+++ b/Tests/CheckpointTests/CheckpointReaderTests.swift
@@ -18,7 +18,7 @@ import XCTest
 @testable import ModelSupport
 
 final class CheckpointReaderTests: XCTestCase {
-    let resourceBaseLocation = URL(fileURLWithPath: #file).deletingLastPathComponent()
+    let resourceBaseLocation = URL(fileURLWithPath: #filePath).deletingLastPathComponent()
         .appendingPathComponent("SavedModels")
 
     func testLocalSavedModel() {

--- a/Tests/CheckpointTests/SnappyDecompressionTests.swift
+++ b/Tests/CheckpointTests/SnappyDecompressionTests.swift
@@ -18,7 +18,7 @@ import XCTest
 @testable import ModelSupport
 
 final class SnappyDecompressionTests: XCTestCase {
-    let resourceBaseLocation = URL(fileURLWithPath: #file).deletingLastPathComponent()
+    let resourceBaseLocation = URL(fileURLWithPath: #filePath).deletingLastPathComponent()
         .appendingPathComponent("IndexFiles")
     
     func testReadingVarints() {

--- a/Tests/SupportTests/ImageTests.swift
+++ b/Tests/SupportTests/ImageTests.swift
@@ -17,7 +17,7 @@ import ModelSupport
 import TensorFlow
 
 final class ImageTests: XCTestCase {
-    let resourceBaseLocation = URL(fileURLWithPath: #file).deletingLastPathComponent()
+    let resourceBaseLocation = URL(fileURLWithPath: #filePath).deletingLastPathComponent()
         .appendingPathComponent("Images")
     let temporaryDirectory = FileManager.default.temporaryDirectory.appendingPathComponent(
         "TestImages", isDirectory: true)


### PR DESCRIPTION
In anticipation of [SE-0274](https://github.com/apple/swift-evolution/blob/master/proposals/0274-magic-file.md), this converts our use of `#file` to `#filePath`. We had been using the full path to point to test and other local files, which will stop functioning when `#file` produces an abbreviated file name.

We have access to `#filePath` within our toolchain, so we should be able to implement this now without impact to our targets here.