### PR TITLE
Load encoded file if BPE is nil in TextUnsupervised

### DIFF
--- a/Datasets/TextUnsupervised/TextUnsupervised.swift
+++ b/Datasets/TextUnsupervised/TextUnsupervised.swift
@@ -179,7 +179,7 @@ public struct TextUnsupervised {
             let pathPrefix = directory.appendingPathComponent("\(variantDetails.encodedFileName!)/\(name)").path
             for i in 0..<documentCount {
                 encodedDocs += [
-                  NSArray(contentsOf: URL(fileURLWithPath: "\(pathPrefix)/doc_\(i).txt")) as! [Int]
+                  try NSArray(contentsOf: URL(fileURLWithPath: "\(pathPrefix)/doc_\(i).txt"), error: ()) as! [Int]
                 ]
             }
         }


### PR DESCRIPTION
Text encoding with Byte Pair Encoder has O(N*N) time complexity https://github.com/tensorflow/swift-models/blob/master/Support/Text/BytePairEncoder.swift#L101. Encoding for full WikiText2 training and testing dataset can take ~100 minutes. 

We wanted to make the cache optional where if the encoded text provided then load them directly.