### PR TITLE
[WordSeg]: Use eager mode in main example

### DIFF
--- a/Examples/WordSeg/main.swift
+++ b/Examples/WordSeg/main.swift
@@ -66,7 +66,7 @@ let modelParameters = SNLM.Parameters(
   order: order
 )
 
-let device = Device.defaultXLA
+let device = Device.defaultTFEager
 
 var model = SNLM(parameters: modelParameters)
 model.move(to: device)


### PR DESCRIPTION
XLA mode has a longer compilation time, which can look like stalling to users unfamiliar with it. For the main WordSeg example, there's a bit more feedback for users with eager mode.