### PR TITLE
Remove unnecessary init in TextUnsupervised

### DIFF
--- a/Datasets/TextUnsupervised/TextUnsupervised.swift
+++ b/Datasets/TextUnsupervised/TextUnsupervised.swift
@@ -67,17 +67,6 @@ public struct TextUnsupervised {
     private let variantDetails: TextUnsupervisedVariantDetails
 
     public init(
-        variant: TextUnsupervisedVariant = TextUnsupervisedVariant.wikiText2
-    ) {
-        // Empty BytePairEncoder.
-        let vocabulary = Vocabulary(tokensToIds: ["<|endoftext|>": 0])
-        let mergePairs = [BytePairEncoder.Pair: Int]()
-        let bpe = BytePairEncoder(vocabulary: vocabulary, mergePairs: mergePairs)
-
-        self.init(bpe: bpe, variant: variant)
-    }
-
-    public init(
         bpe: BytePairEncoder? = nil,
         variant: TextUnsupervisedVariant = TextUnsupervisedVariant.wikiText2,
         trainingBatchSize: Int = 8, validationBatchSize: Int = 4, sequenceLength: Int = 1024,

--- a/Tests/DatasetsTests/TextUnsupervised/TextUnsupervisedTests.swift
+++ b/Tests/DatasetsTests/TextUnsupervised/TextUnsupervisedTests.swift
@@ -55,7 +55,7 @@ final class TextUnsupervisedTests: XCTestCase {
             XCTAssertEqual(example.second.shape[0], 1024)
             totalCount += 1
         }
-        XCTAssertEqual(totalCount, 128)
+        XCTAssertEqual(totalCount, 24)
     }
 
     func testCreateWikiText2WithBpe() {
@@ -94,7 +94,7 @@ final class TextUnsupervisedTests: XCTestCase {
             XCTAssertEqual(example.second.shape[0], 1024)
             totalCount += 1
         }
-        XCTAssertEqual(totalCount, 64)
+        XCTAssertEqual(totalCount, 12)
     }
 }
 


### PR DESCRIPTION
#490 removed the requirement to provide a byte pair encoder when initializing `TextUnsupervised`. This init function was essentially a placeholder and is no longer necessary, so remove it.