### PR TITLE
[GPT2] Add generation unwrapping protection

### DIFF
--- a/Examples/GPT2-Inference/main.swift
+++ b/Examples/GPT2-Inference/main.swift
@@ -35,8 +35,12 @@ if CommandLine.arguments.count == 3 {
 for _ in 0..<100 {
     do {
         try print(gpt.generate(), terminator: "")
+    } catch GPT2.GPT2Error.invalidEncoding(let id) {
+        print("ERROR: Invalid encoding: \(id)")
+    } catch GPT2.GPT2Error.invalidSeed(let seed) {
+        print("ERROR: Invalid seed: \(seed)")
     } catch {
-        continue
+        fatalError("ERROR: Unexpected error: \(error).")
     }
 }
 print()

--- a/Models/Text/GPT2/GPT2.swift
+++ b/Models/Text/GPT2/GPT2.swift
@@ -20,8 +20,9 @@ public class GPT2 {
     public static let remoteCheckpoint: URL =
         URL(string: "https://storage.googleapis.com/gpt-2/models/117M/model.ckpt")!
 
-    enum GPT2Error: Error {
+    public enum GPT2Error: Error {
         case invalidEncoding(id: Int32)
+        case invalidSeed(seed: Tensor<Int32>)
     }
 
     public var model: TransformerLM
@@ -154,7 +155,9 @@ public class GPT2 {
             randomCategorialLogits: logits.squeezingShape(at: 1),
             sampleCount: 1)
 
-        guard let id = Int32(seed[0][0]) else { return "" }
+        guard let id = Int32(seed[0][0]) else {
+          throw GPT2Error.invalidSeed(seed: seed)
+        }
         if id == Int32(endOfTextId) {
             // Replace with newline.
             return "\r\n"

--- a/Models/Text/GPT2/GPT2.swift
+++ b/Models/Text/GPT2/GPT2.swift
@@ -154,7 +154,7 @@ public class GPT2 {
             randomCategorialLogits: logits.squeezingShape(at: 1),
             sampleCount: 1)
 
-        let id = Int32(seed[0][0])!
+        guard let id = Int32(seed[0][0]) else { return "" }
         if id == Int32(endOfTextId) {
             // Replace with newline.
             return "\r\n"


### PR DESCRIPTION
Every once in a while, GPT2-Inference will crash with this error:
```
Illegal instruction (core dumped)
```

This change adds unwrapping protection in case something goes wrong during generation.