### PR TITLE
Prepend all WordSeg tests with "WordSeg".

### DIFF
--- a/Tests/TextTests/WordSegmentationTests/ProbeLayers.swift
+++ b/Tests/TextTests/WordSegmentationTests/ProbeLayers.swift
@@ -121,7 +121,7 @@ func almostEqual(
   return success
 }
 
-class ProbeLayerTests: XCTestCase {
+class WordSegProbeLayerTests: XCTestCase {
   func testProbeEncoder() {
     // chrVocab is:
     // 0 - a

--- a/Tests/TextTests/WordSegmentationTests/WordSegmentationTests.swift
+++ b/Tests/TextTests/WordSegmentationTests/WordSegmentationTests.swift
@@ -16,7 +16,7 @@ import XCTest
 
 @testable import TextModels
 
-class DataSetTests: XCTestCase {
+class WordSegDataSetTests: XCTestCase {
   func test_DataSetLoad() {
     let buffer: [UInt8] = [
       0x61, 0x6c, 0x70, 0x68, 0x61, 0x0a,  // alpha.
@@ -42,7 +42,7 @@ class DataSetTests: XCTestCase {
   ]
 }
 
-class SemiRingTests: XCTestCase {
+class WordSegSemiRingTests: XCTestCase {
   func test_SemiRingAdd() {
     let value: SemiRing =
       SemiRing(logp: 1.0, logr: 2.0) + SemiRing(logp: 3.0, logr: 4.0)
@@ -98,7 +98,7 @@ class SemiRingTests: XCTestCase {
   ]
 }
 
-class VocabularyTests: XCTestCase {
+class WordSegVocabularyTests: XCTestCase {
   func test_AlphabetaConstruct() {
     let characters: Alphabet = Alphabet(
       [

--- a/Tests/TextTests/XCTestManifests.swift
+++ b/Tests/TextTests/XCTestManifests.swift
@@ -18,10 +18,10 @@ import XCTest
   public func allTests() -> [XCTestCaseEntry] {
     return [
       testCase(TextInferenceTests.allTests),
-      testCase(DataSetTests.allTests),
-      testCase(SemiRingTests.allTests),
-      testCase(VocabularyTests.allTests),
-      testCase(ProbeLayerTests.allTests),
+      testCase(WordSegDataSetTests.allTests),
+      testCase(WordSegSemiRingTests.allTests),
+      testCase(WordSegVocabularyTests.allTests),
+      testCase(WordSegProbeLayerTests.allTests),
     ]
   }
 #endif


### PR DESCRIPTION
This makes it easy to run all WordSeg tests via `swift test --filter WordSeg`.