### PR TITLE
[WordSeg] Add link to explanation doc

### DIFF
--- a/Examples/WordSeg/README.md
+++ b/Examples/WordSeg/README.md
@@ -8,7 +8,8 @@ by Kazuya Kawakami, Chris Dyer, and Phil Blunsom.
 
 A segmental neural language model (SNLM) is instantiated from the library of
 standard models. A custom training loop is defined and the training
-losses for each epoch are shown.
+losses for each epoch are shown. For an explanation of this approach, see
+the [Understanding WordSeg doc][understanding].
 
 This implementation is not affiliated with DeepMind and has not been verified by
 the authors.
@@ -18,6 +19,8 @@ the authors.
 To begin, you'll need the [latest version of Swift for
 TensorFlow][s4tf] installed. Make sure you've added the correct version of
 `swift` to your path.
+
+## Execution
 
 To train the model using the full datasets published in the paper, run:
 
@@ -30,7 +33,7 @@ To train the model using a smaller, unrealistic sample dataset, run:
 
 ```sh
 cd swift-models
-swift run -c release WordSeg Examples/WordSeg/smalldata.txt
+swift run -c release WordSeg Examples/WordSeg/smalldata.txt Examples/WordSeg/smalldata.txt
 ```
 
 To run the model with your own dataset, run:
@@ -43,3 +46,4 @@ swift run -c release WordSeg path/to/training_data.txt [path/to/validation_data.
 [model]: https://github.com/tensorflow/swift-models/tree/master/Models/Text/WordSeg
 [paper]: https://www.aclweb.org/anthology/P19-1645.pdf
 [s4tf]: https://github.com/tensorflow/swift/blob/master/Installation.md
+[understanding]: https://docs.google.com/document/d/1NlFH0_89gB_qggtgzJIKYHL2xPI3IQjWjv18pnT1M0E


### PR DESCRIPTION
Adds a link to the document @sgugger created that describes the WordSeg paper in detail.

Also adds a validation set to sample commands for viewing inference results during training.