### PR TITLE
Adding delay to download retry attempts in Dockerfile

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -6,7 +6,7 @@ ARG swift_tf_url=https://storage.googleapis.com/swift-tensorflow-artifacts/night
 # Download and extract S4TF
 WORKDIR /swift-tensorflow-toolchain
 RUN if ! curl -fSsL --retry 5 $swift_tf_url -o swift.tar.gz; \
-    then curl -fSsL --retry 5 $swift_tf_url -o swift.tar.gz; \
+    then sleep 30 && curl -fSsL --retry 5 $swift_tf_url -o swift.tar.gz; \
     fi;
 
 RUN mkdir usr \


### PR DESCRIPTION
Adding the retry seemed to help with CI failures, but one slipped through where we received two OpenSSL errors in a row. In an attempt to make this more robust, I've added a 30 second delay before attempting to retry the download.