### PR TITLE
Loading multiple GPT2 checkpoints on same computer.

### DIFF
--- a/Models/Text/GPT2/GPT2.swift
+++ b/Models/Text/GPT2/GPT2.swift
@@ -49,7 +49,6 @@ public class GPT2 {
                 "model.ckpt.meta",
                 "vocab.bpe",
             ]
-            let FS: FileManager = FileManager.default
 
             let reader: CheckpointReader = try CheckpointReader(
                 checkpointLocation: checkpoint,

--- a/Models/Text/GPT2/GPT2.swift
+++ b/Models/Text/GPT2/GPT2.swift
@@ -50,15 +50,16 @@ public class GPT2 {
                 "vocab.bpe",
             ]
             let FS: FileManager = FileManager.default
-            let storage: URL = FS.temporaryDirectory.appendingPathComponent("Transformer")
 
             let reader: CheckpointReader = try CheckpointReader(
                 checkpointLocation: checkpoint,
-                modelName: "Transformer",
+                modelName: "GPT2-\(checkpoint.pathComponents.dropLast().last ?? "")",
                 additionalFiles: auxiliary)
             // TODO(michellecasbon): expose this.
             reader.isCRCVerificationEnabled = false
 
+            let storage: URL = reader.localCheckpointLocation.deletingLastPathComponent()
+            
             // Load model configuration.
             let hparamsFile: URL = storage.appendingPathComponent("hparams.json")
             let configuration: (file: URL, data: Data) = try (


### PR DESCRIPTION
GPT2 initializer tries to load parameters by directly referencing `Transformer` directory under temporary directory, which happens to be where CheckpointReader keeps those files if modelName is `Transformer`. This works if there is only one checkpoint on the system, for example 117M. Using GPT2 with other checkpoints will break with shape errors.

```
Fatal error: Input to reshape is a tensor with 5120 values, but the requested shape has 5100: file /Users/swiftninjas/s4tf/tensorflow-swift-apis/Sources/TensorFlow/Bindings/EagerExecution.swift, line 301
```
This change uses the directory name as part of the modelName parameter of CheckpointReader, for example: GPT2-117M, GPT2-345M to avoid mixing files. It also uses CheckpointReader's localCheckpointLocation to get the directory of the locally stored checkpoint files.