### PR TITLE
[WordSeg] Clean up lattice node updates.

### DIFF
--- a/Models/Text/WordSeg/Lattice.swift
+++ b/Models/Text/WordSeg/Lattice.swift
@@ -97,7 +97,12 @@ public struct Lattice: Differentiable {
     @differentiable
     func computeSemiringScore() -> SemiRing {
       // TODO: Reduceinto and +=
-      semiRingSum(edges.differentiableMap{ $0.totalScore })
+      semiRingSum(edges.differentiableMap { $0.totalScore })
+    }
+
+    @differentiable
+    mutating func recomputeSemiringScore() {
+      semiringScore = computeSemiringScore()
     }
   }
 
@@ -106,8 +111,14 @@ public struct Lattice: Differentiable {
   @differentiable
   public subscript(index: Int) -> Node {
     get { return positions[index] }
-    set(v) { positions[index] = v }
-    //_modify { yield &positions[index] }
+
+    // TODO(TF-1193): Support derivative registration for accessors.
+    // This enables cleanup:
+    // - Before: `lattice.positions.update(at: i, to: node)`
+    // - After: `lattice[i] = node`
+    set { positions[index] = newValue }
+
+    // _modify { yield &positions[index] }
   }
 
   init(count: Int) {

--- a/Models/Text/WordSeg/Model.swift
+++ b/Models/Text/WordSeg/Model.swift
@@ -251,12 +251,9 @@ public struct SNLM: EuclideanDifferentiable, KeyPathIterable {
       let logp_lex = logp_lex_batch[pos].scalarsADHack  // [strVocab.chr.count]
       let logp_chr = decode(candidates, current_state).scalarsADHack  // [candidates.count]
       if pos != 0 {
-        let updatedNode = Lattice.Node(
-          bestEdge: lattice[pos].bestEdge,
-          bestScore: lattice[pos].bestScore,
-          edges: lattice[pos].edges,
-          semiringScore: lattice[pos].computeSemiringScore()
-        )
+        // Cleanup: lattice[pos].recomputeSemiringScore()
+        var updatedNode = lattice[pos]
+        updatedNode.recomputeSemiringScore()
         lattice.positions.update(at: pos, to: updatedNode)
       }
 
@@ -284,24 +281,17 @@ public struct SNLM: EuclideanDifferentiable, KeyPathIterable {
           previous: lattice[pos].semiringScore,
           order: parameters.order)
 
-        let updatedNode = Lattice.Node(
-          bestEdge: lattice[next_pos].bestEdge,
-          bestScore: lattice[next_pos].bestScore,
-          edges: lattice[next_pos].edges + [edge],
-          semiringScore: lattice[next_pos].semiringScore
-        )
+        // Cleanup: lattice[next_pos].edges.append(edge)
+        var updatedNode = lattice[next_pos]
+        updatedNode.edges.append(edge)
         lattice.positions.update(at: next_pos, to: updatedNode)
       }
     }
 
-    // lattice[sentence.count].recomputeSemiringScore()
-    let updatedNode = Lattice.Node(
-      bestEdge: lattice[sentence.count].bestEdge,
-      bestScore: lattice[sentence.count].bestScore,
-      edges: lattice[sentence.count].edges,
-      semiringScore: lattice[sentence.count].computeSemiringScore()
-    )
-    lattice.positions.update(at: sentence.count, to: updatedNode)
+    // Cleanup: lattice[sentence.count].recomputeSemiringScore()
+    var lastNode = lattice[sentence.count]
+    lastNode.recomputeSemiringScore()
+    lattice.positions.update(at: sentence.count, to: lastNode)
 
     return lattice
   }


### PR DESCRIPTION
Update lattice nodes by creating and mutating a local `var` variable, rather
than initializing a new `let` variable. This shortens the code.

Reference TF-1193: support derivative registration for accessors.
`@derivative(of: Lattice.subscript.set)` enables further code cleanup.

Add "cleanup" comments showing ideal final code.