### PR TITLE
Move typealias LabeledTextBatch into struct CoLA

### DIFF
--- a/Datasets/CoLA/CoLA.swift
+++ b/Datasets/CoLA/CoLA.swift
@@ -19,8 +19,6 @@ import Foundation
 import ModelSupport
 import TensorFlow
 
-/// A `TextBatch` with the corresponding labels.
-public typealias LabeledTextBatch = (data: TextBatch, label: Tensor<Int32>)
 
 /// CoLA example.
 public struct CoLAExample {
@@ -42,6 +40,9 @@ public struct CoLAExample {
 public struct CoLA<Entropy: RandomNumberGenerator> {
   /// The directory where the dataset will be downloaded
   public let directoryURL: URL
+
+  /// A `TextBatch` with the corresponding labels.
+  public typealias LabeledTextBatch = (data: TextBatch, label: Tensor<Int32>)
   /// The type of the labeled samples.
   public typealias Samples = LazyMapSequence<[CoLAExample], LabeledTextBatch>
   /// The training texts.

--- a/Examples/BERT-CoLA/main.swift
+++ b/Examples/BERT-CoLA/main.swift
@@ -63,7 +63,7 @@ var cola = try CoLA(
   maxSequenceLength: maxSequenceLength,
   batchSize: batchSize,
   entropy: SystemRandomNumberGenerator()
-) { (example: CoLAExample) -> LabeledTextBatch in
+) { (example: CoLAExample) -> CoLA.LabeledTextBatch in
   let textBatch = bertClassifier.bert.preprocess(
     sequences: [example.sentence],
     maxSequenceLength: maxSequenceLength)


### PR DESCRIPTION
Ran into "ambiguous for type lookup in this context" error when importing Datasets module while redefining the alias locally. This change constrain it inside CoLA struct to prevent the conflict.