### PR TITLE
Suppress output from unzipping datasets

### DIFF
--- a/Datasets/WordSeg/WordSegDataset.swift
+++ b/Datasets/WordSeg/WordSegDataset.swift
@@ -96,7 +96,7 @@ public struct WordSegDataset {
 
   public init() throws {
     let downloadDetails = DownloadDetails()
-    let localStorageDirectory: URL = FileManager.default.temporaryDirectory
+    let localStorageDirectory: URL = DatasetUtilities.defaultDirectory
       .appendingPathComponent("WordSeg", isDirectory: true)
 
     WordSegDataset.downloadIfNotPresent(to: localStorageDirectory, downloadDetails: downloadDetails)

--- a/Support/FileManagement.swift
+++ b/Support/FileManagement.swift
@@ -127,7 +127,7 @@ public func extractArchive(
     case "zip":
         binaryLocation = "/usr/bin/"
         toolName = "unzip"
-        arguments = [archivePath, "-d", localStorageDirectory.path]
+        arguments = ["-qq", archivePath, "-d", localStorageDirectory.path]
     default:
         printError(
             "Unable to find archiver for extension \(fileExtension ?? adjustedPathExtension).")


### PR DESCRIPTION
Zipped datasets currently use the local `unzip` command to decompress. The default options for `unzip` log out the individual file names in the archive to standard out. When running benchmarks that expect a JSON output, this corrupts the resulting command-line output. This makes a quick change to silence that output during unzipping.

The WordSeg dataset was also being downloaded to a different location than the other datasets, so that has been aligned with the others.