### PR TITLE
Rename to merge Epochs

### DIFF
--- a/Batcher/Backend.swift
+++ b/Batcher/Backend.swift
@@ -31,7 +31,7 @@ public final class ThreadSafe<A> {
 }
 
 public extension Array {
-    func concurrentMap<B>(nthreads:Int?=nil, _ transform: (Element) -> B) -> [B] {
+    func _concurrentMap<B>(nthreads:Int?=nil, _ transform: (Element) -> B) -> [B] {
         let result = ThreadSafe(Array<B?>(repeating: nil, count: count))
         let nt = nthreads ?? count
         let cs = (count-1)/nt+1

--- a/Batcher/Batcher.swift
+++ b/Batcher/Batcher.swift
@@ -22,8 +22,8 @@ public func defaultSample<C: Collection>(on dataset: inout C, shuffled: Bool) ->
 }
 
 // Default collate function for samples that conform to Collatable
-public func defaultCollate<S: Collatable>(_ batch: [S]) -> S {
-    return S(collating: batch)
+public func defaultCollate<S: _Collatable>(_ batch: [S]) -> S {
+    return S(oldCollating: batch)
 }
 
 // Main struct to collate the samples from a dataset into a batch
@@ -102,7 +102,7 @@ public struct BatchIterator<C: Collection>: IteratorProtocol, Sequence where C.I
         if (end - pos) < b.batchSize && b.dropLast { return nil }
         // The idea is to have samples processed and collated on the CPU before moving to the host.
         // This part has not been optimized yet
-        let samples = Array(pos..<end).concurrentMap(nthreads: Swift.min(b.numWorkers, end-pos)) {
+        let samples = Array(pos..<end)._concurrentMap(nthreads: Swift.min(b.numWorkers, end-pos)) {
             b.dataset[indices[$0]]
         }
         pos = end
@@ -110,8 +110,8 @@ public struct BatchIterator<C: Collection>: IteratorProtocol, Sequence where C.I
     }
 }
 
-// Add default collateSamples when the dataset elements conform to Collatable
-public extension Batcher where C.Element: Collatable {
+// Add default collateSamples when the dataset elements conform to _Collatable
+public extension Batcher where C.Element: _Collatable {
     init(
         on dataset: C, 
         batchSize: Int, 

--- a/Batcher/Collatable.swift
+++ b/Batcher/Collatable.swift
@@ -15,26 +15,26 @@
 import TensorFlow
 
 // Private protocol used to derive conformance to Collatable using KeyPathIterable
-public protocol _Collatable {
+public protocol __Collatable {
      static func _collateLeaf<Root>(
          _ rootOut: inout Root, _ rootKeyPath: PartialKeyPath<Root>, _ rootIn: [Root])
 }
 
-// Collatable: a protocol representing a type where you can stack elements together to
+// _Collatable: a protocol representing a type where you can stack elements together to
 // get some higher-rank element of the same type (example: tensors, tuple of tensors)
-public protocol Collatable: _Collatable {
-    init(collating: [Self])
+public protocol _Collatable: __Collatable {
+    init(oldCollating: [Self])
 }
 
 // For derived conformance
-extension Collatable {
+extension _Collatable {
     public static func _collateLeaf<Root>(
         _ rootOut: inout Root, _ rootKeyPath: PartialKeyPath<Root>, _ rootIn: [Root]
     ) {
         guard let keyPath = rootKeyPath as? WritableKeyPath<Root, Self> else {
             fatalError("Failed conversion from \(rootKeyPath) to 'WritableKeyPath<\(Root.self), \(Self.self)>'")
         }
-        rootOut[keyPath: keyPath] = Self.init(collating: rootIn.map { $0[keyPath: keyPath] })
+        rootOut[keyPath: keyPath] = Self.init(oldCollating: rootIn.map { $0[keyPath: keyPath] })
     }
 }
 
@@ -44,7 +44,7 @@ extension _KeyPathIterableBase {
         _ rootOut: inout Root, _ rootKeyPath: PartialKeyPath<Root>, _ rootIn: [Root]) {
         for kp in _allKeyPathsTypeErased {
             let joinedKeyPath = rootKeyPath.appending(path: kp)!
-            if let valueType = type(of: joinedKeyPath).valueType as? _Collatable.Type {
+            if let valueType = type(of: joinedKeyPath).valueType as? __Collatable.Type {
                 valueType._collateLeaf(&rootOut, joinedKeyPath, rootIn)
             } else if let nested = self[keyPath: kp] as? _KeyPathIterableBase {
                 nested._collateAll(&rootOut, joinedKeyPath, rootIn)
@@ -57,19 +57,19 @@ extension _KeyPathIterableBase {
 
 // For derived conformance
 extension KeyPathIterable {
-    public init(collating roots: [Self]) {
+    public init(oldCollating roots: [Self]) {
         self = roots[0]
         _collateAll(&self, \.self, roots)
     }
 }
 
 // Tensor are collated using stacking
-extension Tensor: Collatable {
-    public init(collating: [Self]) { self.init(stacking: collating) }
+extension Tensor: _Collatable {
+    public init(oldCollating: [Self]) { self.init(stacking: oldCollating) }
 }
 
-// Example: you can derive conformance to Collatable directly if a struct has only tensors
-// struct Pair : Collatable, KeyPathIterable {
+// Example: you can derive conformance to _Collatable directly if a struct has only tensors
+// struct Pair : _Collatable, KeyPathIterable {
 //     var first: Tensor
 //     var second: Tensor
 //     var third: Tensor = Tensor(5.0)

--- a/Datasets/COCO/COCODataset.swift
+++ b/Datasets/COCO/COCODataset.swift
@@ -46,7 +46,7 @@ func loadCOCOExamples(from coco: COCO, includeMasks: Bool, batchSize: Int, numWo
     let batchCount: Int = images.count / batchSize + 1
     let n = min(numWorkers, batchCount)
     let batches = Array(0..<batchCount)
-    let examples: [[ObjectDetectionExample]] = batches.concurrentMap(nthreads: n) { batchIdx in
+    let examples: [[ObjectDetectionExample]] = batches._concurrentMap(nthreads: n) { batchIdx in
         var examples: [ObjectDetectionExample] = []
         for i in 0..<batchSize {
             let idx = batchSize * batchIdx + i

--- a/Datasets/ObjectDetectionDataset.swift
+++ b/Datasets/ObjectDetectionDataset.swift
@@ -52,7 +52,7 @@ public struct LabeledObject {
     }
 }
 
-public struct ObjectDetectionExample: Collatable, KeyPathIterable {
+public struct ObjectDetectionExample: _Collatable, KeyPathIterable {
     public let image: LazyImage
     public let objects: [LabeledObject]
 

--- a/Datasets/TensorPair.swift
+++ b/Datasets/TensorPair.swift
@@ -21,7 +21,7 @@ import Batcher
 /// `Collatable`. You can use it for most basic datasets with one tensor of inputs and one tensor of
 /// labels but you should write your own struct for more complex tasks (or if you want more descriptive
 /// names).
-public struct TensorPair<S1: TensorFlowScalar, S2: TensorFlowScalar>: Collatable, KeyPathIterable {
+public struct TensorPair<S1: TensorFlowScalar, S2: TensorFlowScalar>: _Collatable, KeyPathIterable {
     public var first: Tensor<S1>
     public var second: Tensor<S2>
     

--- a/pix2pix/Dataset.swift
+++ b/pix2pix/Dataset.swift
@@ -18,10 +18,10 @@ import TensorFlow
 import Batcher
 
 public class PairedImages {
-    public struct ImagePair: Collatable {
-        public init(collating: [PairedImages.ImagePair]) {
-            self.source = .init(stacking: collating.map(\.source))
-            self.target = .init(stacking: collating.map(\.target))
+    public struct ImagePair: _Collatable {
+        public init(oldCollating: [PairedImages.ImagePair]) {
+            self.source = .init(stacking: oldCollating.map(\.source))
+            self.target = .init(stacking: oldCollating.map(\.target))
         }
         
         public init(source: Tensor<Float>, target: Tensor<Float>) {


### PR DESCRIPTION
In order to merge the [epochs PR](https://github.com/tensorflow/swift-apis/pull/864), we need to temporarily rename `Collatable` and `concurrentMap` to avoid conflicts with the same struct/extension in Epochs.

This PR underscores them, we can undo that in the applications once the epochs PR is merged and in the nightlies.