### PR TITLE
Add eager / X10 backend selection to the benchmarks

### DIFF
--- a/Benchmarks/Benchmark.swift
+++ b/Benchmarks/Benchmark.swift
@@ -16,7 +16,7 @@ import Foundation
 
 protocol Benchmark {
     var batchSize: Int { get }
-    func run() -> [Double]
+    func run(backend: Backend) -> [Double]
 }
 
 /// Performs the specified benchmark over a certain number of iterations and provides the result to a callback function.
@@ -29,7 +29,7 @@ func measure(
     let iterations = configuration.settings.iterations
     let start = timestampInMilliseconds()
     for _ in 0..<iterations {
-        var timedSteps = benchmark.run()
+        var timedSteps = benchmark.run(backend: configuration.settings.backend)
         warmup.append(contentsOf: timedSteps.prefix(configuration.settings.warmupBatches))
         timedSteps.removeFirst(configuration.settings.warmupBatches)
         timings.append(contentsOf: timedSteps)

--- a/Benchmarks/BenchmarkSettings.swift
+++ b/Benchmarks/BenchmarkSettings.swift
@@ -18,4 +18,10 @@ struct BenchmarkSettings: Codable {
     let iterations: Int
     let warmupBatches: Int
     let synthetic: Bool
+    let backend: Backend
+}
+
+enum Backend: String, Codable {
+    case eager = "eager"
+    case x10 = "x10"
 }

--- a/Benchmarks/Models/ImageClassificationInference.swift
+++ b/Benchmarks/Models/ImageClassificationInference.swift
@@ -58,7 +58,6 @@ where Model: ImageClassificationModel, ClassificationDataset: ImageClassificatio
         case .x10: device = Device.defaultXLA
         }
         model.move(to: device)
-        LazyTensorBarrier()
 
         var batchTimings: [Double] = []
         var currentBatch = 0

--- a/Benchmarks/Models/ImageClassificationInference.swift
+++ b/Benchmarks/Models/ImageClassificationInference.swift
@@ -51,7 +51,7 @@ where Model: ImageClassificationModel, ClassificationDataset: ImageClassificatio
         }
     }
 
-    func run() -> [Double] {
+    func run(backend: Backend) -> [Double] {
         var batchTimings: [Double] = []
         var currentBatch = 0
         for batch in testDataset.sequenced() {

--- a/Benchmarks/Models/ImageClassificationTraining.swift
+++ b/Benchmarks/Models/ImageClassificationTraining.swift
@@ -61,7 +61,6 @@ where
         optimizer = SGD(copying: optimizer, to: device)
         var batchTimings: [Double] = []
         var currentBatch = 0
-        LazyTensorBarrier()
 
         // Run a blank iteration through the entire dataset to force loading of all data from disk.
         for _ in trainingDataset.sequenced() {}

--- a/Benchmarks/Models/LeNetMnist.swift
+++ b/Benchmarks/Models/LeNetMnist.swift
@@ -29,10 +29,10 @@ enum LeNetMNIST: BenchmarkModel {
         switch(variety) {
         case .inferenceThroughput:
             return BenchmarkSettings(batches: 1000, batchSize: 128, iterations: 10,
-                                     warmupBatches: 1, synthetic: false)
+                                     warmupBatches: 1, synthetic: false, backend: .eager)
         case .trainingThroughput:
             return BenchmarkSettings(batches: 110, batchSize: 128, iterations: 1, warmupBatches: 1,
-                                     synthetic: false)
+                                     synthetic: false, backend: .eager)
         }
     }
 

--- a/Benchmarks/Models/ResNetCIFAR10.swift
+++ b/Benchmarks/Models/ResNetCIFAR10.swift
@@ -30,10 +30,10 @@ enum ResNetCIFAR10: BenchmarkModel {
         switch(variety) {
         case .inferenceThroughput:
             return BenchmarkSettings(batches: 1000, batchSize: 128, iterations: 10,
-                                     warmupBatches: 1, synthetic: false)
+                                     warmupBatches: 1, synthetic: false, backend: .eager)
         case .trainingThroughput:
             return BenchmarkSettings(batches: 110, batchSize: 128, iterations: 1, warmupBatches: 1,
-                                     synthetic: false)
+                                     synthetic: false, backend: .eager)
         }
     }
 

--- a/Benchmarks/PrintingStyle.swift
+++ b/Benchmarks/PrintingStyle.swift
@@ -79,6 +79,7 @@ extension BenchmarkConfiguration {
         case .inferenceThroughput:
             result += "--inference "
         }
+        result += "--\(settings.backend) "
         if self.settings.synthetic {
             result += "--synthetic "
         } else {

--- a/Benchmarks/__init__.py
+++ b/Benchmarks/__init__.py
@@ -135,9 +135,10 @@ def extract_metrics(result, variety, backend):
 
 def run_swift_benchmark(name, variety, backend):
   print('running swift benchmark {} ({})'.format(name, variety))
+  # TODO: Remove the need for 2 warmup batches when we have better-shaped zero tangent vectors.
   output = subp.check_output([
       'swift', 'run', '-c', 'release', 'Benchmarks', 'measure', '--benchmark',
-      name, '--' + variety, '--' + backend, '--json'
+      name, '--' + variety, '--' + backend, '--warmupBatches 2', '--json'
   ], cwd=cwd)
   result = json.loads(output)
   print('got json result back from swift: ')

--- a/Benchmarks/__init__.py
+++ b/Benchmarks/__init__.py
@@ -45,13 +45,23 @@ class SwiftBenchmark(tf.test.Benchmark):
     pass
 
   def training(self):
-    """Runner-ccallable benchmark entry point for training benchmark."""
-    result = run_swift_benchmark(name=self.benchmark_name, variety='training')
+    """Runner-callable benchmark entry point for eager training benchmark."""
+    result = run_swift_benchmark(name=self.benchmark_name, variety='training', backend='eager')
     self.report_benchmark(**result)
 
   def inference(self):
-    """Runner-callable benchmark entry point for inference benchmark."""
-    result = run_swift_benchmark(name=self.benchmark_name, variety='inference')
+    """Runner-callable benchmark entry point for eager inference benchmark."""
+    result = run_swift_benchmark(name=self.benchmark_name, variety='inference', backend='eager')
+    self.report_benchmark(**result)
+
+  def training_x10(self):
+    """Runner-callable benchmark entry point for x10 training benchmark."""
+    result = run_swift_benchmark(name=self.benchmark_name, variety='training', backend='x10')
+    self.report_benchmark(**result)
+
+  def inference_x10(self):
+    """Runner-callable benchmark entry point for x10 inference benchmark."""
+    result = run_swift_benchmark(name=self.benchmark_name, variety='inference', backend='x10')
     self.report_benchmark(**result)
 
 
@@ -71,7 +81,7 @@ def extract_extras(settings):
   return
 
 
-def extract_metrics(result, variety):
+def extract_metrics(result, variety, backend):
   """Extract PerfZero metrics based on the measurements.
 
   Extracts metrics such as number of examples per second,
@@ -123,17 +133,17 @@ def extract_metrics(result, variety):
   return (wall_time, metrics)
 
 
-def run_swift_benchmark(name, variety):
+def run_swift_benchmark(name, variety, backend):
   print('running swift benchmark {} ({})'.format(name, variety))
   output = subp.check_output([
       'swift', 'run', '-c', 'release', 'Benchmarks', 'measure', '--benchmark',
-      name, '--' + variety, '--json'
+      name, '--' + variety, '--' + backend, '--json'
   ], cwd=cwd)
   result = json.loads(output)
   print('got json result back from swift: ')
   print(result)
   settings = result['configuration']['settings']
-  wall_time, metrics = extract_metrics(result, variety)
+  wall_time, metrics = extract_metrics(result, variety, backend)
   return {
       'iters': settings['iterations'],
       'wall_time': wall_time,

--- a/Benchmarks/main.swift
+++ b/Benchmarks/main.swift
@@ -101,6 +101,12 @@ extension BenchmarkCommand {
         @Flag(help: "Use real data.")
         var real: Bool
 
+        @Flag(help: "Use eager backend.")
+        var eager: Bool
+
+        @Flag(help: "Use X10 backend.")
+        var x10: Bool
+
         @Option(help: "Name of the benchmark to run.")
         var benchmark: String?
 
@@ -139,6 +145,11 @@ extension BenchmarkCommand {
                     "Can't specify both --real and --synthetic data sources.")
             }
 
+            guard !(eager && x10) else {
+                throw ValidationError(
+                    "Can't specify both --eager and --x10 backends.")
+            }
+
             guard !((batches != nil) && (epochs != nil)) else {
                 throw ValidationError(
                     "Can't specify both the number of batches and epochs.")
@@ -157,6 +168,7 @@ extension BenchmarkCommand {
         func run() throws {
             let style: PrintingStyle = useJSON ? .json : .plainText
             let variety: BenchmarkVariety = training ? .trainingThroughput : .inferenceThroughput
+            let backend: Backend = x10 ? .x10 : .eager
             let benchmarkModel = benchmarkModels[benchmark!]!
             let defaults = benchmarkModel.defaults(for: variety)
             let batchSizeToUse = batchSize ?? defaults.batchSize
@@ -173,7 +185,7 @@ extension BenchmarkCommand {
                 batchSize: batchSizeToUse,
                 iterations: iterations ?? defaults.iterations,
                 warmupBatches: warmupBatches ?? defaults.warmupBatches,
-                synthetic: synthetic)
+                synthetic: synthetic, backend: backend)
 
             runBenchmark(
                 benchmarkModel,


### PR DESCRIPTION
In order to provide benchmarks for the new x10 backend, in addition to the existing eager backend, this adds the `--x10` and `--eager` options to the Benchmarks target. These options switch between using the X10 and eager backends, respectively, and support has been added within the image classification inference and training benchmarks to support X10 in parallel with the default eager execution.

For now, we're using the first two batches as a warmup period, instead of just the first batch (as is done for the other PerfZero benchmarks), due to an extra recompilation we're experiencing in the second batch. Once that extra recompilation is removed, we'll switch back to a single batch for warmup.

Additionally, to work around some caching artifacts we're seeing with batched data, I'm doing an initial empty pass through the entire training dataset before running the throughput benchmarks in order to warm up any caches involved. This provides more consistent results.

