### PR TITLE
Convert portions of WordSeg to use scalars instead of Tensors

### DIFF
--- a/Benchmarks/Models/WordSeg.swift
+++ b/Benchmarks/Models/WordSeg.swift
@@ -161,7 +161,7 @@ extension WordSegBenchmark {
     static func scoreAndGradient(model: SNLM, sentence: CharacterSequence) {
         let lambd: Float = 0.00075
 
-        let _ = valueWithGradient(at: model) { model -> Tensor<Float> in
+        let _ = valueWithGradient(at: model) { model -> Float in
           let lattice = model.buildLattice(sentence, maxLen: maximumSequenceLength)
           let score = lattice[sentence.count].semiringScore
           let expectedLength = exp(score.logr - score.logp)

--- a/Examples/WordSeg/main.swift
+++ b/Examples/WordSeg/main.swift
@@ -78,7 +78,7 @@ for epoch in 1...maxEpochs {
   var trainingBatchCount = 0
   for record in dataset.training {
     let sentence = record.numericalizedText
-    let (loss, gradients) = valueWithGradient(at: model) { model -> Tensor<Float> in
+    let (loss, gradients) = valueWithGradient(at: model) { model -> Float in
       let lattice = model.buildLattice(sentence, maxLen: maxLength)
       let score = lattice[sentence.count].semiringScore
       let expectedLength = exp(score.logr - score.logp)
@@ -86,7 +86,7 @@ for epoch in 1...maxEpochs {
       return loss
     }
 
-    trainingLossSum += loss.scalarized()
+    trainingLossSum += loss
     trainingBatchCount += 1
     optimizer.update(&model, along: gradients)
 
@@ -132,7 +132,7 @@ for epoch in 1...maxEpochs {
     var lattice = model.buildLattice(sentence, maxLen: maxLength)
     let score = lattice[sentence.count].semiringScore
 
-    validationLossSum -= score.logp.scalarized()
+    validationLossSum -= score.logp
     validationBatchCount += 1
     validationCharacterCount += sentence.count
 

--- a/Models/Text/WordSeg/Model.swift
+++ b/Models/Text/WordSeg/Model.swift
@@ -334,3 +334,4 @@ extension Tensor {
     return (scalars, pullback)
   }
 }
+ 

--- a/Models/Text/WordSeg/Model.swift
+++ b/Models/Text/WordSeg/Model.swift
@@ -192,9 +192,9 @@ public struct SNLM: EuclideanDifferentiable, KeyPathIterable {
   }
 
   // MARK: - buildLattice
-  func get_logp_lex(_ logp_lex: Tensor<Float>, _ candidate: CharacterSequence) -> Tensor<Float> {
+  func get_logp_lex(_ logp_lex: [Float], _ candidate: CharacterSequence) -> Float {
     guard let index = parameters.strVocab.dictionary[candidate] else {
-      return Tensor(-Float.infinity)
+      return -Float.infinity
     }
     return logp_lex[Int(index)]
   }
@@ -225,9 +225,9 @@ public struct SNLM: EuclideanDifferentiable, KeyPathIterable {
       }
 
       let current_state = states[pos]
-      let logg = logg_batch[pos].identityADHack  // [2]
-      let logp_lex = logp_lex_batch[pos].identityADHack  // [strVocab.chr.count]
-      let logp_chr = decode(candidates, current_state).identityADHack  // [candidates.count]
+        let logg = logg_batch[pos].identityADHack.scalars  // [2]
+      let logp_lex = logp_lex_batch[pos].identityADHack.scalars  // [strVocab.chr.count]
+      let logp_chr = decode(candidates, current_state).identityADHack.scalars  // [candidates.count]
       if pos != 0 {
         // Cleanup: lattice[pos].recomputeSemiringScore()
         var updatedNode = lattice[pos]

--- a/Models/Text/WordSeg/Model.swift
+++ b/Models/Text/WordSeg/Model.swift
@@ -225,9 +225,9 @@ public struct SNLM: EuclideanDifferentiable, KeyPathIterable {
       }
 
       let current_state = states[pos]
-        let logg = logg_batch[pos].identityADHack.scalars  // [2]
-      let logp_lex = logp_lex_batch[pos].identityADHack.scalars  // [strVocab.chr.count]
-      let logp_chr = decode(candidates, current_state).identityADHack.scalars  // [candidates.count]
+      let logg = logg_batch[pos].scalarsADHack  // [2]
+      let logp_lex = logp_lex_batch[pos].scalarsADHack  // [strVocab.chr.count]
+      let logp_chr = decode(candidates, current_state).scalarsADHack  // [candidates.count]
       if pos != 0 {
         // Cleanup: lattice[pos].recomputeSemiringScore()
         var updatedNode = lattice[pos]
@@ -308,29 +308,29 @@ public struct MLP: Layer {
 }
 
 extension Tensor {
-  // NOTE(TF-1008): this is a workaround for TF-1008 that is needed for differentiation
-  // correctness.
+  // NOTE(TF-1008): this is a duplicate of `Tensor.scalars` that is needed for differentiation
+  // correctness. It exists as a workaround for TF-1008: per-instance zero tangent vectors.
   //
   // Remove this when differentiation uses per-instance zeros
   // (`Differentiable.zeroTangentVectorInitializer`) instead of static zeros
   // (`AdditiveArithmetic.zero`).
   @differentiable(where Scalar: TensorFlowFloatingPoint)
-  var identityADHack: Tensor {
-    self
+  var scalarsADHack: [Scalar] {
+    scalars
   }
 
-  @derivative(of: identityADHack)
-  func vjpIdentityADHack() -> (
-    value: Tensor, pullback: (Tensor) -> Tensor
+  @derivative(of: scalarsADHack)
+  func vjpScalarsADHack() -> (
+    value: [Scalar], pullback: (Array<Scalar>.TangentVector) -> Tensor
   ) where Scalar: TensorFlowFloatingPoint {
     // In the pullback: capture only `self.shape`, not all of `self`.
     let shape = self.shape
-    func pullback(_ v: Tensor) -> Tensor {
-      if v.scalarCount == 1 {
-        return v.broadcasted(to: shape)
+    func pullback(_ tv: Array<Scalar>.TangentVector) -> Tensor {
+      if tv.count == 0 {
+        return Tensor(zeros: shape)
       }
-      return v
+      return Tensor(shape: shape, scalars: tv.base)
     }
-    return (self, pullback)
+    return (scalars, pullback)
   }
 }

--- a/Models/Text/WordSeg/SemiRing.swift
+++ b/Models/Text/WordSeg/SemiRing.swift
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import TensorFlow
-
 #if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
   import Darwin
 #elseif os(Windows)
@@ -26,17 +24,33 @@ import TensorFlow
 ///
 /// logSumExp (see https://en.wikipedia.org/wiki/LogSumExp)
 @differentiable
-public func logSumExp(_ x: [Tensor<Float>]) -> Tensor<Float> {
-  // Deal with an empty array first.
-  if x.count == 0 { return Tensor(-Float.infinity) }
-  return Tensor<Float>(stacking: x).logSumExp()
+public func logSumExp(_ x: [Float]) -> Float {
+  if x.count == 0 { return -Float.infinity}
+  let maxVal = x.max()!
+  let exps = x.map { exp($0 - maxVal) }
+  return maxVal + log(exps.reduce(into: 0, +=))
+}
+
+@derivative(of: logSumExp)
+public func vjpLogSumExp(_ x: [Float]) -> (
+  value: Float,
+  pullback: (Float) -> (Array<Float>.TangentVector)
+) {
+  func pb(v: Float) -> (Array<Float>.TangentVector) {
+    if x.count == 0 { return Array<Float>.TangentVector([]) }
+    let maxVal = x.max()!
+    let exps = x.map { exp($0 - maxVal) }
+    let sumExp = exps.reduce(into: 0, +=)
+    return Array<Float>.TangentVector(exps.map{ v * $0 / sumExp })
+  }
+  return (logSumExp(x), pb)
 }
 
 /// logSumExp(_:_:)
 ///
-/// Specialized logSumExp for 2 tensor of floats.
+/// Specialized logSumExp for 2 floats.
 @differentiable
-public func logSumExp(_ lhs: Tensor<Float>, _ rhs: Tensor<Float>) -> Tensor<Float> {
+public func logSumExp(_ lhs: Float, _ rhs: Float) -> Float {
   return logSumExp([lhs, rhs])
 }
 
@@ -44,19 +58,13 @@ public func logSumExp(_ lhs: Tensor<Float>, _ rhs: Tensor<Float>) -> Tensor<Floa
 ///
 /// Represents a SemiRing
 public struct SemiRing: Differentiable {
-  public var logp: Tensor<Float>
-  public var logr: Tensor<Float>
-
-  @differentiable
-  public init(logp: Tensor<Float>, logr: Tensor<Float>) {
-    self.logp = logp
-    self.logr = logr
-  }
+  public var logp: Float
+  public var logr: Float
 
   @differentiable
   public init(logp: Float, logr: Float) {
-    self.logp = Tensor(logp)
-    self.logr = Tensor(logr)
+    self.logp = logp
+    self.logr = logr
   }
 
   static var zero: SemiRing { SemiRing(logp: -Float.infinity, logr: -Float.infinity) }
@@ -97,10 +105,10 @@ extension SemiRing {
   // TODO(abdulras) see if we can use ulp as a default tolerance
   @inlinable
   public func isAlmostEqual(to other: Self, tolerance: Float) -> Bool {
-    return
-      (self.logp.isAlmostEqual(to: other.logp, tolerance: tolerance)
-      || (self.logp.scalarized().isInfinite && other.logp.scalarized().isInfinite))
-      && (self.logr.isAlmostEqual(to: other.logr, tolerance: tolerance)
-        || (self.logr.scalarized().isInfinite && other.logr.scalarized().isInfinite))
+    let diffP = abs(self.logp - other.logp)
+    let diffR = abs(self.logp - other.logp)
+
+    return (diffP <= tolerance || diffP.isNaN)
+      && (diffR <= tolerance || diffR.isNaN)
   }
 }

--- a/Package.resolved
+++ b/Package.resolved
@@ -15,8 +15,8 @@
         "repositoryURL": "https://github.com/apple/swift-protobuf.git",
         "state": {
           "branch": null,
-          "revision": "da75a93ac017534e0028e83c0e4fc4610d2acf48",
-          "version": "1.7.0"
+          "revision": "7f36441e3372665b1b414f8ac93b5905cc42a405",
+          "version": "1.9.0"
         }
       }
     ]

--- a/Tests/TextTests/WordSegmentationTests/ExampleData.swift
+++ b/Tests/TextTests/WordSegmentationTests/ExampleData.swift
@@ -225,7 +225,7 @@ enum Example1 {
             start: 0,
             end: 1,
             string: CharacterSequence(_debug: 1),
-            logp: Tensor(-3.9122378826141357),
+            logp: -3.9122378826141357,
             score: SemiRing(logp: -3.9122378826141357, logr: -3.9122378826141357),
             totalScore: SemiRing(logp: -3.9122378826141357, logr: -3.9122378826141357)
           )
@@ -240,7 +240,7 @@ enum Example1 {
             start: 0,
             end: 2,
             string: CharacterSequence(_debug: 1),
-            logp: Tensor(-2.0545620918273926),
+            logp: -2.0545620918273926,
             score: SemiRing(logp: -2.0545620918273926, logr: 1.4111738204956055),
             totalScore: SemiRing(logp: -2.0545620918273926, logr: 1.4111738204956055)
           ),
@@ -248,7 +248,7 @@ enum Example1 {
             start: 1,
             end: 2,
             string: CharacterSequence(_debug: 1),
-            logp: Tensor(-3.936295986175537),
+            logp: -3.936295986175537,
             score: SemiRing(logp: -3.936295986175537, logr: -3.936295986175537),
             totalScore: SemiRing(logp: -7.848533630371094, logr: -7.155386447906494)
           ),
@@ -263,7 +263,7 @@ enum Example1 {
             start: 0,
             end: 3,
             string: CharacterSequence(_debug: 1),
-            logp: Tensor(-7.253466606140137),
+            logp: -7.253466606140137,
             score: SemiRing(logp: -7.253466606140137, logr: -1.7604050636291504),
             totalScore: SemiRing(logp: -7.253466606140137, logr: -1.7604050636291504)
           ),
@@ -271,7 +271,7 @@ enum Example1 {
             start: 1,
             end: 3,
             string: CharacterSequence(_debug: 1),
-            logp: Tensor(-2.0307273864746094),
+            logp: -2.0307273864746094,
             score: SemiRing(logp: -2.0307273864746094, logr: 1.4350085258483887),
             totalScore: SemiRing(logp: -5.942965507507324, logr: -2.446457624435425)
           ),
@@ -279,7 +279,7 @@ enum Example1 {
             start: 2,
             end: 3,
             string: CharacterSequence(_debug: 1),
-            logp: Tensor(-3.912229061126709),
+            logp: -3.912229061126709,
             score: SemiRing(logp: -3.912229061126709, logr: -3.912229061126709),
             totalScore: SemiRing(logp: -5.963749885559082, logr: -2.4700069427490234)
           ),
@@ -294,7 +294,7 @@ enum Example1 {
             start: 0,
             end: 4,
             string: CharacterSequence(_debug: 1),
-            logp: Tensor(-8.936973571777344),
+            logp: -8.936973571777344,
             score: SemiRing(logp: -8.936973571777344, logr: -2.0055017471313477),
             totalScore: SemiRing(logp: -8.936973571777344, logr: -2.0055017471313477)
           ),
@@ -302,7 +302,7 @@ enum Example1 {
             start: 1,
             end: 4,
             string: CharacterSequence(_debug: 1),
-            logp: Tensor(-7.277979850769043),
+            logp: -7.277979850769043,
             score: SemiRing(logp: -7.277979850769043, logr: -1.7849183082580566),
             totalScore: SemiRing(logp: -11.190217971801758, logr: -5.69304895401001)
           ),
@@ -310,7 +310,7 @@ enum Example1 {
             start: 2,
             end: 4,
             string: CharacterSequence(_debug: 1),
-            logp: Tensor(-2.0545456409454346),
+            logp: -2.0545456409454346,
             score: SemiRing(logp: -2.0545456409454346, logr: 1.4111902713775635),
             totalScore: SemiRing(logp: -4.106066703796387, logr: 0.051392197608947754)
           ),
@@ -318,7 +318,7 @@ enum Example1 {
             start: 3,
             end: 4,
             string: CharacterSequence(_debug: 1),
-            logp: Tensor(-3.936281204223633),
+            logp: -3.936281204223633,
             score: SemiRing(logp: -3.936281204223633, logr: -3.936281204223633),
             totalScore: SemiRing(logp: -9.068710327148438, logr: -4.98878812789917)
           ),

--- a/Tests/TextTests/WordSegmentationTests/ProbeLayers.swift
+++ b/Tests/TextTests/WordSegmentationTests/ProbeLayers.swift
@@ -200,7 +200,7 @@ class WordSegProbeLayerTests: XCTestCase {
     XCTAssert(lattice.isAlmostEqual(to: Example1.lattice, tolerance: 1e-5))
 
     print("Gradient")
-    func f(_ x: SNLM) -> Tensor<Float> {
+    func f(_ x: SNLM) -> Float {
       x.buildLattice(abab, maxLen: 5)[4].semiringScore.logr
     }
     let (_, grad) = valueWithGradient(at: model, in: f)

--- a/Tests/TextTests/WordSegmentationTests/SemiRing.swift
+++ b/Tests/TextTests/WordSegmentationTests/SemiRing.swift
@@ -23,45 +23,45 @@ class WordSegSemiRingTests: XCTestCase {
   func test_SemiRingAdd() {
     let value: SemiRing =
       SemiRing(logp: 1.0, logr: 2.0) + SemiRing(logp: 3.0, logr: 4.0)
-    XCTAssertEqual(value.logp.scalarized(), 3.126928, accuracy: 0.000001)
-    XCTAssertEqual(value.logr.scalarized(), 4.126928, accuracy: 0.000001)
+    XCTAssertEqual(value.logp, 3.126928, accuracy: 0.000001)
+    XCTAssertEqual(value.logr, 4.126928, accuracy: 0.000001)
   }
 
   func test_SemiRingInit() {
     let value: SemiRing = SemiRing(logp: 1.0, logr: 2.0)
-    XCTAssertEqual(value.logp.scalarized(), 1.0)
-    XCTAssertEqual(value.logr.scalarized(), 2.0)
+    XCTAssertEqual(value.logp, 1.0)
+    XCTAssertEqual(value.logr, 2.0)
   }
 
   func test_SemiRingZero() {
     let value: SemiRing = SemiRing.zero
-    XCTAssertEqual(value.logp.scalarized(), -Float.infinity)
-    XCTAssertEqual(value.logr.scalarized(), -Float.infinity)
+    XCTAssertEqual(value.logp, -Float.infinity)
+    XCTAssertEqual(value.logr, -Float.infinity)
   }
 
   func test_SemiRingAdditiveIdentity() {
     let value: SemiRing = SemiRing.zero + SemiRing(logp: 1.0, logr: 2.0)
-    XCTAssertEqual(value.logp.scalarized(), 1.0)
-    XCTAssertEqual(value.logr.scalarized(), 2.0)
+    XCTAssertEqual(value.logp, 1.0)
+    XCTAssertEqual(value.logr, 2.0)
   }
 
   func test_SemiRingOne() {
     let value: SemiRing = SemiRing.one
-    XCTAssertEqual(value.logp.scalarized(), 0.0)
-    XCTAssertEqual(value.logr.scalarized(), -Float.infinity)
+    XCTAssertEqual(value.logp, 0.0)
+    XCTAssertEqual(value.logr, -Float.infinity)
   }
 
   func test_SemiRingMultiplicativeIdentity() {
     let value: SemiRing = SemiRing.one * SemiRing(logp: 1.0, logr: 2.0)
-    XCTAssertEqual(value.logp.scalarized(), 1.0)
-    XCTAssertEqual(value.logr.scalarized(), 2.0)
+    XCTAssertEqual(value.logp, 1.0)
+    XCTAssertEqual(value.logr, 2.0)
   }
 
   func test_SemiRingMultiply() {
     let value: SemiRing =
       SemiRing(logp: 1.0, logr: 2.0) * SemiRing(logp: 3.0, logr: 4.0)
-    XCTAssertEqual(value.logp.scalarized(), 4.0)
-    XCTAssertEqual(value.logr.scalarized(), 5.693147, accuracy: 0.000001)
+    XCTAssertEqual(value.logp, 4.0)
+    XCTAssertEqual(value.logr, 5.693147, accuracy: 0.000001)
   }
 
   static var allTests = [


### PR DESCRIPTION
After profiling, it appears that we're creating a lot of small Tensors in the last steps of `buildLattice()`, where those calculations might better be performed using scalars on the host side. This PR therefore effectively rolls back portions of PR #535 to return to the use of scalars in many places.

Benchmarks before this change on a GTX 1080-equipped Ubuntu system:
WordSeg_score_4: 314 ms / step
WordSeg_score_and_gradient_4: 2801 ms / step

After:
WordSeg_score_4: 132 ms / step
WordSeg_score_and_gradient_4: 1246 ms / step