### PR TITLE
Remove outdated references to Batcher

### DIFF
--- a/Autoencoder/Autoencoder1D/main.swift
+++ b/Autoencoder/Autoencoder1D/main.swift
@@ -16,7 +16,6 @@ import Datasets
 import Foundation
 import ModelSupport
 import TensorFlow
-import Batcher
 
 let epochCount = 10
 let batchSize = 100

--- a/Autoencoder/Autoencoder2D/main.swift
+++ b/Autoencoder/Autoencoder2D/main.swift
@@ -18,7 +18,6 @@ import Datasets
 import Foundation
 import ModelSupport
 import TensorFlow
-import Batcher
 
 let epochCount = 10
 let batchSize = 100

--- a/Benchmarks/Models/ImageClassificationInference.swift
+++ b/Benchmarks/Models/ImageClassificationInference.swift
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import Batcher
 import Datasets
 import ImageClassificationModels
 import TensorFlow
@@ -23,7 +22,6 @@ protocol ImageClassificationModel: Layer where Input == Tensor<Float>, Output ==
     static var outputLabels: Int { get }
 }
 
-// TODO: Ease the tight restriction on Batcher data sources to allow for lazy datasets.
 class ImageClassificationInference<Model, ClassificationDataset>: Benchmark
 where
     Model: ImageClassificationModel,

--- a/Benchmarks/Models/ImageClassificationTraining.swift
+++ b/Benchmarks/Models/ImageClassificationTraining.swift
@@ -12,11 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import Batcher
 import Datasets
 import TensorFlow
 
-// TODO: Ease the tight restriction on Batcher data sources to allow for lazy datasets.
 struct ImageClassificationTraining<Model, ClassificationDataset>: Benchmark
 where
     Model: ImageClassificationModel, Model.TangentVector.VectorSpaceScalar == Float,

--- a/Benchmarks/Models/SyntheticImageDataset.swift
+++ b/Benchmarks/Models/SyntheticImageDataset.swift
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import Batcher
 import Datasets
 import TensorFlow
 

--- a/Datasets/CIFAR10/CIFAR10.swift
+++ b/Datasets/CIFAR10/CIFAR10.swift
@@ -20,7 +20,6 @@
 import Foundation
 import ModelSupport
 import TensorFlow
-import Batcher
 
 public struct CIFAR10<Entropy: RandomNumberGenerator> {
   /// Type of the collection of non-collated batches.

--- a/Datasets/MNIST/FashionMNIST.swift
+++ b/Datasets/MNIST/FashionMNIST.swift
@@ -19,7 +19,6 @@
 
 import Foundation
 import TensorFlow
-import Batcher
 
 public struct FashionMNIST<Entropy: RandomNumberGenerator> {
   /// Type of the collection of non-collated batches.

--- a/Datasets/MNIST/KuzushijiMNIST.swift
+++ b/Datasets/MNIST/KuzushijiMNIST.swift
@@ -18,7 +18,6 @@
 
 import Foundation
 import TensorFlow
-import Batcher
 
 public struct KuzushijiMNIST<Entropy: RandomNumberGenerator> {
   /// Type of the collection of non-collated batches.

--- a/Datasets/MNIST/MNIST.swift
+++ b/Datasets/MNIST/MNIST.swift
@@ -19,7 +19,6 @@
 
 import Foundation
 import TensorFlow
-import Batcher
 
 public struct MNIST<Entropy: RandomNumberGenerator> {
   /// Type of the collection of non-collated batches.

--- a/Datasets/TextUnsupervised/TextUnsupervised.swift
+++ b/Datasets/TextUnsupervised/TextUnsupervised.swift
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import Batcher
 import Foundation
 import ModelSupport
 import TensorFlow

--- a/Examples/GPT2-WikiText2/main.swift
+++ b/Examples/GPT2-WikiText2/main.swift
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import Batcher
 import Datasets
 import TensorFlow
 import TextModels

--- a/Package.swift
+++ b/Package.swift
@@ -86,7 +86,7 @@ let package = Package(
             exclude: ["UI/Windows/main.swift", "UI/macOS/main.swift"]),
         .target(
             name: "GPT2-WikiText2",
-            dependencies: ["Batcher", "Datasets", "TextModels"],
+            dependencies: ["Datasets", "TextModels"],
             path: "Examples/GPT2-WikiText2",
             exclude: ["UI/Windows/main.swift"]),
         .testTarget(name: "TextTests", dependencies: ["TextModels"]),
@@ -112,7 +112,7 @@ let package = Package(
         .testTarget(name: "SupportTests", dependencies: ["ModelSupport"]),
         .target(
             name: "CycleGAN",
-            dependencies: ["Batcher", "ArgumentParser", "ModelSupport", "Datasets"],
+            dependencies: ["ArgumentParser", "ModelSupport", "Datasets"],
             path: "CycleGAN"
         ),
         .target(


### PR DESCRIPTION
There were several left over references to Batcher in targets that no longer needed that older API. These have been removed.