### PR TITLE
Quick fix for a bad PerfZero argument

### DIFF
--- a/Benchmarks/__init__.py
+++ b/Benchmarks/__init__.py
@@ -138,7 +138,7 @@ def run_swift_benchmark(name, variety, backend):
   # TODO: Remove the need for 2 warmup batches when we have better-shaped zero tangent vectors.
   output = subp.check_output([
       'swift', 'run', '-c', 'release', 'Benchmarks', 'measure', '--benchmark',
-      name, '--' + variety, '--' + backend, '--warmupBatches 2', '--json'
+      name, '--' + variety, '--' + backend, '--warmupBatches', '2', '--json'
   ], cwd=cwd)
   result = json.loads(output)
   print('got json result back from swift: ')


### PR DESCRIPTION
I accidentally forgot to split the argument for the `warmupBatches` in PR #468, and only ran the Docker tests on the commit just before that, so this slipped through. This re-enables our benchmarks with correct arguments.