### PR TITLE
[WIP]: Exploring removing `<Float>` everywhere.

### DIFF
--- a/Models/ImageClassification/LeNet-5.swift
+++ b/Models/ImageClassification/LeNet-5.swift
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 import TensorFlow
+import ModelSupport
 
 // Original Paper:
 // "Gradient-Based Learning Applied to Document Recognition"
@@ -22,21 +23,32 @@ import TensorFlow
 // Note: this implementation connects all the feature maps in the second convolutional layer.
 // Additionally, ReLU is used instead of sigmoid activations.
 
-public struct LeNet: Layer {
-    public var conv1 = Conv2D<Float>(filterShape: (5, 5, 1, 6), padding: .same, activation: relu)
-    public var pool1 = AvgPool2D<Float>(poolSize: (2, 2), strides: (2, 2))
-    public var conv2 = Conv2D<Float>(filterShape: (5, 5, 6, 16), activation: relu)
-    public var pool2 = AvgPool2D<Float>(poolSize: (2, 2), strides: (2, 2))
-    public var flatten = Flatten<Float>()
-    public var fc1 = Dense<Float>(inputSize: 400, outputSize: 120, activation: relu)
-    public var fc2 = Dense<Float>(inputSize: 120, outputSize: 84, activation: relu)
-    public var fc3 = Dense<Float>(inputSize: 84, outputSize: 10)
+
+public struct LeNet: Layer, Foo {
+    public var conv1 = Conv2D(filterShape: (5, 5, 1, 6), padding: .same, activation: relu)
+    public var pool1 = AvgPool2D(poolSize: (2, 2), strides: (2, 2))
+    public var conv2 = Conv2D(filterShape: (5, 5, 6, 16), activation: relu)
+    public var pool2 = AvgPool2D(poolSize: (2, 2), strides: (2, 2))
+    public var flatten = Flatten()
+    public var fc1 = Dense(inputSize: 400, outputSize: 120, activation: relu)
+    public var fc2 = Dense(inputSize: 120, outputSize: 84, activation: relu)
+    public var fc3 = Dense(inputSize: 84, outputSize: 10)
 
     public init() {}
 
     @differentiable
-    public func callAsFunction(_ input: Tensor<Float>) -> Tensor<Float> {
+    public func callAsFunction(_ input: TensorF) -> TensorF {
         let convolved = input.sequenced(through: conv1, pool1, conv2, pool2)
         return convolved.sequenced(through: flatten, fc1, fc2, fc3)
     }
+}
+
+// Can't move this to another module apparently...
+public protocol Foo {
+  typealias Conv2D = TensorFlow.Conv2D<Float>
+  typealias AvgPool2D = TensorFlow.AvgPool2D<Float>
+  typealias MaxPool2D = TensorFlow.MaxPool2D<Float>
+  typealias Flatten = TensorFlow.Flatten<Float>
+  typealias Dense = TensorFlow.Dense<Float>
+  typealias TensorF = TensorFlow.Tensor<Float>
 }

--- a/Models/ImageClassification/VGG.swift
+++ b/Models/ImageClassification/VGG.swift
@@ -19,38 +19,38 @@ import TensorFlow
 // Karen Simonyan, Andrew Zisserman
 // https://arxiv.org/abs/1409.1556
 
-public struct VGGBlock: Layer {
-    var blocks: [Conv2D<Float>] = []
-    var maxpool = MaxPool2D<Float>(poolSize: (2, 2), strides: (2, 2))
+public struct VGGBlock: Layer, Foo {
+    var blocks: [Self.Conv2D] = []
+    var maxpool = MaxPool2D(poolSize: (2, 2), strides: (2, 2))
 
     public init(featureCounts: (Int, Int, Int, Int), blockCount: Int) {
-        self.blocks = [Conv2D<Float>(filterShape: (3, 3, featureCounts.0, featureCounts.1),
+        self.blocks = [Conv2D(filterShape: (3, 3, featureCounts.0, featureCounts.1),
             padding: .same,
             activation: relu)]
         for _ in 1..<blockCount {
-            self.blocks += [Conv2D<Float>(filterShape: (3, 3, featureCounts.2, featureCounts.3),
+            self.blocks += [Conv2D(filterShape: (3, 3, featureCounts.2, featureCounts.3),
                 padding: .same,
                 activation: relu)]
         }
     }
 
     @differentiable
-    public func callAsFunction(_ input: Tensor<Float>) -> Tensor<Float> {
+    public func callAsFunction(_ input: TensorF) -> TensorF {
         return maxpool(blocks.differentiableReduce(input) { $1($0) })
     }
 }
 
-public struct VGG16: Layer {
+public struct VGG16: Layer, Foo {
     var layer1: VGGBlock
     var layer2: VGGBlock
     var layer3: VGGBlock
     var layer4: VGGBlock
     var layer5: VGGBlock
 
-    var flatten = Flatten<Float>()
-    var dense1 = Dense<Float>(inputSize: 512 * 7 * 7, outputSize: 4096, activation: relu)
-    var dense2 = Dense<Float>(inputSize: 4096, outputSize: 4096, activation: relu)
-    var output: Dense<Float>
+    var flatten = Flatten()
+    var dense1 = Dense(inputSize: 512 * 7 * 7, outputSize: 4096, activation: relu)
+    var dense2 = Dense(inputSize: 4096, outputSize: 4096, activation: relu)
+    var output: Self.Dense
 
     public init(classCount: Int = 1000) {
         layer1 = VGGBlock(featureCounts: (3, 64, 64, 64), blockCount: 2)

--- a/Support/SugarLayer.swift
+++ b/Support/SugarLayer.swift
@@ -1,0 +1,43 @@
+// Copyright 2019 The TensorFlow Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import TensorFlow
+
+public protocol EasyLayers {
+  typealias Conv2D = TensorFlow.Conv2D<Float>
+  typealias AvgPool2D = TensorFlow.AvgPool2D<Float>
+  typealias Flatten = TensorFlow.Flatten<Float>
+  typealias Dense = TensorFlow.Dense<Float>
+  typealias TensorF = TensorFlow.Tensor<Float>
+}
+
+
+/*
+// Tinkercruft...
+public protocol TypedModel: Layer {
+  associatedtype Scalar: TensorFlowScalar
+  
+  typealias Tensor = TensorFlow.Tensor<Scalar>
+  typealias TTensor = TensorFlow.Tensor
+}
+
+public extension TypedModel where Scalar: TensorFlowFloatingPoint {
+  typealias Conv2D = TensorFlow.Conv2D<Scalar>
+  typealias AvgPool2D = TensorFlow.AvgPool2D<Scalar>
+  typealias Flatten = TensorFlow.Flatten<Scalar>
+  typealias Dense = TensorFlow.Dense<Scalar>
+}
+
+public protocol FloatModel: TypedModel where Scalar == Float {}
+*/


### PR DESCRIPTION
This change explores stuffing some extra typealiases in a protocol to obviate
the need to specify `Foo<Float>` everywhere. Unfortunately, it appears that
the typealiases don't override the imports when they're defined in another
module.

Disadvantages of this approach: it might make it more confusing for someone
who is unfamiliar with this pattern to understand what is specifying the
scalar parameter.

Finally, in certain usages, typealiases even within the same module did not
work, and had to use `Self.$TYPEALIAS` to get it to compile, even in the
same module. Also, although I didn't play around with it much, the `Tensor`
typealias also caused a number of problems in the typechecker.