### PR TITLE
Point KMNIST at GCS-hosted archives

### DIFF
--- a/Datasets/MNIST/KuzushijiMNIST.swift
+++ b/Datasets/MNIST/KuzushijiMNIST.swift
@@ -37,7 +37,7 @@ public struct KuzushijiMNIST: ImageClassificationDataset {
         training = Batcher<SourceDataSet>(
             on: fetchMNISTDataset(
                 localStorageDirectory: localStorageDirectory,
-                remoteBaseDirectory: "http://codh.rois.ac.jp/kmnist/dataset/kmnist/",
+                remoteBaseDirectory: "https://storage.googleapis.com/s4tf-hosted-binaries/datasets/KMNIST",
                 imagesFilename: "train-images-idx3-ubyte",
                 labelsFilename: "train-labels-idx1-ubyte",
                 flattening: flattening,
@@ -49,7 +49,7 @@ public struct KuzushijiMNIST: ImageClassificationDataset {
         test = Batcher<SourceDataSet>(
             on: fetchMNISTDataset(
                 localStorageDirectory: localStorageDirectory,
-                remoteBaseDirectory: "http://codh.rois.ac.jp/kmnist/dataset/kmnist/",
+                remoteBaseDirectory: "https://storage.googleapis.com/s4tf-hosted-binaries/datasets/KMNIST",
                 imagesFilename: "t10k-images-idx3-ubyte",
                 labelsFilename: "t10k-labels-idx1-ubyte",
                 flattening: flattening,


### PR DESCRIPTION
The server hosting the original KMNIST dataset archives went offline today, triggering test failures, so we've hosted a copy of these archives on GCS. This updates the archive URLs to point to the new locations on our GCS bucket.