### PR TITLE
In the Neural Collaborative Filtering model, generalize to arbitrary layers and improve parameters (#474)

### DIFF
--- a/Examples/NeuMF-MovieLens/main.swift
+++ b/Examples/NeuMF-MovieLens/main.swift
@@ -28,8 +28,8 @@ let size: [Int] = [16, 32, 16, 8]
 let regs: [Float] = [0.0, 0.0, 0.0, 0.0]
 
 var model = NeuMF(
-    numUsers: numUsers, numItems: numItems, mfDim: 8, mfReg: 0.0, mlpLayerSizes: size,
-    mlpLayerRegs: regs)
+    numUsers: numUsers, numItems: numItems, numLatentFeatures: 8, matrixRegularization: 0.0, mlpLayerSizes: size,
+    mlpRegularizations: regs)
 let optimizer = Adam(for: model, learningRate: 0.001)
 var itemCount = Dictionary(
     uniqueKeysWithValues: zip(

--- a/Models/Recommendation/NeuMF.swift
+++ b/Models/Recommendation/NeuMF.swift
@@ -26,73 +26,71 @@ public struct NeuMF: Module {
     public typealias Scalar = Float
     @noDerivative public let numUsers: Int
     @noDerivative public let numItems: Int
-    @noDerivative public let mfDim: Int
-    @noDerivative public let mfReg: Scalar
+    @noDerivative public let numLatentFeatures: Int
+    @noDerivative public let matrixRegularization: Scalar
     @noDerivative public var mlpLayerSizes: [Int] = [64, 32, 16, 8]
-    @noDerivative public var mlpLayerRegs: [Scalar] = [0, 0, 0, 0]
+    @noDerivative public var mlpRegularizations: [Scalar] = [0, 0, 0, 0]
 
-    public var mfUserEmbed: Embedding<Scalar>
-    public var mfItemEmbed: Embedding<Scalar>
-    public var mlpUserEmbed: Embedding<Scalar>
-    public var mlpItemEmbed: Embedding<Scalar>
-    public var dense1: Dense<Scalar>
-    public var dense2: Dense<Scalar>
-    public var dense3: Dense<Scalar>
-    public var finalDense: Dense<Scalar>
+    public var mfUserEmbedding: Embedding<Scalar>
+    public var mfItemEmbedding: Embedding<Scalar>
+
+    public var mlpUserEmbedding: Embedding<Scalar>
+    public var mlpItemEmbedding: Embedding<Scalar>
+    public var mlpLayers: [Dense<Scalar>]
+
+    public var neuMFLayer: Dense<Scalar>
 
     /// Initializes a NeuMF model as per the dataset from the given hyperparameters.
     ///
     /// -Parameters
     /// - numUsers: Total number of users in the dataset.
     /// - numItems: Total number of items in the dataset.
-    /// - mfDim: Embedding size of the matrix factorization model.
-    /// - mfReg: Regularization for the matrix factorization embeddings.
+    /// - numLatentFeatures: Embedding size of the matrix factorization model.
+    /// - matrixRegularization: Regularization for the matrix factorization embeddings.
     /// - mlpLayerSizes: The sizes of the layers in the multi-layer perceptron model.
-    /// - mlpLayerRegs: Regularization for each multi-layer perceptron layer.
+    /// - mlpRegularizations: Regularization for each multi-layer perceptron layer.
     ///
     ///  Note: The first MLP layer is the concatenation of user and item embeddings, so mlpLayerSizes[0]/2 is the embedding size.
-
     public init(
-        numUsers: Int,
-        numItems: Int,
-        mfDim: Int,
-        mfReg: Float,
-        mlpLayerSizes: [Int],
-        mlpLayerRegs: [Float]
+        numUsers : Int,
+        numItems : Int,
+        numLatentFeatures : Int,
+        matrixRegularization : Float,
+        mlpLayerSizes : [Int],
+        mlpRegularizations : [Float]
     ) {
-        self.numUsers = numUsers
-        self.numItems = numItems
-        self.mfDim = mfDim
-        self.mfReg = mfReg
-        self.mlpLayerSizes = mlpLayerSizes
-        self.mlpLayerRegs = mlpLayerRegs
 
         precondition(mlpLayerSizes[0] % 2 == 0, "Input of first MLP layers must be multiple of 2")
         precondition(
-            mlpLayerSizes.count == mlpLayerRegs.count,
-            "Size of MLP layers and MLP reqularization must be equal")
+            mlpLayerSizes.count == mlpRegularizations.count,
+            "Size of MLP layers and MLP regularization must be equal")
+
+        self.numUsers = numUsers
+        self.numItems = numItems
+        self.numLatentFeatures = numLatentFeatures
+        self.matrixRegularization = matrixRegularization
+        self.mlpLayerSizes = mlpLayerSizes
+        self.mlpRegularizations = mlpRegularizations
+        mlpLayers = []
 
         // TODO: regularization
         // Embedding Layer
-        self.mfUserEmbed = Embedding<Scalar>(
-            vocabularySize: self.numUsers, embeddingSize: self.mfDim)
-        self.mfItemEmbed = Embedding<Scalar>(
-            vocabularySize: self.numItems, embeddingSize: self.mfDim)
-        self.mlpUserEmbed = Embedding<Scalar>(
+        mfUserEmbedding = Embedding<Scalar>(
+            vocabularySize: self.numUsers, embeddingSize: self.numLatentFeatures)
+        mfItemEmbedding = Embedding<Scalar>(
+            vocabularySize: self.numItems, embeddingSize: self.numLatentFeatures)
+        mlpUserEmbedding = Embedding<Scalar>(
             vocabularySize: self.numUsers, embeddingSize: self.mlpLayerSizes[0] / 2)
-        self.mlpItemEmbed = Embedding<Scalar>(
+        mlpItemEmbedding = Embedding<Scalar>(
             vocabularySize: self.numItems, embeddingSize: self.mlpLayerSizes[0] / 2)
 
-        // TODO: Extend it for n layers by using for loop
-        // Currently only for 4 layers
-        dense1 = Dense(
-            inputSize: self.mlpLayerSizes[0], outputSize: self.mlpLayerSizes[1], activation: relu)
-        dense2 = Dense(
-            inputSize: self.mlpLayerSizes[1], outputSize: self.mlpLayerSizes[2], activation: relu)
-        dense3 = Dense(
-            inputSize: self.mlpLayerSizes[2], outputSize: self.mlpLayerSizes[3], activation: relu)
-        finalDense = Dense(inputSize: (self.mlpLayerSizes[3] + self.mfDim), outputSize: 1)
+        for (inputSize, outputSize) in zip(mlpLayerSizes, mlpLayerSizes[1...]) {
+            mlpLayers.append(Dense(inputSize: inputSize, outputSize: outputSize, activation: relu))
+        }
+
+        neuMFLayer = Dense(inputSize: (self.mlpLayerSizes.last! + self.numLatentFeatures), outputSize: 1)
     }
+
     @differentiable
     public func callAsFunction(_ input: Tensor<Int32>) -> Tensor<Scalar> {
         // Extracting user and item from dataset
@@ -100,21 +98,22 @@ public struct NeuMF: Module {
         let itemIndices = input.unstacked(alongAxis: 1)[1]
 
         // MLP part
-        let userEmbedMlp = self.mlpUserEmbed(userIndices)
-        let itemEmbedMlp = self.mlpItemEmbed(itemIndices)
+        let userEmbeddingMLP = mlpUserEmbedding(userIndices)
+        let itemEmbeddingMLP = mlpItemEmbedding(itemIndices)
 
         // MF part
-        let userEmbedMf = self.mfUserEmbed(userIndices)
-        let itemEmbedMf = self.mfItemEmbed(itemIndices)
+        let userEmbeddingMF = mfUserEmbedding(userIndices)
+        let itemEmbeddingMF = mfItemEmbedding(itemIndices)
+
+        let mfVector = userEmbeddingMF * itemEmbeddingMF
+
+        var mlpVector = userEmbeddingMLP.concatenated(with: itemEmbeddingMLP, alongAxis: -1)
+        mlpVector = mlpLayers.differentiableReduce(mlpVector){ $1($0) }
 
         // Concatenate MF and MLP parts
-        let mfVector = userEmbedMf * itemEmbedMf
-        var mlpVector = userEmbedMlp.concatenated(with: itemEmbedMlp, alongAxis: -1)
-
-        // Final prediction layer
-        mlpVector = mlpVector.sequenced(through: dense1, dense2, dense3)
         let vector = mlpVector.concatenated(with: mfVector, alongAxis: -1)
 
-        return finalDense(vector)
+        // Final prediction layer
+        return neuMFLayer(vector)
     }
 }


### PR DESCRIPTION
* Generalized the model by building the layers in an array and processing through `differentiableReduce()`

* Using more descriptive names for model parameters

* Updated NeuMF example to work with the new parameter names