### PR TITLE
GPT2 fix: should split QKV first then head

### DIFF
--- a/Models/Text/GPT2/TransformerLM.swift
+++ b/Models/Text/GPT2/TransformerLM.swift
@@ -229,8 +229,12 @@ struct MultiHeadAttentionGPT2: Layer {
     @differentiable(wrt: (self,input))
     func callAsFunction(_ input: Tensor<Float>) -> Tensor<Float> {
         let qkvProjected = wqkv(input)
-        let qkvSplit = splitHeads(qkvProjected, headCount: headCount)
-        let attentionInput = splitQKV(qkvSplit)
+        let qkvSplit = splitQKV(qkvProjected)
+        let attentionInput = makeAttentionInput(
+            query: splitHeads(qkvSplit.query, headCount: headCount),
+            key: splitHeads(qkvSplit.key, headCount: headCount),
+            value: splitHeads(qkvSplit.value, headCount: headCount)
+        )
         let outputs = attention(attentionInput)
         return wo(joinHeads(outputs, headCount: headCount))
     }


### PR DESCRIPTION
With the small pre-trained model, zero-shot with WikiText2 is supposed to get 29.41 ppl, whereas what we get is as high as e^10. It turns out that the major cause is a bug in the model: it applies QKV split after head split. This PR fixes this. (Note: there is another smaller cause from encoding where we find 1.35% tokens are improperly encoded.)