### PR TITLE
Fix CycleGAN build error.

### DIFF
--- a/CycleGAN/main.swift
+++ b/CycleGAN/main.swift
@@ -25,7 +25,7 @@ let trainFolderB: URL
 let testFolderA: URL
 let testFolderB: URL
 
-if options.datasetPath.length != 0 {
+if !options.datasetPath.isEmpty {
     datasetFolder = URL(fileURLWithPath: options.datasetPath, isDirectory: true)
     trainFolderA = datasetFolder.appendingPathComponent("trainA")
     trainFolderB = datasetFolder.appendingPathComponent("trainB")


### PR DESCRIPTION
`String` has no member called `length`.
Use `String.isEmpty` instead.

---

Fixes `swift build` (on macOS):
```console
$ swift build
swift-models/CycleGAN/main.swift:28:24: error: value of type 'String' has no member 'length'
if options.datasetPath.length != 0 {
   ~~~~~~~~~~~~~~~~~~~ ^~~~~~
```

Confirmed that `swift run CycleGAN` works.