### PR TITLE
Fix `ParameterlessLayer` conformances.

### DIFF
--- a/FastStyleTransfer/Layers/Helpers.swift
+++ b/FastStyleTransfer/Layers/Helpers.swift
@@ -2,6 +2,8 @@ import TensorFlow
 
 /// A 2-D layer applying padding with reflection over a mini-batch.
 public struct ReflectionPad2D<Scalar: TensorFlowFloatingPoint>: ParameterlessLayer {
+    public typealias TangentVector = EmptyTangentVector
+
     /// The padding values along the spatial dimensions.
     @noDerivative public let padding: ((Int, Int), (Int, Int))
 
@@ -39,6 +41,8 @@ public struct ReflectionPad2D<Scalar: TensorFlowFloatingPoint>: ParameterlessLay
 
 /// A layer applying `relu` activation function.
 public struct ReLU<Scalar: TensorFlowFloatingPoint>: ParameterlessLayer {
+    public typealias TangentVector = EmptyTangentVector
+
     /// Returns the output obtained from applying the layer to the given input.
     ///
     /// - Parameter input: The input to the layer.

--- a/Models/ImageClassification/ShuffleNetV2.swift
+++ b/Models/ImageClassification/ShuffleNetV2.swift
@@ -19,6 +19,8 @@ import TensorFlow
 // Ningning Ma, Xiangyu Zhang, Hai-Tao Zheng, Jian Sun
 
 public struct ChannelShuffle: ParameterlessLayer {
+    public typealias TangentVector = EmptyTangentVector
+
     @noDerivative public var groups: Int
     
     public init(groups: Int = 2) {

--- a/Models/Text/GPT2/TransformerLM.swift
+++ b/Models/Text/GPT2/TransformerLM.swift
@@ -130,6 +130,8 @@ func _vjpCausallyMasked(_ dotProducts: Tensor<Float>, enable: Bool)
 }
 
 struct Attention: ParameterlessLayer {
+    typealias TangentVector = EmptyTangentVector
+
     @noDerivative var dropout: Dropout<Float>
     @noDerivative var scale: Tensor<Float>
     @noDerivative var causal: Bool

--- a/pix2pix/Layers.swift
+++ b/pix2pix/Layers.swift
@@ -15,6 +15,8 @@ import TensorFlow
 import Foundation
 
 public struct Identity: ParameterlessLayer {
+    public typealias TangentVector = EmptyTangentVector
+
     @differentiable
     public func callAsFunction(_ input: Tensor<Float>) -> Tensor<Float> {
         input


### PR DESCRIPTION
Associated type inference behavior was changed in https://github.com/apple/swift/pull/32578:
derived conformances are now attempted before associated type inference.

This broke `ParameterlessLayer`, which relied on a
`TangentVector == EmptyTangentVector` same-type constraint to set a
default `TangentVector` type witness for conforming types.

Add explicit `TangentVector` type witnesses to
`ParameterlessLayer`-conforming types to fix this regression.

This workaround is forward- and backward-compatible, but makes code more
verbose.

Related `tensorflow/swift-apis` change: https://github.com/tensorflow/swift-apis/pull/1034

---

Fixes build errors from the [2020-06-30 `master -> tensorflow` merge](https://github.com/apple/swift/pull/32623):

<details>

```
/swift-models/Models/ImageClassification/ShuffleNetV2.swift:21:15: error: 'ParameterlessLayer' requires the types 'ChannelShuffle.TangentVector' and 'EmptyTangentVector' be equivalent
public struct ChannelShuffle: ParameterlessLayer {
              ^
/swift-models/Models/ImageClassification/ShuffleNetV2.swift:21:15: note: requirement specified as 'Self.TangentVector' == 'EmptyTangentVector' [with Self = ChannelShuffle]
public struct ChannelShuffle: ParameterlessLayer {
              ^
/swift-models/Models/ImageClassification/ShuffleNetV2.swift:21:15: error: type 'ChannelShuffle.TangentVector' does not conform to protocol 'VectorProtocol'
public struct ChannelShuffle: ParameterlessLayer {
              ^
[19/147] Compiling TextModels BERTClassifier.swift
/swift-models/FastStyleTransfer/Layers/Helpers.swift:4:15: error: 'ParameterlessLayer' requires the types 'ReflectionPad2D<Scalar>.TangentVector' and 'EmptyTangentVector' be equivalent
public struct ReflectionPad2D<Scalar: TensorFlowFloatingPoint>: ParameterlessLayer {
              ^
/swift-models/FastStyleTransfer/Layers/Helpers.swift:4:15: note: requirement specified as 'Self.TangentVector' == 'EmptyTangentVector' [with Self = ReflectionPad2D<Scalar>]
public struct ReflectionPad2D<Scalar: TensorFlowFloatingPoint>: ParameterlessLayer {
              ^
/swift-models/FastStyleTransfer/Layers/Helpers.swift:4:15: error: type 'ReflectionPad2D<Scalar>.TangentVector' does not conform to protocol 'VectorProtocol'
public struct ReflectionPad2D<Scalar: TensorFlowFloatingPoint>: ParameterlessLayer {
              ^
/swift-models/FastStyleTransfer/Layers/Helpers.swift:41:15: error: 'ParameterlessLayer' requires the types 'ReLU<Scalar>.TangentVector' and 'EmptyTangentVector' be equivalent
public struct ReLU<Scalar: TensorFlowFloatingPoint>: ParameterlessLayer {
              ^
/swift-models/FastStyleTransfer/Layers/Helpers.swift:41:15: note: requirement specified as 'Self.TangentVector' == 'EmptyTangentVector' [with Self = ReLU<Scalar>]
public struct ReLU<Scalar: TensorFlowFloatingPoint>: ParameterlessLayer {
              ^
/swift-models/FastStyleTransfer/Layers/Helpers.swift:41:15: error: type 'ReLU<Scalar>.TangentVector' does not conform to protocol 'VectorProtocol'
public struct ReLU<Scalar: TensorFlowFloatingPoint>: ParameterlessLayer {
              ^
/swift-models/FastStyleTransfer/Models/TransformerNet.swift:5:15: error: type 'TransformerNet.TangentVector' does not conform to protocol 'VectorProtocol'
public struct TransformerNet: Layer {
              ^
/swift-models/FastStyleTransfer/Models/TransformerNet.swift:58:15: error: type 'ConvLayer.TangentVector' does not conform to protocol 'VectorProtocol'
public struct ConvLayer: Layer {
              ^
/swift-models/FastStyleTransfer/Models/TransformerNet.swift:90:15: error: type 'ResidualBlock.TangentVector' does not conform to protocol 'VectorProtocol'
public struct ResidualBlock: Layer {
              ^
/swift-models/FastStyleTransfer/Models/TransformerNet.swift:124:15: error: type 'UpsampleConvLayer.TangentVector' does not conform to protocol 'VectorProtocol'
public struct UpsampleConvLayer: Layer {
              ^
```

</details>