### PR TITLE
[WordSeg] Clarify autodiff workarounds.

### DIFF
--- a/Models/Text/WordSeg/Model.swift
+++ b/Models/Text/WordSeg/Model.swift
@@ -133,7 +133,8 @@ public struct SNLM: EuclideanDifferentiable, KeyPathIterable {
 
   /// Returns log probabilities for each of the candidates.
   public func decode(_ candidates: [CharacterSequence], _ state: Tensor<Float>) -> Tensor<Float> {
-    // TODO: Shouldn't use a closure here.
+    // TODO(TF-433): Remove closure workaround when autodiff supports non-active rethrowing
+    // functions (`Array.map`).
     let maxLen = { candidates.map { $0.count }.max()! + 1 }()
     var xBatch: [Int32] = []
     var yBatch: [Int32] = []
@@ -225,7 +226,8 @@ public struct SNLM: EuclideanDifferentiable, KeyPathIterable {
           CharacterSequence(
             alphabet: parameters.chrVocab,
             characters: sentence[pos..<pos + span])
-        // TODO: use && instead of nested ifs (AD workaround)
+        // TODO(TF-433): Use `Bool.&&` instead of nested if statements when autodiff supports
+        // non-active rethrowing functions (`Bool.&&`).
         if candidate.count != 1 {
           if candidate.last == parameters.chrVocab.eos {
             // Prohibit strings such as ["t", "h", "e", "</s>"]


### PR DESCRIPTION
Clarify autodiff workarounds related to TF-433: autodiff does not yet support
non-active throwing/rethrowing functions like `Array.map` and `Bool.&&`.