### PR TITLE
[WordSeg] Remove autodiff workaround.

### DIFF
--- a/Models/Text/WordSeg/Lattice.swift
+++ b/Models/Text/WordSeg/Lattice.swift
@@ -110,9 +110,7 @@ public struct Lattice: Differentiable {
     //_modify { yield &positions[index] }
   }
 
-  // TODO: remove dummy. (workaround to make AD thing that lattice is varied)
-  @differentiable
-  init(count: Int, _ dummy: Tensor<Float>) {
+  init(count: Int) {
     positions = Array(repeating: Node(), count: count + 1)
   }
 

--- a/Models/Text/WordSeg/Model.swift
+++ b/Models/Text/WordSeg/Model.swift
@@ -213,7 +213,7 @@ public struct SNLM: EuclideanDifferentiable, KeyPathIterable {
 
   @differentiable
   public func buildLattice(_ sentence: CharacterSequence, maxLen: Int) -> Lattice {
-    var lattice = Lattice(count: sentence.count, embEnc.embeddings)
+    var lattice = Lattice(count: sentence.count)
     let states = encode(sentence)
     let logg_batch = mlpInterpolation(Tensor(stacking: states))
     let logp_lex_batch = mlpMemory(Tensor(stacking: states))


### PR DESCRIPTION
Remove dummy `Tensor<Float>` argument from `Lattice.init(count:)`.
It was a workaround for an activity analysis bug, no longer reproducible.