### PR TITLE
[WordSeg]: Add named arguments with defaults

### DIFF
--- a/Examples/WordSeg/CMakeLists.txt
+++ b/Examples/WordSeg/CMakeLists.txt
@@ -1,5 +1,7 @@
 add_executable(WordSeg
-  main.swift)
+  main.swift
+  WordSegCommand.swift
+  WordSegSettings.swift)
 target_link_libraries(WordSeg PRIVATE
   TextModels
   Datasets)

--- a/Examples/WordSeg/README.md
+++ b/Examples/WordSeg/README.md
@@ -22,7 +22,7 @@ TensorFlow][s4tf] installed. Make sure you've added the correct version of
 
 ## Execution
 
-To train the model using the full datasets published in the paper, run:
+To train the model to accuracy using the full datasets published in the paper, run:
 
 ```sh
 cd swift-models
@@ -32,15 +32,24 @@ swift run -c release WordSeg
 To train the model using a smaller, unrealistic sample dataset, run:
 
 ```sh
-cd swift-models
-swift run -c release WordSeg Examples/WordSeg/smalldata.txt Examples/WordSeg/smalldata.txt
+swift run -c release WordSeg \
+  --training-path Examples/WordSeg/smalldata.txt \
+  --validation-path Examples/WordSeg/smalldata.txt
 ```
 
 To run the model with your own dataset, run:
 
 ```sh
-cd swift-models
-swift run -c release WordSeg path/to/training_data.txt [path/to/validation_data.txt [path/to/test_data.txt]]
+swift run -c release WordSeg \
+  --training-path path/to/training_data.txt \
+  [ --validation-path path/to/validation_data.txt \
+  [ --test-path path/to/test_data.txt ]]
+```
+
+To view a list of all configurable parameters and their defaults, run:
+
+```sh
+swift run -c release WordSeg --help
 ```
 
 [model]: https://github.com/tensorflow/swift-models/tree/master/Models/Text/WordSeg

--- a/Examples/WordSeg/WordSegCommand.swift
+++ b/Examples/WordSeg/WordSegCommand.swift
@@ -1,0 +1,84 @@
+// Copyright 2020 The TensorFlow Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import ArgumentParser
+
+struct WordSegCommand: ParsableCommand {
+  static var configuration = CommandConfiguration(
+    commandName: "WordSeg",
+    abstract: """
+      Runs training for the WordSeg model.
+      """
+  )
+
+  @Flag(help: "Use eager backend (default).")
+  var eager: Bool
+
+  @Flag(help: "Use X10 backend.")
+  var x10: Bool
+
+  @Option(help: "Path to training data.")
+  var trainingPath: String?
+
+  @Option(help: "Path to validation data.")
+  var validationPath: String?
+
+  @Option(help: "Path to test data.")
+  var testPath: String?
+
+  @Option(default: 1000, help: "Maximum number of training epochs.")
+  var maxEpochs: Int
+
+  @Option(default: 512, help: "Size of hidden layers.")
+  var hiddenSize: Int
+
+  @Option(default: 0.5, help: "Dropout rate.")
+  var dropoutProbability: Double
+
+  @Option(default: 5, help: "Power of the length penalty.")
+  var order: Int
+
+  @Option(default: 0.001, help: "Initial learning rate.")
+  var learningRate: Float
+
+  @Option(default: 0.00075, help: "Weight of the length penalty.")
+  var lambd: Float
+
+  @Option(default: 10, help: "Maximum length of a word.")
+  var maxLength: Int
+
+  @Option(default: 10, help: "Minimum frequency of a word.")
+  var minFrequency: Int
+
+  func validate() throws {
+    guard !(eager && x10) else {
+      throw ValidationError(
+        "Can't specify both --eager and --x10 backends.")
+    }
+  }
+
+  func run() throws {
+    let backend: Backend = x10 ? .x10 : .eager
+
+    let settings = WordSegSettings(
+      trainingPath: trainingPath,
+      validationPath: validationPath, testPath: testPath,
+      hiddenSize: hiddenSize, dropoutProbability: dropoutProbability,
+      order: order, lambd: lambd, maxEpochs: maxEpochs,
+      learningRate: learningRate, backend: backend,
+      maxLength: maxLength, minFrequency: minFrequency)
+
+    try runTraining(settings: settings)
+  }
+}

--- a/Examples/WordSeg/WordSegSettings.swift
+++ b/Examples/WordSeg/WordSegSettings.swift
@@ -1,0 +1,66 @@
+// Copyright 2020 The TensorFlow Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+struct WordSegSettings: Codable {
+
+  /// Dataset settings.
+
+  /// Path to training data.
+  let trainingPath: String?
+
+  /// Path to validation data.
+  let validationPath: String?
+
+  /// Path to test data.
+  let testPath: String?
+
+  /// Model settings.
+
+  /// Hidden unit size.
+  let hiddenSize: Int
+
+  /// Applicable to training.
+
+  /// Dropout rate.
+  let dropoutProbability: Double
+
+  /// Power of the length penalty.
+  let order: Int
+
+  /// Weight of the length penalty.
+  let lambd: Float
+
+  /// Maximum number of training epochs.
+  let maxEpochs: Int
+
+  /// Initial learning rate.
+  let learningRate: Float
+
+  /// Backend to use.
+  let backend: Backend
+
+  /// Lexicon settings.
+
+  /// Maximum length of a word.
+  let maxLength: Int
+
+  /// Minimum frequency of a word.
+  let minFrequency: Int
+}
+
+/// Backend used to dispatch tensor operations.
+enum Backend: String, Codable {
+  case eager = "eager"
+  case x10 = "x10"
+}

--- a/Examples/WordSeg/main.swift
+++ b/Examples/WordSeg/main.swift
@@ -28,8 +28,8 @@ internal func runTraining(settings: WordSegSettings) throws {
     dataset = try WordSegDataset()
   } else {
     dataset = try WordSegDataset(
-    training: settings.trainingPath!, validation: settings.validationPath,
-    testing: settings.testPath)
+      training: settings.trainingPath!, validation: settings.validationPath,
+      testing: settings.testPath)
   }
 
   let sequences = dataset.trainingPhrases.map { $0.numericalizedText }
@@ -50,10 +50,10 @@ internal func runTraining(settings: WordSegSettings) throws {
 
   let device: Device
   switch settings.backend {
-    case .eager:
-      device = Device.defaultTFEager
-    case .x10:
-      device = Device.defaultXLA
+  case .eager:
+    device = Device.defaultTFEager
+  case .x10:
+    device = Device.defaultXLA
   }
 
   var model = SNLM(parameters: modelParameters)

--- a/Package.swift
+++ b/Package.swift
@@ -122,7 +122,7 @@ let package = Package(
         ),
         .target(
             name: "WordSeg",
-            dependencies: ["ModelSupport", "TextModels", "Datasets"],
+            dependencies: ["ArgumentParser", "Datasets", "ModelSupport", "TextModels"],
             path: "Examples/WordSeg"
         ),
        .target(


### PR DESCRIPTION
Fixes #601 

Adds names to command-line arguments using `ArgumentParser`.
Updates README with new commands and how to view all available arguments with defaults.
Scopes helper functions as `fileprivate`.