### PR TITLE
[ShuffleNetV2] Resolve warning about non-mutating var

### DIFF
--- a/Models/ImageClassification/ShuffleNetV2.swift
+++ b/Models/ImageClassification/ShuffleNetV2.swift
@@ -70,7 +70,7 @@ public struct InvertedResidual: Layer {
             )
             BatchNorm<Float>(featureCount: branchChannels)
         }
-        var inputChannels = includeBranch ? filters.0: branchChannels
+        let inputChannels = includeBranch ? filters.0: branchChannels
         conv1 = Conv2D<Float>(
             filterShape: (1, 1, inputChannels, branchChannels), strides: (1, 1), padding: .valid,
             useBias: false


### PR DESCRIPTION
Change `inputChannels` from variable to constant to resolve compiler warning:

```
Models/ImageClassification/ShuffleNetV2.swift:73:13: warning: variable 'inputChannels' was never mutated; consider changing to 'let' constant
```