### PR TITLE
Introduce new layer initialization APIs with automatic shape computation

### DIFF
--- a/Models/CMakeLists.txt
+++ b/Models/CMakeLists.txt
@@ -1,3 +1,4 @@
 add_subdirectory(ImageClassification)
+add_subdirectory(LayerInit)
 add_subdirectory(Recommendation)
 add_subdirectory(Text)

--- a/Models/LayerInit/AutoBatchNorm.swift
+++ b/Models/LayerInit/AutoBatchNorm.swift
@@ -1,0 +1,33 @@
+import TensorFlow
+
+public struct AutoBatchNorm<Shape, Scalar>: AutoLayer where Scalar: TensorFlowFloatingPoint {
+    let axis: Int
+    let momentum: Scalar
+    let epsilon: Scalar
+
+    public typealias InstanceType = BatchNorm<Scalar>
+    public typealias InputShape = Shape
+    public typealias OutputShape = Shape
+
+    public init(
+        axis: Int = -1,
+        momentum: Scalar = 0.99,
+        epsilon: Scalar = 0.001
+    ) {
+        self.axis = axis
+        self.momentum = momentum
+        self.epsilon = epsilon
+    }
+
+    public func buildModelWithOutputShape(inputShape: Shape) -> (InstanceType, Shape) {
+        let inputShapeArray: [Int]
+        if let inputShapeTuple = inputShape as? (Int, Int, Int) {
+            inputShapeArray = [inputShapeTuple.0, inputShapeTuple.1, inputShapeTuple.2]
+        } else {
+            fatalError("Could not extract out elements of shape")
+        }
+
+        let featureCount = inputShapeArray[(inputShapeArray.count + axis) % inputShapeArray.count]
+        return (BatchNorm<Scalar>(featureCount: featureCount, axis: axis, momentum: momentum, epsilon: epsilon), inputShape)
+    }
+}

--- a/Models/LayerInit/AutoBatchNorm.swift
+++ b/Models/LayerInit/AutoBatchNorm.swift
@@ -20,12 +20,7 @@ public struct AutoBatchNorm<Shape, Scalar>: AutoLayer where Scalar: TensorFlowFl
     }
 
     public func buildModelWithOutputShape<Prefix>(inputShape: Shape, keyPathSoFar: KeyPath<Prefix, InstanceType>, keyDict: inout [AnyAutoLayerKey: Any]) -> (InstanceType, Shape) {
-        let inputShapeArray: [Int]
-        if let inputShapeTuple = inputShape as? (Int, Int, Int) {
-            inputShapeArray = [inputShapeTuple.0, inputShapeTuple.1, inputShapeTuple.2]
-        } else {
-            fatalError("Could not extract out elements of shape")
-        }
+        let inputShapeArray: [Int] = intTupleToArray(tuple: inputShape)
 
         let featureCount = inputShapeArray[(inputShapeArray.count + axis) % inputShapeArray.count]
         return (BatchNorm<Scalar>(featureCount: featureCount, axis: axis, momentum: momentum, epsilon: epsilon), inputShape)

--- a/Models/LayerInit/AutoBatchNorm.swift
+++ b/Models/LayerInit/AutoBatchNorm.swift
@@ -19,7 +19,7 @@ public struct AutoBatchNorm<Shape, Scalar>: AutoLayer where Scalar: TensorFlowFl
         self.epsilon = epsilon
     }
 
-    public func buildModelWithOutputShape(inputShape: Shape) -> (InstanceType, Shape) {
+    public func buildModelWithOutputShape<Prefix>(inputShape: Shape, keyPathSoFar: KeyPath<Prefix, InstanceType>, keyDict: inout [AnyAutoLayerKey: Any]) -> (InstanceType, Shape) {
         let inputShapeArray: [Int]
         if let inputShapeTuple = inputShape as? (Int, Int, Int) {
             inputShapeArray = [inputShapeTuple.0, inputShapeTuple.1, inputShapeTuple.2]

--- a/Models/LayerInit/AutoConv.swift
+++ b/Models/LayerInit/AutoConv.swift
@@ -37,7 +37,7 @@ public struct AutoConv2D<Scalar>: AutoLayer where Scalar: TensorFlowFloatingPoin
         self.biasInitializer = biasInitializer
     }
 
-    public func buildModelWithOutputShape(inputShape: (Int, Int, Int)) -> (InstanceType, (Int, Int, Int)) {
+    public func buildModelWithOutputShape<Prefix>(inputShape: (Int, Int, Int), keyPathSoFar: KeyPath<Prefix, InstanceType>, keyDict: inout [AnyAutoLayerKey: Any]) -> (InstanceType, (Int, Int, Int)) {
         let outputShape: (Int, Int, Int)
         if (padding == .valid) {
             outputShape = (

--- a/Models/LayerInit/AutoConv.swift
+++ b/Models/LayerInit/AutoConv.swift
@@ -1,0 +1,63 @@
+import TensorFlow
+
+public struct AutoConv2D<Scalar>: AutoLayer where Scalar: TensorFlowFloatingPoint {
+    let filterShape: (Int, Int)
+    let outputChannels: Int
+    let strides: (Int, Int)
+    let padding: Padding
+    let dilations: (Int, Int)
+    let activation: Conv2D<Scalar>.Activation
+    let useBias: Bool
+    let filterInitializer: ParameterInitializer<Scalar>
+    let biasInitializer: ParameterInitializer<Scalar>
+
+    public typealias InstanceType = Conv2D<Scalar>
+    public typealias InputShape = (Int, Int, Int)
+    public typealias OutputShape = (Int, Int, Int)
+
+    public init(
+        filterShape: (Int, Int),
+        outputChannels: Int,
+        strides: (Int, Int) = (1, 1),
+        padding: Padding = .valid,
+        dilations: (Int, Int) = (1, 1),
+        activation: @escaping Conv2D<Scalar>.Activation = identity,
+        useBias: Bool = true,
+        filterInitializer: @escaping ParameterInitializer<Scalar> = glorotUniform(),
+        biasInitializer: @escaping ParameterInitializer<Scalar> = zeros()
+    ) {
+        self.filterShape = filterShape
+        self.outputChannels = outputChannels
+        self.strides = strides
+        self.padding = padding
+        self.dilations = dilations
+        self.activation = activation
+        self.useBias = useBias
+        self.filterInitializer = filterInitializer
+        self.biasInitializer = biasInitializer
+    }
+
+    public func buildModelWithOutputShape(inputShape: (Int, Int, Int)) -> (InstanceType, (Int, Int, Int)) {
+        let outputShape: (Int, Int, Int)
+        if (padding == .valid) {
+            outputShape = (
+                Int(ceil(Float(inputShape.0 - filterShape.0 + 1) / Float(strides.0))),
+                Int(ceil(Float(inputShape.1 - filterShape.1 + 1) / Float(strides.1))),
+                outputChannels
+            )
+        } else {
+            outputShape = (
+                Int(ceil(Float(inputShape.0) / Float(strides.0))),
+                Int(ceil(Float(inputShape.1) / Float(strides.1))),
+                outputChannels
+            )
+        }
+
+        return (Conv2D<Scalar>(
+            filterShape: (filterShape.0, filterShape.1, inputShape.2, outputChannels),
+            strides: strides, padding: padding, dilations: dilations,
+            activation: activation, useBias: useBias,
+            filterInitializer: filterInitializer, biasInitializer: biasInitializer
+        ), outputShape)
+    }
+}

--- a/Models/LayerInit/AutoDense.swift
+++ b/Models/LayerInit/AutoDense.swift
@@ -1,0 +1,19 @@
+import TensorFlow
+
+public struct AutoDense<Scalar>: AutoLayer where Scalar: TensorFlowFloatingPoint {
+    let outputSize: Int;
+    let activation: Dense<Scalar>.Activation
+
+    public typealias InstanceType = Dense<Scalar>
+    public typealias InputShape = Int
+    public typealias OutputShape = Int
+
+    public init(outputSize: Int, activation: @escaping Dense<Scalar>.Activation = identity) {
+        self.outputSize = outputSize
+        self.activation = activation
+    }
+
+    public func buildModelWithOutputShape(inputShape: Int) -> (InstanceType, Int) {
+        return (Dense<Scalar>(inputSize: inputShape, outputSize: self.outputSize, activation: self.activation), self.outputSize)
+    }
+}

--- a/Models/LayerInit/AutoDense.swift
+++ b/Models/LayerInit/AutoDense.swift
@@ -13,7 +13,7 @@ public struct AutoDense<Scalar>: AutoLayer where Scalar: TensorFlowFloatingPoint
         self.activation = activation
     }
 
-    public func buildModelWithOutputShape(inputShape: Int) -> (InstanceType, Int) {
+    public func buildModelWithOutputShape<Prefix>(inputShape: Int, keyPathSoFar: KeyPath<Prefix, InstanceType>, keyDict: inout [AnyAutoLayerKey: Any]) -> (InstanceType, Int) {
         return (Dense<Scalar>(inputSize: inputShape, outputSize: self.outputSize, activation: self.activation), self.outputSize)
     }
 }

--- a/Models/LayerInit/AutoFlatten.swift
+++ b/Models/LayerInit/AutoFlatten.swift
@@ -1,0 +1,13 @@
+import TensorFlow
+
+public struct AutoFlatten<Scalar>: AutoLayer where Scalar: TensorFlowFloatingPoint {
+    public typealias InstanceType = Flatten<Scalar>
+    public typealias InputShape = (Int, Int, Int)
+    public typealias OutputShape = Int
+
+    public init() {}
+
+    public func buildModelWithOutputShape(inputShape: (Int, Int, Int)) -> (InstanceType, Int) {
+        return (Flatten<Scalar>(), inputShape.0 * inputShape.1 * inputShape.2)
+    }
+}

--- a/Models/LayerInit/AutoFlatten.swift
+++ b/Models/LayerInit/AutoFlatten.swift
@@ -2,12 +2,12 @@ import TensorFlow
 
 public struct AutoFlatten<Scalar>: AutoLayer where Scalar: TensorFlowFloatingPoint {
     public typealias InstanceType = Flatten<Scalar>
-    public typealias InputShape = (Int, Int, Int)
+    public typealias InputShape = Any
     public typealias OutputShape = Int
 
     public init() {}
 
-    public func buildModelWithOutputShape<Prefix>(inputShape: (Int, Int, Int), keyPathSoFar: KeyPath<Prefix, InstanceType>, keyDict: inout [AnyAutoLayerKey: Any]) -> (InstanceType, Int) {
-        return (Flatten<Scalar>(), inputShape.0 * inputShape.1 * inputShape.2)
+    public func buildModelWithOutputShape<Prefix>(inputShape: Any, keyPathSoFar: KeyPath<Prefix, InstanceType>, keyDict: inout [AnyAutoLayerKey: Any]) -> (InstanceType, Int) {
+        return (Flatten<Scalar>(), intTupleToArray(tuple: inputShape).reduce(1, { $0 * $1 }))
     }
 }

--- a/Models/LayerInit/AutoFlatten.swift
+++ b/Models/LayerInit/AutoFlatten.swift
@@ -7,7 +7,7 @@ public struct AutoFlatten<Scalar>: AutoLayer where Scalar: TensorFlowFloatingPoi
 
     public init() {}
 
-    public func buildModelWithOutputShape(inputShape: (Int, Int, Int)) -> (InstanceType, Int) {
+    public func buildModelWithOutputShape<Prefix>(inputShape: (Int, Int, Int), keyPathSoFar: KeyPath<Prefix, InstanceType>, keyDict: inout [AnyAutoLayerKey: Any]) -> (InstanceType, Int) {
         return (Flatten<Scalar>(), inputShape.0 * inputShape.1 * inputShape.2)
     }
 }

--- a/Models/LayerInit/AutoFunction.swift
+++ b/Models/LayerInit/AutoFunction.swift
@@ -1,0 +1,19 @@
+import TensorFlow
+
+public struct AutoFunction<Input: Differentiable, Output: Differentiable, InputShape, OutputShape>: AutoLayer {
+    let fnShape: (InputShape) -> OutputShape
+    let fn: @differentiable (Input) -> Output
+
+    public typealias InstanceType = Function<Input, Output>
+    public typealias InputShape = InputShape
+    public typealias OutputShape = OutputShape
+
+    public init(fnShape: @escaping (InputShape) -> OutputShape, fn: @escaping @differentiable (Input) -> Output) {
+        self.fnShape = fnShape
+        self.fn = fn
+    }
+
+    public func buildModelWithOutputShape(inputShape: InputShape) -> (InstanceType, OutputShape) {
+        return (Function(fn), fnShape(inputShape))
+    }
+}

--- a/Models/LayerInit/AutoFunction.swift
+++ b/Models/LayerInit/AutoFunction.swift
@@ -13,7 +13,7 @@ public struct AutoFunction<Input: Differentiable, Output: Differentiable, InputS
         self.fn = fn
     }
 
-    public func buildModelWithOutputShape(inputShape: InputShape) -> (InstanceType, OutputShape) {
+    public func buildModelWithOutputShape<Prefix>(inputShape: InputShape, keyPathSoFar: KeyPath<Prefix, InstanceType>, keyDict: inout [AnyAutoLayerKey: Any]) -> (InstanceType, OutputShape) {
         return (Function(fn), fnShape(inputShape))
     }
 }

--- a/Models/LayerInit/AutoFunction.swift
+++ b/Models/LayerInit/AutoFunction.swift
@@ -1,5 +1,6 @@
 import TensorFlow
 
+/// A layer that applies a user-defined function to the input data
 public struct AutoFunction<Input: Differentiable, Output: Differentiable, InputShape, OutputShape>: AutoLayer {
     let fnShape: (InputShape) -> OutputShape
     let fn: @differentiable (Input) -> Output
@@ -8,6 +9,13 @@ public struct AutoFunction<Input: Differentiable, Output: Differentiable, InputS
     public typealias InputShape = InputShape
     public typealias OutputShape = OutputShape
 
+    /**
+     Constructs a function layer instance.
+
+     Parameters:
+        - fnShape: a function that computes the output shape of the function given the input shape
+        - fn: a function that computes the output data of the function given the input data
+     */
     public init(fnShape: @escaping (InputShape) -> OutputShape, fn: @escaping @differentiable (Input) -> Output) {
         self.fnShape = fnShape
         self.fn = fn

--- a/Models/LayerInit/AutoFunction.swift
+++ b/Models/LayerInit/AutoFunction.swift
@@ -9,13 +9,10 @@ public struct AutoFunction<Input: Differentiable, Output: Differentiable, InputS
     public typealias InputShape = InputShape
     public typealias OutputShape = OutputShape
 
-    /**
-     Constructs a function layer instance.
-
-     Parameters:
-        - fnShape: a function that computes the output shape of the function given the input shape
-        - fn: a function that computes the output data of the function given the input data
-     */
+    /// Constructs a function layer instance.
+    /// Parameters:
+    ///     - fnShape: a function that computes the output shape of the function given the input shape
+    ///     - fn: a function that computes the output data of the function given the input data
     public init(fnShape: @escaping (InputShape) -> OutputShape, fn: @escaping @differentiable (Input) -> Output) {
         self.fnShape = fnShape
         self.fn = fn

--- a/Models/LayerInit/AutoLayer.swift
+++ b/Models/LayerInit/AutoLayer.swift
@@ -5,11 +5,19 @@ public protocol AutoLayer {
     associatedtype InputShape
     associatedtype OutputShape
 
-    func buildModelWithOutputShape(inputShape: InputShape) -> (InstanceType, OutputShape)
+    func buildModelWithOutputShape<Prefix>(inputShape: InputShape, keyPathSoFar: KeyPath<Prefix, InstanceType>, keyDict: inout [AnyAutoLayerKey: Any]) -> (InstanceType, OutputShape)
 }
 
 extension AutoLayer {
     public func buildModel(inputShape: InputShape) -> InstanceType {
-        return self.buildModelWithOutputShape(inputShape: inputShape).0
+        var keyDict: [AnyAutoLayerKey: Any] = [:]
+        let (layerInstance, _) = self.buildModelWithOutputShape(inputShape: inputShape, keyPathSoFar: \InstanceType.self, keyDict: &keyDict)
+        return layerInstance
+    }
+
+    public func buildModelWithKeys(inputShape: InputShape) -> (InstanceType, [AnyAutoLayerKey: Any]) {
+        var keyDict: [AnyAutoLayerKey: Any] = [:]
+        let (layerInstance, _) = self.buildModelWithOutputShape(inputShape: inputShape, keyPathSoFar: \InstanceType.self, keyDict: &keyDict)
+        return (layerInstance, keyDict)
     }
 }

--- a/Models/LayerInit/AutoLayer.swift
+++ b/Models/LayerInit/AutoLayer.swift
@@ -11,18 +11,14 @@ public protocol AutoLayer {
     /// The specific tuple of `Int`s that define the output shape of the layer
     associatedtype OutputShape
 
-    /**
-     Initializes a new instance of the layer defined by this blueprint.
-
-     - Paremeters:
-        - inputShape: the shape of a single input instance (no batch) to this layer
-        - keyPathSoFar: a `KeyPath` that tracks the path from the root layer to the current layer instance
-        - keyDict: a dictionary tracking the mapping from `AutoLayerKey`s to the key path to the layer instance
-    
-    - Returns:
-        - $0: the instance of the layer with the given input shape
-        - $1: the output shape of the layer instance computed based on the input shape
-    */
+    /// Initializes a new instance of the layer defined by this blueprint.
+    /// Parameters:
+    ///     - inputShape: the shape of a single input instance (no batch) to this layer
+    ///     - keyPathSoFar: a `KeyPath` that tracks the path from the root layer to the current layer instance
+    ///     - keyDict: a dictionary tracking the mapping from `AutoLayerKey`s to the key path to the layer instance
+    /// Returns:
+    ///     - $0: the instance of the layer with the given input shape
+    ///     - $1: the output shape of the layer instance computed based on the input shape
     func buildModelWithOutputShape<Prefix>(inputShape: InputShape, keyPathSoFar: KeyPath<Prefix, InstanceType>, keyDict: inout [AnyAutoLayerKey: Any]) -> (InstanceType, OutputShape)
 }
 

--- a/Models/LayerInit/AutoLayer.swift
+++ b/Models/LayerInit/AutoLayer.swift
@@ -2,7 +2,13 @@ import TensorFlow
 
 public protocol AutoLayer {
     associatedtype InstanceType: Layer
-    func buildModel(inputShape: Int) -> (InstanceType, Int)
+    func buildModelWithOutputShape(inputShape: Int) -> (InstanceType, Int)
+}
+
+extension AutoLayer {
+    public func buildModel(inputShape: Int) -> InstanceType {
+        return self.buildModelWithOutputShape(inputShape: inputShape).0
+    }
 }
 
 public struct AutoSequencedDefinition<Layer1: AutoLayer, Layer2: AutoLayer>: AutoLayer
@@ -19,9 +25,9 @@ where
         self.second = second
     }
 
-    public func buildModel(inputShape: Int) -> (InstanceType, Int) {
-        let (firstInstance, firstOutputShape) = first.buildModel(inputShape: inputShape)
-        let (secondInstance, secondOutputShape) = second.buildModel(inputShape: firstOutputShape)
+    public func buildModelWithOutputShape(inputShape: Int) -> (InstanceType, Int) {
+        let (firstInstance, firstOutputShape) = first.buildModelWithOutputShape(inputShape: inputShape)
+        let (secondInstance, secondOutputShape) = second.buildModelWithOutputShape(inputShape: firstOutputShape)
         return (Sequential(firstInstance, secondInstance), secondOutputShape)
     }
 }
@@ -43,7 +49,7 @@ public struct AutoDenseDefinition<Scalar>: AutoLayer where Scalar: TensorFlowFlo
         self.activation = activation
     }
 
-    public func buildModel(inputShape: Int) -> (InstanceType, Int) {
+    public func buildModelWithOutputShape(inputShape: Int) -> (InstanceType, Int) {
         return (Dense<Scalar>(inputSize: inputShape, outputSize: self.outputSize, activation: self.activation), self.outputSize)
     }
 }

--- a/Models/LayerInit/AutoLayer.swift
+++ b/Models/LayerInit/AutoLayer.swift
@@ -2,60 +2,14 @@ import TensorFlow
 
 public protocol AutoLayer {
     associatedtype InstanceType: Layer
-    func buildModelWithOutputShape(inputShape: Int) -> (InstanceType, Int)
+    associatedtype InputShape
+    associatedtype OutputShape
+
+    func buildModelWithOutputShape(inputShape: InputShape) -> (InstanceType, OutputShape)
 }
 
 extension AutoLayer {
-    public func buildModel(inputShape: Int) -> InstanceType {
+    public func buildModel(inputShape: InputShape) -> InstanceType {
         return self.buildModelWithOutputShape(inputShape: inputShape).0
-    }
-}
-
-public struct AutoSequencedDefinition<Layer1: AutoLayer, Layer2: AutoLayer>: AutoLayer
-where
-  Layer1.InstanceType.Output == Layer2.InstanceType.Input,
-  Layer1.InstanceType.TangentVector.VectorSpaceScalar == Layer2.InstanceType.TangentVector.VectorSpaceScalar {
-    let first: Layer1
-    let second: Layer2
-
-    public typealias InstanceType = Sequential<Layer1.InstanceType, Layer2.InstanceType>
-
-    public init(first: Layer1, second: Layer2) {
-        self.first = first
-        self.second = second
-    }
-
-    public func buildModelWithOutputShape(inputShape: Int) -> (InstanceType, Int) {
-        let (firstInstance, firstOutputShape) = first.buildModelWithOutputShape(inputShape: inputShape)
-        let (secondInstance, secondOutputShape) = second.buildModelWithOutputShape(inputShape: firstOutputShape)
-        return (Sequential(firstInstance, secondInstance), secondOutputShape)
-    }
-}
-
-extension AutoSequencedDefinition {
-    public func then<T: AutoLayer>(_ other: T) -> AutoSequencedDefinition<AutoSequencedDefinition<Layer1, Layer2>, T> {
-        return AutoSequencedDefinition<AutoSequencedDefinition<Layer1, Layer2>, T>(first: self, second: other)
-    }
-}
-
-public struct AutoDenseDefinition<Scalar>: AutoLayer where Scalar: TensorFlowFloatingPoint {
-    let outputSize: Int;
-    let activation: Dense<Scalar>.Activation
-
-    public typealias InstanceType = Dense<Scalar>
-
-    public init(outputSize: Int, activation: @escaping Dense<Scalar>.Activation = identity) {
-        self.outputSize = outputSize
-        self.activation = activation
-    }
-
-    public func buildModelWithOutputShape(inputShape: Int) -> (InstanceType, Int) {
-        return (Dense<Scalar>(inputSize: inputShape, outputSize: self.outputSize, activation: self.activation), self.outputSize)
-    }
-}
-
-extension AutoDenseDefinition {
-    public func then<T: AutoLayer>(_ other: T) -> AutoSequencedDefinition<AutoDenseDefinition<Scalar>, T> {
-        return AutoSequencedDefinition<AutoDenseDefinition<Scalar>, T>(first: self, second: other)
     }
 }

--- a/Models/LayerInit/AutoLayer.swift
+++ b/Models/LayerInit/AutoLayer.swift
@@ -1,27 +1,41 @@
 import TensorFlow
 
+/// A layer "blueprint", which defines elements that can be constructed into a Layer instance for training
 public protocol AutoLayer {
+    /// The type of the layer instance that can be built with this prototype
     associatedtype InstanceType: Layer
+
+    /// The specific tuple of `Int`s that define the input shape of the layer
     associatedtype InputShape
+
+    /// The specific tuple of `Int`s that define the output shape of the layer
     associatedtype OutputShape
 
+    /**
+     Initializes a new instance of the layer defined by this blueprint.
+
+     - Paremeters:
+        - inputShape: the shape of a single input instance (no batch) to this layer
+        - keyPathSoFar: a `KeyPath` that tracks the path from the root layer to the current layer instance
+        - keyDict: a dictionary tracking the mapping from `AutoLayerKey`s to the key path to the layer instance
+    
+    - Returns:
+        - $0: the instance of the layer with the given input shape
+        - $1: the output shape of the layer instance computed based on the input shape
+    */
     func buildModelWithOutputShape<Prefix>(inputShape: InputShape, keyPathSoFar: KeyPath<Prefix, InstanceType>, keyDict: inout [AnyAutoLayerKey: Any]) -> (InstanceType, OutputShape)
 }
 
 extension AutoLayer {
+    /// Builds an instance of the model with the given input shape
     public func buildModel(inputShape: InputShape) -> BuiltAutoLayer<InstanceType> {
         var keyDict: [AnyAutoLayerKey: Any] = [:]
         let (layerInstance, _) = self.buildModelWithOutputShape(inputShape: inputShape, keyPathSoFar: \InstanceType.self, keyDict: &keyDict)
         return BuiltAutoLayer(layer: layerInstance, keyMapping: keyDict)
     }
-
-    public func buildModelWithKeys(inputShape: InputShape) -> (InstanceType, [AnyAutoLayerKey: Any]) {
-        var keyDict: [AnyAutoLayerKey: Any] = [:]
-        let (layerInstance, _) = self.buildModelWithOutputShape(inputShape: inputShape, keyPathSoFar: \InstanceType.self, keyDict: &keyDict)
-        return (layerInstance, keyDict)
-    }
 }
 
+/// A layer instance containing a model built with the AutoLayer API. Offers keyed access to layers with `AutoLayerKey`.
 public struct BuiltAutoLayer<InstanceType: Layer>: Layer {
     public var layer: InstanceType
     @noDerivative let keyMapping: [AnyAutoLayerKey: Any]
@@ -36,6 +50,7 @@ public struct BuiltAutoLayer<InstanceType: Layer>: Layer {
         return layer(input)
     }
 
+    /// Grab a specific layer by the given `AutoLayerKey`.
     public subscript<T>(index: AutoLayerKey<T>) -> T {
         return self.layer[keyPath: self.keyMapping[index] as! KeyPath<InstanceType, T>]
     }

--- a/Models/LayerInit/AutoLayer.swift
+++ b/Models/LayerInit/AutoLayer.swift
@@ -9,15 +9,34 @@ public protocol AutoLayer {
 }
 
 extension AutoLayer {
-    public func buildModel(inputShape: InputShape) -> InstanceType {
+    public func buildModel(inputShape: InputShape) -> BuiltAutoLayer<InstanceType> {
         var keyDict: [AnyAutoLayerKey: Any] = [:]
         let (layerInstance, _) = self.buildModelWithOutputShape(inputShape: inputShape, keyPathSoFar: \InstanceType.self, keyDict: &keyDict)
-        return layerInstance
+        return BuiltAutoLayer(layer: layerInstance, keyMapping: keyDict)
     }
 
     public func buildModelWithKeys(inputShape: InputShape) -> (InstanceType, [AnyAutoLayerKey: Any]) {
         var keyDict: [AnyAutoLayerKey: Any] = [:]
         let (layerInstance, _) = self.buildModelWithOutputShape(inputShape: inputShape, keyPathSoFar: \InstanceType.self, keyDict: &keyDict)
         return (layerInstance, keyDict)
+    }
+}
+
+public struct BuiltAutoLayer<InstanceType: Layer>: Layer {
+    public var layer: InstanceType
+    @noDerivative let keyMapping: [AnyAutoLayerKey: Any]
+
+    public init(layer: InstanceType, keyMapping: [AnyAutoLayerKey: Any]) {
+        self.layer = layer
+        self.keyMapping = keyMapping
+    }
+
+    @differentiable
+    public func callAsFunction(_ input: InstanceType.Input) -> InstanceType.Output {
+        return layer(input)
+    }
+
+    public subscript<T>(index: AutoLayerKey<T>) -> T {
+        return self.layer[keyPath: self.keyMapping[index] as! KeyPath<InstanceType, T>]
     }
 }

--- a/Models/LayerInit/AutoLayer.swift
+++ b/Models/LayerInit/AutoLayer.swift
@@ -1,0 +1,55 @@
+import TensorFlow
+
+public protocol AutoLayer {
+    associatedtype InstanceType: Layer
+    func buildModel(inputShape: Int) -> (InstanceType, Int)
+}
+
+public struct AutoSequencedDefinition<Layer1: AutoLayer, Layer2: AutoLayer>: AutoLayer
+where
+  Layer1.InstanceType.Output == Layer2.InstanceType.Input,
+  Layer1.InstanceType.TangentVector.VectorSpaceScalar == Layer2.InstanceType.TangentVector.VectorSpaceScalar {
+    let first: Layer1
+    let second: Layer2
+
+    public typealias InstanceType = Sequential<Layer1.InstanceType, Layer2.InstanceType>
+
+    public init(first: Layer1, second: Layer2) {
+        self.first = first
+        self.second = second
+    }
+
+    public func buildModel(inputShape: Int) -> (InstanceType, Int) {
+        let (firstInstance, firstOutputShape) = first.buildModel(inputShape: inputShape)
+        let (secondInstance, secondOutputShape) = second.buildModel(inputShape: firstOutputShape)
+        return (Sequential(firstInstance, secondInstance), secondOutputShape)
+    }
+}
+
+extension AutoSequencedDefinition {
+    public func then<T: AutoLayer>(_ other: T) -> AutoSequencedDefinition<AutoSequencedDefinition<Layer1, Layer2>, T> {
+        return AutoSequencedDefinition<AutoSequencedDefinition<Layer1, Layer2>, T>(first: self, second: other)
+    }
+}
+
+public struct AutoDenseDefinition<Scalar>: AutoLayer where Scalar: TensorFlowFloatingPoint {
+    let outputSize: Int;
+    let activation: Dense<Scalar>.Activation
+
+    public typealias InstanceType = Dense<Scalar>
+
+    public init(outputSize: Int, activation: @escaping Dense<Scalar>.Activation = identity) {
+        self.outputSize = outputSize
+        self.activation = activation
+    }
+
+    public func buildModel(inputShape: Int) -> (InstanceType, Int) {
+        return (Dense<Scalar>(inputSize: inputShape, outputSize: self.outputSize, activation: self.activation), self.outputSize)
+    }
+}
+
+extension AutoDenseDefinition {
+    public func then<T: AutoLayer>(_ other: T) -> AutoSequencedDefinition<AutoDenseDefinition<Scalar>, T> {
+        return AutoSequencedDefinition<AutoDenseDefinition<Scalar>, T>(first: self, second: other)
+    }
+}

--- a/Models/LayerInit/AutoLayerKey.swift
+++ b/Models/LayerInit/AutoLayerKey.swift
@@ -35,3 +35,10 @@ public struct KeyedAutoLayer<Underlying: AutoLayer>: AutoLayer {
         return (layer, outputShape)
     }
 }
+
+extension AutoLayer {
+    /// Attaches a key to an existing layer blueprint
+    public func withKey(_ key: AutoLayerKey<InstanceType>) -> KeyedAutoLayer<Self> {
+        return KeyedAutoLayer(self, key: key)
+    }
+}

--- a/Models/LayerInit/AutoLayerKey.swift
+++ b/Models/LayerInit/AutoLayerKey.swift
@@ -10,10 +10,12 @@ public class AnyAutoLayerKey: Hashable {
     }
 }
 
+/// A key that can be associated with an `AutoLayer` to access it after it has been built as part of a larger model.
 public class AutoLayerKey<T: Layer>: AnyAutoLayerKey {
     public override init() {}
 }
 
+/// A layer blueprint that associates an underlying blueprint with an `AutoLayerKey` so that the underlying instance can be accessed from the built model.
 public struct KeyedAutoLayer<Underlying: AutoLayer>: AutoLayer {
     let underlying: Underlying
     let key: AutoLayerKey<InstanceType>

--- a/Models/LayerInit/AutoLayerKey.swift
+++ b/Models/LayerInit/AutoLayerKey.swift
@@ -14,12 +14,6 @@ public class AutoLayerKey<T: Layer>: AnyAutoLayerKey {
     public override init() {}
 }
 
-extension AutoLayerKey {
-    public func readFrom<Instance: Layer>(layerInstance: Instance, keyDict: [AnyAutoLayerKey: Any]) -> T {
-        return layerInstance[keyPath: keyDict[self] as! KeyPath<Instance, T>]
-    }
-}
-
 public struct KeyedAutoLayer<Underlying: AutoLayer>: AutoLayer {
     let underlying: Underlying
     let key: AutoLayerKey<InstanceType>

--- a/Models/LayerInit/AutoLayerKey.swift
+++ b/Models/LayerInit/AutoLayerKey.swift
@@ -1,0 +1,41 @@
+import TensorFlow
+
+public class AnyAutoLayerKey: Hashable {
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(ObjectIdentifier(self))
+    }
+
+    public static func == (lhs: AnyAutoLayerKey, rhs: AnyAutoLayerKey) -> Bool {
+        return lhs === rhs
+    }
+}
+
+public class AutoLayerKey<T: Layer>: AnyAutoLayerKey {
+    public override init() {}
+}
+
+extension AutoLayerKey {
+    public func readFrom<Instance: Layer>(layerInstance: Instance, keyDict: [AnyAutoLayerKey: Any]) -> T {
+        return layerInstance[keyPath: keyDict[self] as! KeyPath<Instance, T>]
+    }
+}
+
+public struct KeyedAutoLayer<Underlying: AutoLayer>: AutoLayer {
+    let underlying: Underlying
+    let key: AutoLayerKey<InstanceType>
+
+    public typealias InstanceType = Underlying.InstanceType
+    public typealias InputShape = Underlying.InputShape
+    public typealias OutputShape = Underlying.OutputShape
+
+    public init(_ underlying: Underlying, key: AutoLayerKey<InstanceType>) {
+        self.underlying = underlying
+        self.key = key
+    }
+
+    public func buildModelWithOutputShape<Prefix>(inputShape: InputShape, keyPathSoFar: KeyPath<Prefix, InstanceType>, keyDict: inout [AnyAutoLayerKey: Any]) -> (InstanceType, OutputShape) {
+        let (layer, outputShape) = underlying.buildModelWithOutputShape(inputShape: inputShape, keyPathSoFar: keyPathSoFar, keyDict: &keyDict)
+        keyDict[self.key] = keyPathSoFar
+        return (layer, outputShape)
+    }
+}

--- a/Models/LayerInit/AutoModule.swift
+++ b/Models/LayerInit/AutoModule.swift
@@ -6,7 +6,7 @@ public protocol AutoModule: AutoLayer {
     var initializeLayer: LayerType { mutating get }
 }
 
-extension AutoModule  {
+extension AutoModule {
     public typealias InstanceType = LayerType.InstanceType
     public typealias InputShape = LayerType.InputShape
     public typealias OutputShape = LayerType.OutputShape

--- a/Models/LayerInit/AutoModule.swift
+++ b/Models/LayerInit/AutoModule.swift
@@ -1,0 +1,18 @@
+import TensorFlow
+
+public protocol AutoModule: AutoLayer {
+    associatedtype LayerType: AutoLayer
+
+    var initializeLayer: LayerType { mutating get }
+}
+
+extension AutoModule  {
+    public typealias InstanceType = LayerType.InstanceType
+    public typealias InputShape = LayerType.InputShape
+    public typealias OutputShape = LayerType.OutputShape
+
+    public func buildModelWithOutputShape(inputShape: InputShape) -> (InstanceType, OutputShape) {
+        var selfCopy = self
+        return selfCopy.initializeLayer.buildModelWithOutputShape(inputShape: inputShape)
+    }
+}

--- a/Models/LayerInit/AutoModule.swift
+++ b/Models/LayerInit/AutoModule.swift
@@ -11,8 +11,8 @@ extension AutoModule  {
     public typealias InputShape = LayerType.InputShape
     public typealias OutputShape = LayerType.OutputShape
 
-    public func buildModelWithOutputShape(inputShape: InputShape) -> (InstanceType, OutputShape) {
+    public func buildModelWithOutputShape<Prefix>(inputShape: InputShape, keyPathSoFar: KeyPath<Prefix, InstanceType>, keyDict: inout [AnyAutoLayerKey: Any]) -> (InstanceType, OutputShape) {
         var selfCopy = self
-        return selfCopy.initializeLayer.buildModelWithOutputShape(inputShape: inputShape)
+        return selfCopy.initializeLayer.buildModelWithOutputShape(inputShape: inputShape, keyPathSoFar: keyPathSoFar, keyDict: &keyDict)
     }
 }

--- a/Models/LayerInit/AutoPool.swift
+++ b/Models/LayerInit/AutoPool.swift
@@ -42,3 +42,46 @@ public struct AutoAvgPool2D<Scalar>: AutoLayer where Scalar: TensorFlowFloatingP
         ), outputShape)
     }
 }
+
+public struct AutoMaxPool2D<Scalar>: AutoLayer where Scalar: TensorFlowFloatingPoint {
+    let poolSize: (Int, Int)
+    let strides: (Int, Int)
+    let padding: Padding
+
+    public typealias InstanceType = MaxPool2D<Scalar>
+    public typealias InputShape = (Int, Int, Int)
+    public typealias OutputShape = (Int, Int, Int)
+
+    public init(
+        poolSize: (Int, Int),
+        strides: (Int, Int) = (1, 1),
+        padding: Padding = .valid
+    ) {
+        self.poolSize = poolSize
+        self.strides = strides
+        self.padding = padding
+    }
+
+    public func buildModelWithOutputShape(inputShape: (Int, Int, Int)) -> (InstanceType, (Int, Int, Int)) {
+        let outputShape: (Int, Int, Int)
+        if (padding == .valid) {
+            outputShape = (
+                Int(ceil(Float(inputShape.0 - poolSize.0 + 1) / Float(strides.0))),
+                Int(ceil(Float(inputShape.1 - poolSize.1 + 1) / Float(strides.1))),
+                inputShape.2
+            )
+        } else {
+            outputShape = (
+                Int(ceil(Float(inputShape.0) / Float(strides.0))),
+                Int(ceil(Float(inputShape.1) / Float(strides.1))),
+                inputShape.2
+            )
+        }
+
+        return (MaxPool2D<Scalar>(
+            poolSize: poolSize,
+            strides: strides,
+            padding: padding
+        ), outputShape)
+    }
+}

--- a/Models/LayerInit/AutoPool.swift
+++ b/Models/LayerInit/AutoPool.swift
@@ -19,7 +19,7 @@ public struct AutoAvgPool2D<Scalar>: AutoLayer where Scalar: TensorFlowFloatingP
         self.padding = padding
     }
 
-    public func buildModelWithOutputShape(inputShape: (Int, Int, Int)) -> (InstanceType, (Int, Int, Int)) {
+    public func buildModelWithOutputShape<Prefix>(inputShape: (Int, Int, Int), keyPathSoFar: KeyPath<Prefix, InstanceType>, keyDict: inout [AnyAutoLayerKey: Any]) -> (InstanceType, (Int, Int, Int)) {
         let outputShape: (Int, Int, Int)
         if (padding == .valid) {
             outputShape = (
@@ -51,7 +51,7 @@ public struct AutoGlobalAvgPool2D<Scalar>: AutoLayer where Scalar: TensorFlowFlo
     public init() {
     }
 
-    public func buildModelWithOutputShape(inputShape: (Int, Int, Int)) -> (InstanceType, Int) {
+    public func buildModelWithOutputShape<Prefix>(inputShape: (Int, Int, Int), keyPathSoFar: KeyPath<Prefix, InstanceType>, keyDict: inout [AnyAutoLayerKey: Any]) -> (InstanceType, Int) {
         return (GlobalAvgPool2D<Scalar>(), inputShape.2)
     }
 }
@@ -75,7 +75,7 @@ public struct AutoMaxPool2D<Scalar>: AutoLayer where Scalar: TensorFlowFloatingP
         self.padding = padding
     }
 
-    public func buildModelWithOutputShape(inputShape: (Int, Int, Int)) -> (InstanceType, (Int, Int, Int)) {
+    public func buildModelWithOutputShape<Prefix>(inputShape: (Int, Int, Int), keyPathSoFar: KeyPath<Prefix, InstanceType>, keyDict: inout [AnyAutoLayerKey: Any]) -> (InstanceType, (Int, Int, Int)) {
         let outputShape: (Int, Int, Int)
         if (padding == .valid) {
             outputShape = (

--- a/Models/LayerInit/AutoPool.swift
+++ b/Models/LayerInit/AutoPool.swift
@@ -43,6 +43,19 @@ public struct AutoAvgPool2D<Scalar>: AutoLayer where Scalar: TensorFlowFloatingP
     }
 }
 
+public struct AutoGlobalAvgPool2D<Scalar>: AutoLayer where Scalar: TensorFlowFloatingPoint {
+    public typealias InstanceType = GlobalAvgPool2D<Scalar>
+    public typealias InputShape = (Int, Int, Int)
+    public typealias OutputShape = Int
+
+    public init() {
+    }
+
+    public func buildModelWithOutputShape(inputShape: (Int, Int, Int)) -> (InstanceType, Int) {
+        return (GlobalAvgPool2D<Scalar>(), inputShape.2)
+    }
+}
+
 public struct AutoMaxPool2D<Scalar>: AutoLayer where Scalar: TensorFlowFloatingPoint {
     let poolSize: (Int, Int)
     let strides: (Int, Int)

--- a/Models/LayerInit/AutoPool.swift
+++ b/Models/LayerInit/AutoPool.swift
@@ -1,0 +1,44 @@
+import TensorFlow
+
+public struct AutoAvgPool2D<Scalar>: AutoLayer where Scalar: TensorFlowFloatingPoint {
+    let poolSize: (Int, Int)
+    let strides: (Int, Int)
+    let padding: Padding
+
+    public typealias InstanceType = AvgPool2D<Scalar>
+    public typealias InputShape = (Int, Int, Int)
+    public typealias OutputShape = (Int, Int, Int)
+
+    public init(
+        poolSize: (Int, Int),
+        strides: (Int, Int) = (1, 1),
+        padding: Padding = .valid
+    ) {
+        self.poolSize = poolSize
+        self.strides = strides
+        self.padding = padding
+    }
+
+    public func buildModelWithOutputShape(inputShape: (Int, Int, Int)) -> (InstanceType, (Int, Int, Int)) {
+        let outputShape: (Int, Int, Int)
+        if (padding == .valid) {
+            outputShape = (
+                Int(ceil(Float(inputShape.0 - poolSize.0 + 1) / Float(strides.0))),
+                Int(ceil(Float(inputShape.1 - poolSize.1 + 1) / Float(strides.1))),
+                inputShape.2
+            )
+        } else {
+            outputShape = (
+                Int(ceil(Float(inputShape.0) / Float(strides.0))),
+                Int(ceil(Float(inputShape.1) / Float(strides.1))),
+                inputShape.2
+            )
+        }
+
+        return (AvgPool2D<Scalar>(
+            poolSize: poolSize,
+            strides: strides,
+            padding: padding
+        ), outputShape)
+    }
+}

--- a/Models/LayerInit/AutoReuseLayer.swift
+++ b/Models/LayerInit/AutoReuseLayer.swift
@@ -13,6 +13,8 @@ where
     }
 }
 
+/// A layer blueprint for models that need to reuse the same layer in different places.
+/// Sequences a layer, then another layer, and then the first layer again.
 public struct AutoReuseLayer<OuterLayer: AutoLayer, MiddleLayer: AutoLayer>: AutoLayer
 where
   OuterLayer.OutputShape == MiddleLayer.InputShape,
@@ -25,6 +27,13 @@ where
 
     public typealias InstanceType = AutoReuseLayerInstance<OuterLayer.InstanceType, MiddleLayer.InstanceType>
 
+    /**
+     Constructs the layer reuse blueprint.
+
+     Parameters:
+        - outer: the layer to be reused, once at the beginning and once at the end
+        - middle: the layer to be used once, in between the two outer layers
+     */
     public init(outer: OuterLayer, middle: MiddleLayer) {
         self.outer = outer
         self.middle = middle

--- a/Models/LayerInit/AutoReuseLayer.swift
+++ b/Models/LayerInit/AutoReuseLayer.swift
@@ -36,9 +36,8 @@ where
 
         var tempDictionary: [AnyAutoLayerKey: Any] = [:]
 
-        // TODO(shadaj): tuples are not equatable
-        // let shapeMismatchError: String = "Cannot reuse outer layer because original input size \(inputShape) does not match output size of middle layer \(middleOutputShape)"
-        // precondition(inputShape == middleOutputShape, shapeMismatchError)
+        let shapeMismatchError: String = "Cannot reuse outer layer because original input size \(inputShape) does not match output size of middle layer \(middleOutputShape)"
+        precondition(intTupleToArray(tuple: inputShape) == intTupleToArray(tuple: middleOutputShape), shapeMismatchError)
         let (_, finalOutputShape) = outer.buildModelWithOutputShape(inputShape: middleOutputShape, keyPathSoFar: keyPathSoFar.appending(path: \InstanceType.outerLayer), keyDict: &tempDictionary)
 
         return (AutoReuseLayerInstance(outerLayer: outerLayer, middleLayer: middleLayer), finalOutputShape)

--- a/Models/LayerInit/AutoReuseLayer.swift
+++ b/Models/LayerInit/AutoReuseLayer.swift
@@ -27,13 +27,10 @@ where
 
     public typealias InstanceType = AutoReuseLayerInstance<OuterLayer.InstanceType, MiddleLayer.InstanceType>
 
-    /**
-     Constructs the layer reuse blueprint.
-
-     Parameters:
-        - outer: the layer to be reused, once at the beginning and once at the end
-        - middle: the layer to be used once, in between the two outer layers
-     */
+    /// Constructs the layer reuse blueprint.
+    /// Parameters:
+    ///   - outer: the layer to be reused, once at the beginning and once at the end
+    ///   - middle: the layer to be used once, in between the two outer layers
     public init(outer: OuterLayer, middle: MiddleLayer) {
         self.outer = outer
         self.middle = middle

--- a/Models/LayerInit/AutoReuseLayer.swift
+++ b/Models/LayerInit/AutoReuseLayer.swift
@@ -1,0 +1,46 @@
+import TensorFlow
+
+public struct AutoReuseLayerInstance<OuterLayer: Layer, MiddleLayer: Layer>: Layer
+where
+  OuterLayer.Output == MiddleLayer.Input, OuterLayer.Input == MiddleLayer.Output,
+  OuterLayer.TangentVector.VectorSpaceScalar == MiddleLayer.TangentVector.VectorSpaceScalar {
+    public var outerLayer: OuterLayer
+    public var middleLayer: MiddleLayer
+
+    @differentiable
+    public func callAsFunction(_ input: OuterLayer.Input) -> OuterLayer.Output {
+        return outerLayer(middleLayer(outerLayer(input)))
+    }
+}
+
+public struct AutoReuseLayer<OuterLayer: AutoLayer, MiddleLayer: AutoLayer>: AutoLayer
+where
+  OuterLayer.OutputShape == MiddleLayer.InputShape,
+  MiddleLayer.OutputShape == OuterLayer.InputShape,
+  OuterLayer.InstanceType.Output == MiddleLayer.InstanceType.Input,
+  MiddleLayer.InstanceType.Output == OuterLayer.InstanceType.Input,
+  OuterLayer.InstanceType.TangentVector.VectorSpaceScalar == MiddleLayer.InstanceType.TangentVector.VectorSpaceScalar {
+    let outer: OuterLayer
+    let middle: MiddleLayer
+
+    public typealias InstanceType = AutoReuseLayerInstance<OuterLayer.InstanceType, MiddleLayer.InstanceType>
+
+    public init(outer: OuterLayer, middle: MiddleLayer) {
+        self.outer = outer
+        self.middle = middle
+    }
+
+    public func buildModelWithOutputShape<Prefix>(inputShape: OuterLayer.InputShape, keyPathSoFar: KeyPath<Prefix, InstanceType>, keyDict: inout [AnyAutoLayerKey: Any]) -> (InstanceType, OuterLayer.OutputShape) {
+        let (outerLayer, firstOuterOutputShape) = outer.buildModelWithOutputShape(inputShape: inputShape, keyPathSoFar: keyPathSoFar.appending(path: \InstanceType.outerLayer), keyDict: &keyDict)
+        let (middleLayer, middleOutputShape) = middle.buildModelWithOutputShape(inputShape: firstOuterOutputShape, keyPathSoFar: keyPathSoFar.appending(path: \InstanceType.middleLayer), keyDict: &keyDict)
+
+        var tempDictionary: [AnyAutoLayerKey: Any] = [:]
+
+        // TODO(shadaj): tuples are not equatable
+        // let shapeMismatchError: String = "Cannot reuse outer layer because original input size \(inputShape) does not match output size of middle layer \(middleOutputShape)"
+        // precondition(inputShape == middleOutputShape, shapeMismatchError)
+        let (_, finalOutputShape) = outer.buildModelWithOutputShape(inputShape: middleOutputShape, keyPathSoFar: keyPathSoFar.appending(path: \InstanceType.outerLayer), keyDict: &tempDictionary)
+
+        return (AutoReuseLayerInstance(outerLayer: outerLayer, middleLayer: middleLayer), finalOutputShape)
+    }
+}

--- a/Models/LayerInit/AutoSequenced.swift
+++ b/Models/LayerInit/AutoSequenced.swift
@@ -1,6 +1,6 @@
 import TensorFlow
 
-public struct AutoSequencedDefinition<Layer1: AutoLayer, Layer2: AutoLayer>: AutoLayer
+public struct AutoSequenced<Layer1: AutoLayer, Layer2: AutoLayer>: AutoLayer
 where
   Layer1.OutputShape == Layer2.InputShape,
   Layer1.InstanceType.Output == Layer2.InstanceType.Input,
@@ -23,8 +23,8 @@ where
 }
 
 extension AutoLayer {
-    public func then<T: AutoLayer>(_ other: T) -> AutoSequencedDefinition<Self, T> {
-        return AutoSequencedDefinition<Self, T>(first: self, second: other)
+    public func then<T: AutoLayer>(_ other: T) -> AutoSequenced<Self, T> {
+        return AutoSequenced<Self, T>(first: self, second: other)
     }
 }
 

--- a/Models/LayerInit/AutoSequenced.swift
+++ b/Models/LayerInit/AutoSequenced.swift
@@ -1,0 +1,29 @@
+import TensorFlow
+
+public struct AutoSequencedDefinition<Layer1: AutoLayer, Layer2: AutoLayer>: AutoLayer
+where
+  Layer1.OutputShape == Layer2.InputShape,
+  Layer1.InstanceType.Output == Layer2.InstanceType.Input,
+  Layer1.InstanceType.TangentVector.VectorSpaceScalar == Layer2.InstanceType.TangentVector.VectorSpaceScalar {
+    let first: Layer1
+    let second: Layer2
+
+    public typealias InstanceType = Sequential<Layer1.InstanceType, Layer2.InstanceType>
+
+    public init(first: Layer1, second: Layer2) {
+        self.first = first
+        self.second = second
+    }
+
+    public func buildModelWithOutputShape(inputShape: Layer1.InputShape) -> (InstanceType, Layer2.OutputShape) {
+        let (firstInstance, firstOutputShape) = first.buildModelWithOutputShape(inputShape: inputShape)
+        let (secondInstance, secondOutputShape) = second.buildModelWithOutputShape(inputShape: firstOutputShape)
+        return (Sequential(firstInstance, secondInstance), secondOutputShape)
+    }
+}
+
+extension AutoLayer {
+    public func then<T: AutoLayer>(_ other: T) -> AutoSequencedDefinition<Self, T> {
+        return AutoSequencedDefinition<Self, T>(first: self, second: other)
+    }
+}

--- a/Models/LayerInit/AutoSequenced.swift
+++ b/Models/LayerInit/AutoSequenced.swift
@@ -25,6 +25,7 @@ where
 }
 
 extension AutoLayer {
+    /// Composes layers by sequencing the current layer to be followed by the passed layer
     public func then<T: AutoLayer>(_ other: T) -> AutoSequenced<Self, T> {
         return AutoSequenced<Self, T>(first: self, second: other)
     }
@@ -40,6 +41,8 @@ where LayerType.Input == LayerType.Output {
     }
 }
 
+/// A layer blueprint consisting of many instances of the same type of layer sequenced together
+/// The sequenced layer type must have the same input shape and output shape dimensions, since otherwise there is a shape mismatch.
 public struct AutoSequencedMany<LayerType: AutoLayer>: AutoLayer
 where
   LayerType.OutputShape == LayerType.InputShape,

--- a/Models/LayerInit/AutoSplitMerge.swift
+++ b/Models/LayerInit/AutoSplitMerge.swift
@@ -39,11 +39,15 @@ where Layer1.InputShape == Layer2.InputShape, Layer1.InstanceType.Input == Layer
     public typealias InputShape = Layer1.InputShape
     public typealias OutputShape = OutputShape
 
-    public init(layer1: Layer1, layer2: Layer2, mergeOutputShape: @escaping (Layer1.OutputShape, Layer2.OutputShape) -> OutputShape, mergeFn: SplitMergeFunctionWrapper<Layer1.InstanceType.Output, Layer2.InstanceType.Output, CommonOutput>) {
+    public init(
+        layer1: Layer1, layer2: Layer2,
+        mergeOutputShape: @escaping (Layer1.OutputShape, Layer2.OutputShape) -> OutputShape,
+        mergeFn: @escaping @differentiable (Layer1.InstanceType.Output, Layer2.InstanceType.Output) -> CommonOutput
+    ) {
         self.layer1 = layer1
         self.layer2 = layer2
         self.mergeOutputShape = mergeOutputShape
-        self.mergeFn = mergeFn
+        self.mergeFn = SplitMergeFunctionWrapper(mergeFn)
     }
 
     public func buildModelWithOutputShape<Prefix>(inputShape: Layer1.InputShape, keyPathSoFar: KeyPath<Prefix, InstanceType>, keyDict: inout [AnyAutoLayerKey: Any]) -> (InstanceType, OutputShape) {

--- a/Models/LayerInit/AutoSplitMerge.swift
+++ b/Models/LayerInit/AutoSplitMerge.swift
@@ -27,6 +27,7 @@ where Layer1.Input == Layer2.Input, Layer1.TangentVector.VectorSpaceScalar == La
     }
 }
 
+/// A layer blueprint where the same input is passed to two layers, whose outputs are then merged by a user-defined function.
 public struct AutoSplitMerge<Layer1: AutoLayer, Layer2: AutoLayer, CommonOutput: Differentiable, OutputShape>: AutoLayer
 where Layer1.InputShape == Layer2.InputShape, Layer1.InstanceType.Input == Layer2.InstanceType.Input, Layer1.InstanceType.TangentVector.VectorSpaceScalar == Layer2.InstanceType.TangentVector.VectorSpaceScalar {
     let layer1: Layer1
@@ -39,6 +40,14 @@ where Layer1.InputShape == Layer2.InputShape, Layer1.InstanceType.Input == Layer
     public typealias InputShape = Layer1.InputShape
     public typealias OutputShape = OutputShape
 
+    /**
+     Initializes a split-merge layer blueprint
+
+     Paremeters:
+        - layer1, layer2: the layers to run on the input data
+        - mergeOutputShape: a function describing how the output data merging function transforms the shapes of its inputs
+        - mergeFn: a function that merges the outputs of the two layers
+     */
     public init(
         layer1: Layer1, layer2: Layer2,
         mergeOutputShape: @escaping (Layer1.OutputShape, Layer2.OutputShape) -> OutputShape,

--- a/Models/LayerInit/AutoSplitMerge.swift
+++ b/Models/LayerInit/AutoSplitMerge.swift
@@ -9,8 +9,8 @@ public final class SplitMergeFunctionWrapper<Output1: Differentiable, Output2: D
 
 public struct SplitMergeInstance<Layer1: Layer, Layer2: Layer, CommonOutput: Differentiable>: Layer
 where Layer1.Input == Layer2.Input, Layer1.TangentVector.VectorSpaceScalar == Layer2.TangentVector.VectorSpaceScalar {
-    var layer1: Layer1
-    var layer2: Layer2
+    public var layer1: Layer1
+    public var layer2: Layer2
     @noDerivative let mergeFn: SplitMergeFunctionWrapper<Layer1.Output, Layer2.Output, CommonOutput>
 
     public init(layer1: Layer1, layer2: Layer2, mergeFn: SplitMergeFunctionWrapper<Layer1.Output, Layer2.Output, CommonOutput>) {
@@ -46,9 +46,9 @@ where Layer1.InputShape == Layer2.InputShape, Layer1.InstanceType.Input == Layer
         self.mergeFn = mergeFn
     }
 
-    public func buildModelWithOutputShape(inputShape: Layer1.InputShape) -> (InstanceType, OutputShape) {
-        let (layer1Built, layer1OutputShape) = layer1.buildModelWithOutputShape(inputShape: inputShape)
-        let (layer2Built, layer2OutputShape) = layer2.buildModelWithOutputShape(inputShape: inputShape)
+    public func buildModelWithOutputShape<Prefix>(inputShape: Layer1.InputShape, keyPathSoFar: KeyPath<Prefix, InstanceType>, keyDict: inout [AnyAutoLayerKey: Any]) -> (InstanceType, OutputShape) {
+        let (layer1Built, layer1OutputShape) = layer1.buildModelWithOutputShape(inputShape: inputShape, keyPathSoFar: keyPathSoFar.appending(path: \InstanceType.layer1), keyDict: &keyDict)
+        let (layer2Built, layer2OutputShape) = layer2.buildModelWithOutputShape(inputShape: inputShape, keyPathSoFar: keyPathSoFar.appending(path: \InstanceType.layer2), keyDict: &keyDict)
         return (SplitMergeInstance(layer1: layer1Built, layer2: layer2Built, mergeFn: self.mergeFn), self.mergeOutputShape(layer1OutputShape, layer2OutputShape))
     }
 }

--- a/Models/LayerInit/AutoSplitMerge.swift
+++ b/Models/LayerInit/AutoSplitMerge.swift
@@ -40,14 +40,11 @@ where Layer1.InputShape == Layer2.InputShape, Layer1.InstanceType.Input == Layer
     public typealias InputShape = Layer1.InputShape
     public typealias OutputShape = OutputShape
 
-    /**
-     Initializes a split-merge layer blueprint
-
-     Paremeters:
-        - layer1, layer2: the layers to run on the input data
-        - mergeOutputShape: a function describing how the output data merging function transforms the shapes of its inputs
-        - mergeFn: a function that merges the outputs of the two layers
-     */
+    /// Initializes a split-merge layer blueprint
+    /// Parameters:
+    ///     - layer1, layer2: the layers to run on the input data
+    ///     - mergeOutputShape: a function describing how the output data merging function transforms the shapes of its inputs
+    ///     - mergeFn: a function that merges the outputs of the two layers
     public init(
         layer1: Layer1, layer2: Layer2,
         mergeOutputShape: @escaping (Layer1.OutputShape, Layer2.OutputShape) -> OutputShape,

--- a/Models/LayerInit/AutoSplitMerge.swift
+++ b/Models/LayerInit/AutoSplitMerge.swift
@@ -1,0 +1,54 @@
+import TensorFlow
+
+// Workaround https://bugs.swift.org/browse/TF-1122
+public final class SplitMergeFunctionWrapper<Output1: Differentiable, Output2: Differentiable, CommonOutput: Differentiable> {
+  public typealias F = @differentiable (Output1, Output2) -> CommonOutput
+  public var f: F
+  public init(_ f: @escaping F) { self.f = f }
+}
+
+public struct SplitMergeInstance<Layer1: Layer, Layer2: Layer, CommonOutput: Differentiable>: Layer
+where Layer1.Input == Layer2.Input, Layer1.TangentVector.VectorSpaceScalar == Layer2.TangentVector.VectorSpaceScalar {
+    var layer1: Layer1
+    var layer2: Layer2
+    @noDerivative let mergeFn: SplitMergeFunctionWrapper<Layer1.Output, Layer2.Output, CommonOutput>
+
+    public init(layer1: Layer1, layer2: Layer2, mergeFn: SplitMergeFunctionWrapper<Layer1.Output, Layer2.Output, CommonOutput>) {
+        self.layer1 = layer1
+        self.layer2 = layer2
+        self.mergeFn = mergeFn
+    }
+
+    @differentiable
+    public func callAsFunction(_ input: Layer1.Input) -> CommonOutput {
+        let layer1Out = layer1(input)
+        let layer2Out = layer2(input)
+        return mergeFn.f(layer1Out, layer2Out)
+    }
+}
+
+public struct AutoSplitMerge<Layer1: AutoLayer, Layer2: AutoLayer, CommonOutput: Differentiable, OutputShape>: AutoLayer
+where Layer1.InputShape == Layer2.InputShape, Layer1.InstanceType.Input == Layer2.InstanceType.Input, Layer1.InstanceType.TangentVector.VectorSpaceScalar == Layer2.InstanceType.TangentVector.VectorSpaceScalar {
+    let layer1: Layer1
+    let layer2: Layer2
+
+    let mergeOutputShape: (Layer1.OutputShape, Layer2.OutputShape) -> OutputShape
+    let mergeFn: SplitMergeFunctionWrapper<Layer1.InstanceType.Output, Layer2.InstanceType.Output, CommonOutput>
+
+    public typealias InstanceType = SplitMergeInstance<Layer1.InstanceType, Layer2.InstanceType, CommonOutput>
+    public typealias InputShape = Layer1.InputShape
+    public typealias OutputShape = OutputShape
+
+    public init(layer1: Layer1, layer2: Layer2, mergeOutputShape: @escaping (Layer1.OutputShape, Layer2.OutputShape) -> OutputShape, mergeFn: SplitMergeFunctionWrapper<Layer1.InstanceType.Output, Layer2.InstanceType.Output, CommonOutput>) {
+        self.layer1 = layer1
+        self.layer2 = layer2
+        self.mergeOutputShape = mergeOutputShape
+        self.mergeFn = mergeFn
+    }
+
+    public func buildModelWithOutputShape(inputShape: Layer1.InputShape) -> (InstanceType, OutputShape) {
+        let (layer1Built, layer1OutputShape) = layer1.buildModelWithOutputShape(inputShape: inputShape)
+        let (layer2Built, layer2OutputShape) = layer2.buildModelWithOutputShape(inputShape: inputShape)
+        return (SplitMergeInstance(layer1: layer1Built, layer2: layer2Built, mergeFn: self.mergeFn), self.mergeOutputShape(layer1OutputShape, layer2OutputShape))
+    }
+}

--- a/Models/LayerInit/CMakeLists.txt
+++ b/Models/LayerInit/CMakeLists.txt
@@ -9,7 +9,8 @@ add_library(LayerInit
   AutoPool.swift
   AutoReuseLayer.swift
   AutoSequenced.swift
-  AutoSplitMerge.swift)
+  AutoSplitMerge.swift
+  TupleToArray.swift)
 set_target_properties(LayerInit PROPERTIES
   INTERFACE_INCLUDE_DIRECTORIES ${CMAKE_Swift_MODULE_DIRECTORY})
 target_compile_options(LayerInit PRIVATE

--- a/Models/LayerInit/CMakeLists.txt
+++ b/Models/LayerInit/CMakeLists.txt
@@ -1,0 +1,22 @@
+add_library(LayerInit
+  AutoConv.swift
+  AutoDense.swift
+  AutoFlatten.swift
+  AutoLayer.swift
+  AutoPool.swift
+  AutoSequenced.swift)
+set_target_properties(LayerInit PROPERTIES
+  INTERFACE_INCLUDE_DIRECTORIES ${CMAKE_Swift_MODULE_DIRECTORY})
+target_compile_options(LayerInit PRIVATE
+  $<$<BOOL:${BUILD_TESTING}>:-enable-testing>)
+
+
+install(TARGETS LayerInit
+  ARCHIVE DESTINATION lib/swift/$<LOWER_CASE:${CMAKE_SYSTEM_NAME}>
+  LIBRARY DESTINATION lib/swift/$<LOWER_CASE:${CMAKE_SYSTEM_NAME}>
+  RUNTIME DESTINATION bin)
+get_swift_host_arch(swift_arch)
+install(FILES
+  $<TARGET_PROPERTY:LayerInit,Swift_MODULE_DIRECTORY>/LayerInit.swiftdoc
+  $<TARGET_PROPERTY:LayerInit,Swift_MODULE_DIRECTORY>/LayerInit.swiftmodule
+  DESTINATION lib/swift$<$<NOT:$<BOOL:${BUILD_SHARED_LIBS}>>:_static>/$<LOWER_CASE:${CMAKE_SYSTEM_NAME}>/${swift_arch})

--- a/Models/LayerInit/CMakeLists.txt
+++ b/Models/LayerInit/CMakeLists.txt
@@ -5,7 +5,9 @@ add_library(LayerInit
   AutoFlatten.swift
   AutoFunction.swift
   AutoLayer.swift
+  AutoLayerKey.swift
   AutoPool.swift
+  AutoReuseLayer.swift
   AutoSequenced.swift
   AutoSplitMerge.swift)
 set_target_properties(LayerInit PROPERTIES

--- a/Models/LayerInit/CMakeLists.txt
+++ b/Models/LayerInit/CMakeLists.txt
@@ -1,10 +1,12 @@
 add_library(LayerInit
+  AutoBatchNorm.swift
   AutoConv.swift
   AutoDense.swift
   AutoFlatten.swift
   AutoLayer.swift
   AutoPool.swift
-  AutoSequenced.swift)
+  AutoSequenced.swift
+  AutoSplitMerge.swift)
 set_target_properties(LayerInit PROPERTIES
   INTERFACE_INCLUDE_DIRECTORIES ${CMAKE_Swift_MODULE_DIRECTORY})
 target_compile_options(LayerInit PRIVATE

--- a/Models/LayerInit/CMakeLists.txt
+++ b/Models/LayerInit/CMakeLists.txt
@@ -3,6 +3,7 @@ add_library(LayerInit
   AutoConv.swift
   AutoDense.swift
   AutoFlatten.swift
+  AutoFunction.swift
   AutoLayer.swift
   AutoPool.swift
   AutoSequenced.swift

--- a/Models/LayerInit/TupleToArray.swift
+++ b/Models/LayerInit/TupleToArray.swift
@@ -1,0 +1,61 @@
+public func intTupleToArray(tuple: Any) -> [Int] {
+    if let tuple = tuple as? (Int, Int) {
+        return [tuple.0, tuple.1]
+    }
+    if let tuple = tuple as? (Int, Int, Int) {
+        return [tuple.0, tuple.1, tuple.2]
+    }
+    if let tuple = tuple as? (Int, Int, Int, Int) {
+        return [tuple.0, tuple.1, tuple.2, tuple.3]
+    }
+    if let tuple = tuple as? (Int, Int, Int, Int, Int) {
+        return [tuple.0, tuple.1, tuple.2, tuple.3, tuple.4]
+    }
+    if let tuple = tuple as? (Int, Int, Int, Int, Int, Int) {
+        return [tuple.0, tuple.1, tuple.2, tuple.3, tuple.4, tuple.5]
+    }
+    if let tuple = tuple as? (Int, Int, Int, Int, Int, Int, Int) {
+        return [tuple.0, tuple.1, tuple.2, tuple.3, tuple.4, tuple.5, tuple.6]
+    }
+    if let tuple = tuple as? (Int, Int, Int, Int, Int, Int, Int, Int) {
+        return [tuple.0, tuple.1, tuple.2, tuple.3, tuple.4, tuple.5, tuple.6, tuple.7]
+    }
+    if let tuple = tuple as? (Int, Int, Int, Int, Int, Int, Int, Int, Int) {
+        return [tuple.0, tuple.1, tuple.2, tuple.3, tuple.4, tuple.5, tuple.6, tuple.7, tuple.8]
+    }
+    if let tuple = tuple as? (Int, Int, Int, Int, Int, Int, Int, Int, Int, Int) {
+        return [tuple.0, tuple.1, tuple.2, tuple.3, tuple.4, tuple.5, tuple.6, tuple.7, tuple.8, tuple.9]
+    }
+    if let tuple = tuple as? (Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int) {
+        return [tuple.0, tuple.1, tuple.2, tuple.3, tuple.4, tuple.5, tuple.6, tuple.7, tuple.8, tuple.9, tuple.10]
+    }
+    if let tuple = tuple as? (Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int) {
+        return [tuple.0, tuple.1, tuple.2, tuple.3, tuple.4, tuple.5, tuple.6, tuple.7, tuple.8, tuple.9, tuple.10, tuple.11]
+    }
+    if let tuple = tuple as? (Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int) {
+        return [tuple.0, tuple.1, tuple.2, tuple.3, tuple.4, tuple.5, tuple.6, tuple.7, tuple.8, tuple.9, tuple.10, tuple.11, tuple.12]
+    }
+    if let tuple = tuple as? (Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int) {
+        return [tuple.0, tuple.1, tuple.2, tuple.3, tuple.4, tuple.5, tuple.6, tuple.7, tuple.8, tuple.9, tuple.10, tuple.11, tuple.12, tuple.13]
+    }
+    if let tuple = tuple as? (Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int) {
+        return [tuple.0, tuple.1, tuple.2, tuple.3, tuple.4, tuple.5, tuple.6, tuple.7, tuple.8, tuple.9, tuple.10, tuple.11, tuple.12, tuple.13, tuple.14]
+    }
+    if let tuple = tuple as? (Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int) {
+        return [tuple.0, tuple.1, tuple.2, tuple.3, tuple.4, tuple.5, tuple.6, tuple.7, tuple.8, tuple.9, tuple.10, tuple.11, tuple.12, tuple.13, tuple.14, tuple.15]
+    }
+    if let tuple = tuple as? (Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int) {
+        return [tuple.0, tuple.1, tuple.2, tuple.3, tuple.4, tuple.5, tuple.6, tuple.7, tuple.8, tuple.9, tuple.10, tuple.11, tuple.12, tuple.13, tuple.14, tuple.15, tuple.16]
+    }
+    if let tuple = tuple as? (Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int) {
+        return [tuple.0, tuple.1, tuple.2, tuple.3, tuple.4, tuple.5, tuple.6, tuple.7, tuple.8, tuple.9, tuple.10, tuple.11, tuple.12, tuple.13, tuple.14, tuple.15, tuple.16, tuple.17]
+    }
+    if let tuple = tuple as? (Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int) {
+        return [tuple.0, tuple.1, tuple.2, tuple.3, tuple.4, tuple.5, tuple.6, tuple.7, tuple.8, tuple.9, tuple.10, tuple.11, tuple.12, tuple.13, tuple.14, tuple.15, tuple.16, tuple.17, tuple.18]
+    }
+    if let tuple = tuple as? (Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int) {
+        return [tuple.0, tuple.1, tuple.2, tuple.3, tuple.4, tuple.5, tuple.6, tuple.7, tuple.8, tuple.9, tuple.10, tuple.11, tuple.12, tuple.13, tuple.14, tuple.15, tuple.16, tuple.17, tuple.18, tuple.19]
+    }
+    
+    fatalError("Could not extract out elements of shape")
+}

--- a/Models/LayerInit/TupleToArray.swift.gyb
+++ b/Models/LayerInit/TupleToArray.swift.gyb
@@ -1,0 +1,10 @@
+% counts = range(2, 21)
+public func intTupleToArray(tuple: Any) -> [Int] {
+    % for count in counts:
+    if let tuple = tuple as? (${', '.join(['Int' for i in range(1, count + 1)])}) {
+        return [${', '.join(['tuple.%d' % i for i in range(0, count)])}]
+    }
+    % end
+    
+    fatalError("Could not extract out elements of shape")
+}

--- a/Package.swift
+++ b/Package.swift
@@ -36,6 +36,7 @@ let package = Package(
         .target(name: "TextModels", dependencies: ["Datasets"], path: "Models/Text"),
         .target(name: "RecommendationModels", path: "Models/Recommendation"),
         .target(name: "TrainingLoop", dependencies: ["ModelSupport"], path: "TrainingLoop"),
+        .target(name: "LayerInit", path: "Models/LayerInit"),
         .target(
             name: "Autoencoder1D", dependencies: ["Datasets", "ModelSupport"],
             path: "Autoencoder/Autoencoder1D"),


### PR DESCRIPTION
to be addressed:
- [x] `AutoBatchNorm` is tied to 2 dimensions + channel inputs, we should handle inputs of any dimension (an `HList` equivalent (Automatic Requirement Satisfaction?) could help here)
- [ ] throw an error if the same key is used twice in the model and offer some alternative for attaching keys to layers in reused chunks

Model Porting Progress:
- [x] LeNet ([diff](https://github.com/shadaj/swift-models/compare/layer-init-prototyping...shadaj:layer-init-porting/lenet))
- [x] VGG ([diff](https://github.com/shadaj/swift-models/compare/layer-init-prototyping...shadaj:layer-init-porting/vgg))
- [x] ResNet ([diff](https://github.com/shadaj/swift-models/compare/layer-init-prototyping...shadaj:layer-init-porting/resnet))
- [ ] WordSeg
- [ ] BERT
- [ ] GPT-2