### PR TITLE
Fix epoch count in bert cola example

### DIFF
--- a/Examples/BERT-CoLA/main.swift
+++ b/Examples/BERT-CoLA/main.swift
@@ -96,7 +96,7 @@ var scheduledLearningRate = LinearlyDecayedParameter(
 )
 
 print("Training \(bertPretrained.name) for the CoLA task!")
-for (epoch, epochBatches) in cola.trainingEpochs.prefix(3).enumerated() {
+for (epoch, epochBatches) in cola.trainingEpochs.prefix(epochCount).enumerated() {
     print("[Epoch \(epoch + 1)]")
     Context.local.learningPhase = .training
     var trainingLossSum: Float = 0


### PR DESCRIPTION
There is an `epochCount` variable but actual number of epochs is hard-coded. Just a small fix.