### PR TITLE
remove x10 from toolchain url

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,7 +1,7 @@
 FROM gcr.io/swift-tensorflow/base-deps-cuda10.1-cudnn7-ubuntu18.04
 
 # Allows the caller to specify the toolchain to use.
-ARG swift_tf_url=https://storage.googleapis.com/swift-tensorflow-artifacts/nightlies/latest/swift-tensorflow-DEVELOPMENT-x10-ubuntu18.04.tar.gz
+ARG swift_tf_url=https://storage.googleapis.com/swift-tensorflow-artifacts/nightlies/latest/swift-tensorflow-DEVELOPMENT-ubuntu18.04.tar.gz
 
 # Download and extract S4TF
 WORKDIR /swift-tensorflow-toolchain


### PR DESCRIPTION
https://github.com/apple/swift/pull/31158 makes it so that all of our toolchains include x10. Therefore, I want to change our automated build to stop publishing toolchains named "-x10-". This prepares for this change.