### PR TITLE
Correcting PerfZero benchmarks for new architecture

### DIFF
--- a/Benchmarks/__init__.py
+++ b/Benchmarks/__init__.py
@@ -86,7 +86,7 @@ def extract_metrics(result, variety):
   batch_count = len(timings_s)
 
   timings_s = np.array(timings) / 1000
-  wall_time = total_time
+  wall_time = total_time / 1000.0
 
   # Average examples per second across the entire benchmark run,
   # including warmup period. Assumes a single warmup batch.

--- a/Benchmarks/__init__.py
+++ b/Benchmarks/__init__.py
@@ -83,7 +83,7 @@ def extract_metrics(result, variety):
   warmup_time = result['warmupTime']
   total_time = result['totalTime']
   training_time = total_time - warmup_time
-  batch_count = len(timings_s)
+  batch_count = len(timings)
 
   timings_s = np.array(timings) / 1000
   wall_time = total_time / 1000.0


### PR DESCRIPTION
In PR #444, I incorrectly left off some changes to the PerfZero Python setup files in order to match to the new benchmark metrics in that pull request. This corrects that omission, and should enable PerfZero benchmarks to integrate cleanly with the new Swift benchmarks.