### PR TITLE
[GPT2] Capture an error on unicode support bug

### DIFF
--- a/Examples/GPT2-Inference/main.swift
+++ b/Examples/GPT2-Inference/main.swift
@@ -38,7 +38,7 @@ for _ in 0..<100 {
         try print(gpt.generate(), terminator: "")
     } catch GPT2.GPT2Error.invalidEncoding(let id) {
         print("ERROR: Invalid encoding: \(id)")
-    } catch BytePairEncoder.BPEError.unsupported {
+    } catch BytePairEncoder.BPEError.invalidGeneratedToken {
         print(" ", terminator: "")
     } catch {
         fatalError("ERROR: Unexpected error: \(error).")

--- a/Examples/GPT2-Inference/main.swift
+++ b/Examples/GPT2-Inference/main.swift
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import ModelSupport
 import TextModels
 
 let gpt: GPT2 = try GPT2()
@@ -37,8 +38,8 @@ for _ in 0..<100 {
         try print(gpt.generate(), terminator: "")
     } catch GPT2.GPT2Error.invalidEncoding(let id) {
         print("ERROR: Invalid encoding: \(id)")
-    } catch GPT2.GPT2Error.invalidSeed(let seed) {
-        print("ERROR: Invalid seed: \(seed)")
+    } catch BytePairEncoder.BPEError.unsupported {
+        print(" ", terminator: "")
     } catch {
         fatalError("ERROR: Unexpected error: \(error).")
     }

--- a/Models/Text/GPT2/GPT2.swift
+++ b/Models/Text/GPT2/GPT2.swift
@@ -22,7 +22,6 @@ public class GPT2 {
 
     public enum GPT2Error: Error {
         case invalidEncoding(id: Int32)
-        case invalidSeed(seed: Tensor<Int32>)
     }
 
     public var model: TransformerLM
@@ -155,15 +154,13 @@ public class GPT2 {
             randomCategorialLogits: logits.squeezingShape(at: 1),
             sampleCount: 1)
 
-        guard let id = Int32(seed[0][0]) else {
-          throw GPT2Error.invalidSeed(seed: seed)
-        }
+        let id = Int32(seed[0][0])!
         if id == Int32(endOfTextId) {
             // Replace with newline.
             return "\r\n"
         }
         if let token: String = bpe.vocabulary.token(forId: Int(id)) {
-            let decodedToken = BytePairEncoder.decode(token: token)
+            let decodedToken = try BytePairEncoder.decode(token: token)
             // Make any line breaks universal.
             return decodedToken.replacingOccurrences(of: "\n", with: "\r\n")
         }

--- a/Support/Text/BytePairEncoder.swift
+++ b/Support/Text/BytePairEncoder.swift
@@ -15,6 +15,10 @@
 import Foundation
 
 public struct BytePairEncoder {
+    public enum BPEError: Error {
+        case unsupported
+    }
+
     public let vocabulary: Vocabulary
     public let mergePairs: [Pair: Int]
     public let reversedMergePairs: [String: Pair]
@@ -280,13 +284,18 @@ extension BytePairEncoder {
     /// - Parameters:
     ///   - token: BPE-coded token to decode.
     /// - Returns: String containing the decoded tokens.
-    public static func decode(token: String) -> String {
+    public static func decode(token: String) throws -> String {
         var buffer = [UInt8]()
 
         for scalar in token.unicodeScalars {
             buffer.append(BytePairEncoder.unicodeToBytes[scalar]!)
         }
 
-        return String(bytes: buffer, encoding: .utf8)!
+        // TODO(#385): Support unicode strings with multibyte scalars.
+        guard let decodedToken = String(bytes: buffer, encoding: .utf8) else {
+            throw BPEError.unsupported
+        }
+
+        return decodedToken
     }
 }

--- a/Support/Text/BytePairEncoder.swift
+++ b/Support/Text/BytePairEncoder.swift
@@ -16,7 +16,7 @@ import Foundation
 
 public struct BytePairEncoder {
     public enum BPEError: Error {
-        case unsupported
+        case invalidGeneratedToken
     }
 
     public let vocabulary: Vocabulary
@@ -293,7 +293,7 @@ extension BytePairEncoder {
 
         // TODO(#385): Support unicode strings with multibyte scalars.
         guard let decodedToken = String(bytes: buffer, encoding: .utf8) else {
-            throw BPEError.unsupported
+            throw BPEError.invalidGeneratedToken
         }
 
         return decodedToken


### PR DESCRIPTION
This is a temporary patch to prevent crashes caused by a bug in `BytePairEncoder` support for multibyte unicode scalars, described in #385 