### PR TITLE
Use `String?` instead of `String` in CLIs.

### DIFF
--- a/CycleGAN/CLI.swift
+++ b/CycleGAN/CLI.swift
@@ -15,8 +15,8 @@
 import ArgumentParser
 
 struct Options: ParsableArguments {
-    @Option(default: "", help: ArgumentHelp("Path to the dataset folder", valueName: "dataset-path"))
-    var datasetPath: String
+    @Option(help: ArgumentHelp("Path to the dataset folder", valueName: "dataset-path"))
+    var datasetPath: String?
 
     @Option(default: 50, help: ArgumentHelp("Number of epochs", valueName: "epochs"))
     var epochs: Int

--- a/CycleGAN/main.swift
+++ b/CycleGAN/main.swift
@@ -25,8 +25,8 @@ let trainFolderB: URL
 let testFolderA: URL
 let testFolderB: URL
 
-if !options.datasetPath.isEmpty {
-    datasetFolder = URL(fileURLWithPath: options.datasetPath, isDirectory: true)
+if let datasetPath = options.datasetPath {
+    datasetFolder = URL(fileURLWithPath: datasetPath, isDirectory: true)
     trainFolderA = datasetFolder.appendingPathComponent("trainA")
     trainFolderB = datasetFolder.appendingPathComponent("trainB")
     testFolderA = datasetFolder.appendingPathComponent("testA")

--- a/pix2pix/CLI.swift
+++ b/pix2pix/CLI.swift
@@ -15,8 +15,8 @@
 import ArgumentParser
 
 struct Options: ParsableArguments {
-    @Option(default: "", help: ArgumentHelp("Path to the dataset folder", valueName: "dataset-path"))
-    var datasetPath: String
+    @Option(help: ArgumentHelp("Path to the dataset folder", valueName: "dataset-path"))
+    var datasetPath: String?
 
     @Option(default: 1, help: ArgumentHelp("Number of epochs", valueName: "epochs"))
     var epochs: Int

--- a/pix2pix/main.swift
+++ b/pix2pix/main.swift
@@ -25,8 +25,8 @@ let trainFolderB: URL
 let testFolderA: URL
 let testFolderB: URL
 
-if !options.datasetPath.isEmpty {
-    datasetFolder = URL(fileURLWithPath: options.datasetPath, isDirectory: true)
+if let datasetPath = options.datasetPath {
+    datasetFolder = URL(fileURLWithPath: datasetPath, isDirectory: true)
     trainFolderA = datasetFolder.appendingPathComponent("trainA")
     testFolderA = datasetFolder.appendingPathComponent("testA")
     trainFolderB = datasetFolder.appendingPathComponent("trainB")


### PR DESCRIPTION
Use `String?` instead of `String` with default empty string to parse
CycleGAN and pix2pix command line arguments.

Fiollow-up to https://github.com/tensorflow/swift-models/pull/460.

Confirmed that `swift run CycleGAN` and `swift run pix2pix` continue to work.