### PR TITLE
[WordSeg] Minor semiring sum cleanup.

### DIFF
--- a/Models/Text/WordSeg/Lattice.swift
+++ b/Models/Text/WordSeg/Lattice.swift
@@ -97,7 +97,7 @@ public struct Lattice: Differentiable {
     @differentiable
     func computeSemiringScore() -> SemiRing {
       // TODO: Reduceinto and +=
-      semiRingSum(edges.differentiableMap { $0.totalScore })
+      edges.differentiableMap { $0.totalScore }.sum()
     }
 
     @differentiable

--- a/Models/Text/WordSeg/SemiRing.swift
+++ b/Models/Text/WordSeg/SemiRing.swift
@@ -85,11 +85,13 @@ func + (_ lhs: SemiRing, _ rhs: SemiRing) -> SemiRing {
     logr: logSumExp(lhs.logr, rhs.logr))
 }
 
-@differentiable
-func semiRingSum(_ x: [SemiRing]) -> SemiRing {
-  return SemiRing(
-    logp: logSumExp(x.differentiableMap{ $0.logp }),
-    logr: logSumExp(x.differentiableMap{ $0.logr }))
+extension Array where Element == SemiRing {
+  @differentiable
+  func sum() -> SemiRing {
+    return SemiRing(
+      logp: logSumExp(differentiableMap { $0.logp }),
+      logr: logSumExp(differentiableMap { $0.logr }))
+  }
 }
 
 extension SemiRing {


### PR DESCRIPTION
Rewrite `semiRingSum(_:)` to `Array.sum()`, which is more idiomatic.