### PR TITLE
Workaround to prevent X10 crashes during benchmarks

### DIFF
--- a/Benchmarks/Models/ImageClassificationInference.swift
+++ b/Benchmarks/Models/ImageClassificationInference.swift
@@ -52,6 +52,11 @@ where
 
         for (epoch, epochBatches) in dataset.training.enumerated() {
             if case let .epochs(epochs) = duration, epoch >= epochs {
+                if backend == .x10 {
+                    // A synchronous barrier is needed for X10 to ensure all execution completes
+                    // before tearing down the model.
+                    LazyTensorBarrier(wait: true)
+                }
                 return batchTimings
             }
 

--- a/Benchmarks/Models/ImageClassificationInference.swift
+++ b/Benchmarks/Models/ImageClassificationInference.swift
@@ -65,9 +65,19 @@ where
                 batchTimings.append(batchTime)
                 currentBatch += 1
                 if case let .batches(batches) = duration, currentBatch >= batches {
+                    if backend == .x10 {
+                        // A synchronous barrier is needed for X10 to ensure all execution completes
+                        // before tearing down the model.
+                        LazyTensorBarrier(wait: true)
+                    }
                     return batchTimings
                 }
             }
+        }
+        if backend == .x10 {
+            // A synchronous barrier is needed for X10 to ensure all execution completes
+            // before tearing down the model.
+            LazyTensorBarrier(wait: true)
         }
         return batchTimings
     }

--- a/Benchmarks/Models/ImageClassificationTraining.swift
+++ b/Benchmarks/Models/ImageClassificationTraining.swift
@@ -74,10 +74,20 @@ where
                 batchTimings.append(durationInMilliseconds(since: beforeBatch))
                 currentBatch += 1
                 if case let .batches(batches) = duration, currentBatch >= batches {
+                    if backend == .x10 {
+                        // A synchronous barrier is needed for X10 to ensure all execution completes
+                        // before tearing down the model.
+                        LazyTensorBarrier(wait: true)
+                    }
                     return batchTimings
                 }
                 beforeBatch = timestampInMilliseconds()
             }
+        }
+        if backend == .x10 {
+            // A synchronous barrier is needed for X10 to ensure all execution completes
+            // before tearing down the model.
+            LazyTensorBarrier(wait: true)
         }
         return batchTimings
     }

--- a/Benchmarks/Models/ImageClassificationTraining.swift
+++ b/Benchmarks/Models/ImageClassificationTraining.swift
@@ -59,6 +59,11 @@ where
         Context.local.learningPhase = .training
         for (epoch, epochBatches) in dataset.training.enumerated() {
             if case let .epochs(epochs) = duration, epoch >= epochs {
+                if backend == .x10 {
+                    // A synchronous barrier is needed for X10 to ensure all execution completes
+                    // before tearing down the model.
+                    LazyTensorBarrier(wait: true)
+                }
                 return batchTimings
             }
 

--- a/Benchmarks/Models/WordSeg.swift
+++ b/Benchmarks/Models/WordSeg.swift
@@ -139,6 +139,11 @@ struct WordSegBenchmark: Benchmark {
             fatalError("Error during WordSeg benchmark: \(error)")
         }
         
+        if backend == .x10 {
+            // A synchronous barrier is needed for X10 to ensure all execution completes
+            // before tearing down the model.
+            LazyTensorBarrier(wait: true)
+        }
         return batchTimings
     }
 }


### PR DESCRIPTION
Larger X10 models occasionally cause crashes when run in our benchmarks, but these crashes were only occurring at the very end of the benchmark. Tracking this down, it appears to be due to X10 (at least on GPU) executing traces asynchronously, leading to them running slightly after the point that the model and optimizer have gone out of scope. Inserting a synchronous barrier that blocks until execution is finished prevents these crashes.

This is inserted immediately before the returns of the timing values, because I found that this is the only location that reliably prevents crashes. Placing this barrier in a `defer` doesn't achieve the desired results, and the barrier must be within the benchmark function where the model and optimizer are allocated.

This addresses issue #528, but a more robust fix may be needed at the API level. 