### PR TITLE
Use Collatable for TextBatch

### DIFF
--- a/Datasets/CoLA/CoLA.swift
+++ b/Datasets/CoLA/CoLA.swift
@@ -163,8 +163,8 @@ extension CoLA {
                 sizeFn: { _ in batchSize / maxSequenceLength },
                 reduceFn: {
                     DataBatch(
-                        inputs: padAndBatch(
-                            textBatches: $0.map { $0.inputs }, maxLength: maxSequenceLength),
+                        inputs: $0.map { $0.inputs }.paddedAndCollated(
+                            to: maxSequenceLength),
                         labels: Tensor.batch($0.map { $0.labels! }))
                 },
                 dropRemainder: dropRemainder
@@ -177,8 +177,8 @@ extension CoLA {
                 sizeFn: { _ in batchSize / maxSequenceLength },
                 reduceFn: {
                     DataBatch(
-                        inputs: padAndBatch(
-                            textBatches: $0.map { $0.inputs }, maxLength: maxSequenceLength),
+                        inputs: $0.map { $0.inputs }.paddedAndCollated(
+                            to: maxSequenceLength),
                         labels: Tensor.batch($0.map { $0.labels! }))
                 },
                 dropRemainder: dropRemainder
@@ -190,8 +190,8 @@ extension CoLA {
                 sizeFn: { _ in batchSize / maxSequenceLength },
                 reduceFn: {
                     DataBatch(
-                        inputs: padAndBatch(
-                            textBatches: $0.map { $0.inputs }, maxLength: maxSequenceLength),
+                        inputs: $0.map { $0.inputs }.paddedAndCollated(
+                            to: maxSequenceLength),
                         labels: nil)
                 },
                 dropRemainder: dropRemainder

--- a/Support/Text/TextBatch.swift
+++ b/Support/Text/TextBatch.swift
@@ -15,48 +15,62 @@
 import TensorFlow
 
 /// Tokenized text passage.
-public struct TextBatch: KeyPathIterable {
-    /// IDs that correspond to the vocabulary used while tokenizing.
-    /// The shape of this tensor is `[batchSize, maxSequenceLength]`.
-    public var tokenIds: Tensor<Int32> // TODO: !!! Mutable in order to allow for batching.
+public struct TextBatch {
+  /// IDs that correspond to the vocabulary used while tokenizing.
+  /// The shape of this tensor is `[batchSize, maxSequenceLength]`.
+  public let tokenIds: Tensor<Int32>
 
-    /// IDs of the token types (e.g., sentence A and sentence B in BERT).
-    /// The shape of this tensor is `[batchSize, maxSequenceLength]`.
-    public var tokenTypeIds: Tensor<Int32> // TODO: !!! Mutable in order to allow for batching.
+  /// IDs of the token types (e.g., sentence A and sentence B in BERT).
+  /// The shape of this tensor is `[batchSize, maxSequenceLength]`.
+  public let tokenTypeIds: Tensor<Int32>
 
-    /// Mask over the sequence of tokens specifying which ones are "real" as opposed to "padding".
-    /// The shape of this tensor is `[batchSize, maxSequenceLength]`.
-    public var mask: Tensor<Int32> // TODO: !!! Mutable in order to allow for batching.
+  /// Mask over the sequence of tokens specifying which ones are "real" as 
+  /// opposed to "padding".
+  /// The shape of this tensor is `[batchSize, maxSequenceLength]`.
+  public let mask: Tensor<Int32>
 
-    public init(tokenIds: Tensor<Int32>, tokenTypeIds: Tensor<Int32>, mask: Tensor<Int32>) {
-        self.tokenIds = tokenIds
-        self.tokenTypeIds = tokenTypeIds
-        self.mask = mask
-    }
+  public init(
+    tokenIds: Tensor<Int32>, tokenTypeIds: Tensor<Int32>, mask: Tensor<Int32>
+  ) {
+    self.tokenIds = tokenIds
+    self.tokenTypeIds = tokenTypeIds
+    self.mask = mask
+  }
 }
 
-// TODO: Add documentation.
-public func padAndBatch(textBatches: [TextBatch], maxLength: Int? = nil) -> TextBatch {
-    if textBatches.count == 1 { return textBatches.first! }
-    let maxLength = maxLength ?? textBatches.map { $0.tokenIds.shape[1] }.max()!
-    let paddedBatches = textBatches.map { batch -> TextBatch in
-        let paddingSize = maxLength - batch.tokenIds.shape[1]
-        return TextBatch(
-            tokenIds: batch.tokenIds.padded(forSizes: [
-                (before: 0, after: 0),
-                (before: 0, after: paddingSize)]),
-            tokenTypeIds: batch.tokenTypeIds.padded(forSizes: [
-                (before: 0, after: 0),
-                (before: 0, after: paddingSize)]),
-            mask: batch.mask.padded(forSizes: [
-                (before: 0, after: 0),
-                (before: 0, after: paddingSize)]))
+// TODO: When derived conformance to Collatable is implemented in swift-apis, 
+// this won't be necessary.
+extension TextBatch: Collatable {
+  /// Creates an instance from collating `samples`.
+  public init<BatchSamples: Collection>(collating samples: BatchSamples)
+  where BatchSamples.Element == Self {
+    self.init(
+      tokenIds: .init(collating: samples.map(\.tokenIds)), 
+      tokenTypeIds: .init(collating: samples.map(\.tokenTypeIds)), 
+      mask: .init(collating: samples.map(\.mask))
+    )
+  }
+}
+
+extension Collection where Element == TextBatch {
+  /// Returns the elements of `self`, padded to `maxLength` if specified
+  /// or the maximum length of the elements in `self` otherwise.
+  public func paddedAndCollated(to maxLength: Int? = nil) -> TextBatch {
+    if count == 1 { return first! }
+    let maxLength = maxLength ?? self.map { $0.tokenIds.shape[1] }.max()!
+    let paddedTexts = self.map { text -> TextBatch in
+      let paddingSize = maxLength - text.tokenIds.shape[1]
+      return TextBatch(
+        tokenIds: text.tokenIds.padded(forSizes: [
+          (before: 0, after: 0),
+          (before: 0, after: paddingSize)]),
+        tokenTypeIds: text.tokenTypeIds.padded(forSizes: [
+          (before: 0, after: 0),
+          (before: 0, after: paddingSize)]),
+        mask: text.mask.padded(forSizes: [
+          (before: 0, after: 0),
+          (before: 0, after: paddingSize)]))
     }
-    return TextBatch(
-        tokenIds: Tensor<Int32>(
-            concatenating: paddedBatches.map { $0.tokenIds }, alongAxis: 0),
-        tokenTypeIds: Tensor<Int32>(
-            concatenating: paddedBatches.map { $0.tokenTypeIds }, alongAxis: 0),
-        mask: Tensor<Int32>(
-            concatenating: paddedBatches.map { $0.mask }, alongAxis: 0))
+    return paddedTexts.collated
+  }
 }

--- a/Support/Text/TextBatch.swift
+++ b/Support/Text/TextBatch.swift
@@ -38,19 +38,19 @@ public struct TextBatch {
   }
 }
 
-// TODO: When derived conformance to Collatable is implemented in swift-apis, 
-// this won't be necessary.
+// TODO: Use parallelism to grab the samples in parallel.
 extension TextBatch: Collatable {
   /// Creates an instance from collating `samples`.
   public init<BatchSamples: Collection>(collating samples: BatchSamples)
   where BatchSamples.Element == Self {
     self.init(
-      tokenIds: .init(collating: samples.map(\.tokenIds)), 
-      tokenTypeIds: .init(collating: samples.map(\.tokenTypeIds)), 
-      mask: .init(collating: samples.map(\.mask))
+      tokenIds: .init(concatenating: samples.map(\.tokenIds)), 
+      tokenTypeIds: .init(concatenating: samples.map(\.tokenTypeIds)), 
+      mask: .init(concatenating: samples.map(\.mask))
     )
   }
 }
+
 
 extension Collection where Element == TextBatch {
   /// Returns the elements of `self`, padded to `maxLength` if specified


### PR DESCRIPTION
This is the first step toward using Epochs to load the COLA dataset. The changes are:

- make `TextBatch` conform to `Collatable` (this will be trivial once derived conformance is implemented in master);
- use `let` instead of `var` inside `TextBatch` since we don't need to mutate them;
- make the padding function a method on `Collection` of `TextBatch` (with the same name as what is in Epochs for consistence).