### PR TITLE
Make GPT2 Dropout aligned with huggingface

### DIFF
--- a/Models/Text/GPT2/PythonCheckpointReader.swift
+++ b/Models/Text/GPT2/PythonCheckpointReader.swift
@@ -128,7 +128,7 @@ extension TransformerLM: InitializableFromPythonCheckpoint {
         positionalEmbeddings = reader.readTensor(
             name: scope + "/wpe",
             scalarType: Float.self)
-        embeddingDropout = Dropout<Float>(probability: 0.1)
+        embeddingDropout = Dropout(probability: 0.1)
         layers = (0..<config.layerCount).map { i in
             EncoderLayer(reader: reader, config: config, scope: scope + "/h\(i)")
         }

--- a/Models/Text/GPT2/PythonCheckpointReader.swift
+++ b/Models/Text/GPT2/PythonCheckpointReader.swift
@@ -90,7 +90,7 @@ extension MultiHeadAttentionGPT2: InitializableFromPythonCheckpoint {
         attention = Attention(
             size: config.embeddingSize / config.headCount,
             causal: true,
-            dropProbability: 0.2)
+            dropProbability: 0.1)
         wqkv = TimeDistributed(
             Dense<Float>(reader: reader, config: config, scope: scope + "/c_attn"))
         wo = TimeDistributed(
@@ -106,7 +106,6 @@ extension FeedForward: InitializableFromPythonCheckpoint {
         )
         dense2 = TimeDistributed(
             Dense<Float>(reader: reader, config: config, scope: scope + "/c_proj"))
-        dropout = Dropout(probability: 0.2)
     }
 }
 
@@ -114,10 +113,10 @@ extension EncoderLayer: InitializableFromPythonCheckpoint {
     init(reader: CheckpointReader, config: TransformerLMConfig, scope: String) {
         selfAttention = MultiHeadAttentionGPT2(
             reader: reader, config: config, scope: scope + "/attn")
-        selfAttentionDropout = Dropout(probability: 0.2)
+        selfAttentionDropout = Dropout(probability: 0.1)
         selfAttentionNorm = LayerNorm(reader: reader, config: config, scope: scope + "/ln_1")
         feedForward = FeedForward(reader: reader, config: config, scope: scope + "/mlp")
-        feedForwardDropout = Dropout(probability: 0.2)
+        feedForwardDropout = Dropout(probability: 0.1)
         feedForwardNorm = LayerNorm(reader: reader, config: config, scope: scope + "/ln_2")
     }
 }
@@ -129,6 +128,7 @@ extension TransformerLM: InitializableFromPythonCheckpoint {
         positionalEmbeddings = reader.readTensor(
             name: scope + "/wpe",
             scalarType: Float.self)
+        embeddingDropout = Dropout<Float>(probability: 0.1)
         layers = (0..<config.layerCount).map { i in
             EncoderLayer(reader: reader, config: config, scope: scope + "/h\(i)")
         }

--- a/Models/Text/GPT2/TransformerLM.swift
+++ b/Models/Text/GPT2/TransformerLM.swift
@@ -307,7 +307,7 @@ public struct TransformerLM: Module {
     ) {
         self.embedding = embedding
         self.positionalEmbeddings = positionalEmbeddings
-        self.embeddingDropout = Dropout<Float>(probability: dropProbability)
+        self.embeddingDropout = Dropout(probability: dropProbability)
         self.layers = layers
         self.norm = norm
     }
@@ -338,6 +338,7 @@ public struct TransformerLM: Module {
         let positionsTensor = Tensor<Int32>(shape: [1, tokens.shape[1]], scalars: positions, on: tokens.device)
         var h = embedding(tokens)
         h = h + positionalEmbeddings.gathering(atIndices: positionsTensor)
+        h = embeddingDropout(h)
         h = layers.differentiableReduce(h) { $1($0) }
         h = norm(h)
         // A somewhat hacky way to share weights.


### PR DESCRIPTION
This PR resolves issue https://github.com/tensorflow/swift-models/issues/104.

hugging face model for reference: https://github.com/huggingface/transformers/blob/2c1ebb8b507c19c75af5084b6c73e0b003c9eda6/src/transformers/modeling_gpt2.py

and dropout possibility settings:
https://github.com/huggingface/transformers/blob/2c1ebb8b507c19c75af5084b6c73e0b003c9eda6/src/transformers/configuration_gpt2.py#L122