### PR TITLE
Add a retry to the Swift download in the Dockerfile

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -5,8 +5,11 @@ ARG swift_tf_url=https://storage.googleapis.com/swift-tensorflow-artifacts/night
 
 # Download and extract S4TF
 WORKDIR /swift-tensorflow-toolchain
-RUN curl -fSsL --retry 5 $swift_tf_url -o swift.tar.gz \
-    && mkdir usr \
+RUN if ! curl -fSsL --retry 5 $swift_tf_url -o swift.tar.gz \
+    then curl -fSsL --retry 5 $swift_tf_url -o swift.tar.gz \
+    fi
+
+RUN mkdir usr \
     && tar -xzf swift.tar.gz --directory=usr --strip-components=1 \
     && rm swift.tar.gz
 ENV PATH="/swift-tensorflow-toolchain/usr/bin:${PATH}"

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -5,9 +5,9 @@ ARG swift_tf_url=https://storage.googleapis.com/swift-tensorflow-artifacts/night
 
 # Download and extract S4TF
 WORKDIR /swift-tensorflow-toolchain
-RUN if ! curl -fSsL --retry 5 $swift_tf_url -o swift.tar.gz \
-    then curl -fSsL --retry 5 $swift_tf_url -o swift.tar.gz \
-    fi
+RUN if ! curl -fSsL --retry 5 $swift_tf_url -o swift.tar.gz; \
+    then curl -fSsL --retry 5 $swift_tf_url -o swift.tar.gz; \
+    fi;
 
 RUN mkdir usr \
     && tar -xzf swift.tar.gz --directory=usr --strip-components=1 \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -5,7 +5,7 @@ ARG swift_tf_url=https://storage.googleapis.com/swift-tensorflow-artifacts/night
 
 # Download and extract S4TF
 WORKDIR /swift-tensorflow-toolchain
-RUN curl -fSsL $swift_tf_url -o swift.tar.gz \
+RUN curl -fSsL --retry 5 $swift_tf_url -o swift.tar.gz \
     && mkdir usr \
     && tar -xzf swift.tar.gz --directory=usr --strip-components=1 \
     && rm swift.tar.gz


### PR DESCRIPTION
We're experiencing intermittent SSL errors when trying to download the Swift nightly for CI builds. Added a retry of the curl command to the Dockerfile, which seems to defend against this and make CI more reliable.