### PR TITLE
Add fine-grain layer benchmarks

### DIFF
--- a/Benchmarks/Layers/DefaultInit.swift
+++ b/Benchmarks/Layers/DefaultInit.swift
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-let suites = Array([
-    layerSuites,
-    modelSuites,
-].joined())
+protocol DefaultInit {
+  init()
+}

--- a/Benchmarks/Layers/DenseNet.swift
+++ b/Benchmarks/Layers/DenseNet.swift
@@ -12,10 +12,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-let layerSuites = Array(
-  [
-    DenseNetSuites,
-    LeNetSuites,
-    ResNetSuites,
-    ResNetV2Suites,
-  ].joined())
+import ImageClassificationModels
+
+let DenseNetSuites = [
+  makeLayerSuite(
+    name: "DenseNet121",
+    inputDimensions: imageNetInput,
+    outputDimensions: imageNetOutput
+  ) {
+    DenseNet121(classCount: 1000)
+  }
+]

--- a/Benchmarks/Layers/Dimensions.swift
+++ b/Benchmarks/Layers/Dimensions.swift
@@ -12,6 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+let mnistInput = [28, 28, 1]
+let mnistOutput = [10]
+
 let cifarInput = [32, 32, 3]
 let cifarOutput = [10]
 

--- a/Benchmarks/Layers/Dimensions.swift
+++ b/Benchmarks/Layers/Dimensions.swift
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-protocol DefaultInit {
-  init()
-}
+let cifarInput = [32, 32, 3]
+let cifarOutput = [10]
+
+let imageNetInput = [224, 224, 3]
+let imageNetOutput = [1000]

--- a/Benchmarks/Layers/EfficientNet.swift
+++ b/Benchmarks/Layers/EfficientNet.swift
@@ -81,8 +81,7 @@ let EfficientNetSuites = [
   makeLayerSuite(
     name: "EfficientNetL2",
     inputDimensions: imageNetInput,
-    outputDimensions: imageNetOutput,
-    batchSizes: [2] // Default of 4 doesn't work with x10 on v100.
+    outputDimensions: imageNetOutput
   ) {
     EfficientNet(kind: .efficientnetL2, classCount: 1000)
   },

--- a/Benchmarks/Layers/EfficientNet.swift
+++ b/Benchmarks/Layers/EfficientNet.swift
@@ -81,7 +81,8 @@ let EfficientNetSuites = [
   makeLayerSuite(
     name: "EfficientNetL2",
     inputDimensions: imageNetInput,
-    outputDimensions: imageNetOutput
+    outputDimensions: imageNetOutput,
+    batchSizes: [2] // Default of 4 doesn't work with x10 on v100.
   ) {
     EfficientNet(kind: .efficientnetL2, classCount: 1000)
   },

--- a/Benchmarks/Layers/EfficientNet.swift
+++ b/Benchmarks/Layers/EfficientNet.swift
@@ -1,0 +1,88 @@
+// Copyright 2019 The TensorFlow Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import ImageClassificationModels
+
+let EfficientNetSuites = [
+  makeLayerSuite(
+    name: "EfficientNetB0",
+    inputDimensions: imageNetInput,
+    outputDimensions: imageNetOutput
+  ) {
+    EfficientNet(kind: .efficientnetB0, classCount: 1000)
+  },
+  makeLayerSuite(
+    name: "EfficientNetB1",
+    inputDimensions: imageNetInput,
+    outputDimensions: imageNetOutput
+  ) {
+    EfficientNet(kind: .efficientnetB1, classCount: 1000)
+  },
+  makeLayerSuite(
+    name: "EfficientNetB2",
+    inputDimensions: imageNetInput,
+    outputDimensions: imageNetOutput
+  ) {
+    EfficientNet(kind: .efficientnetB2, classCount: 1000)
+  },
+  makeLayerSuite(
+    name: "EfficientNetB3",
+    inputDimensions: imageNetInput,
+    outputDimensions: imageNetOutput
+  ) {
+    EfficientNet(kind: .efficientnetB3, classCount: 1000)
+  },
+  makeLayerSuite(
+    name: "EfficientNetB4",
+    inputDimensions: imageNetInput,
+    outputDimensions: imageNetOutput
+  ) {
+    EfficientNet(kind: .efficientnetB4, classCount: 1000)
+  },
+  makeLayerSuite(
+    name: "EfficientNetB5",
+    inputDimensions: imageNetInput,
+    outputDimensions: imageNetOutput
+  ) {
+    EfficientNet(kind: .efficientnetB5, classCount: 1000)
+  },
+  makeLayerSuite(
+    name: "EfficientNetB6",
+    inputDimensions: imageNetInput,
+    outputDimensions: imageNetOutput
+  ) {
+    EfficientNet(kind: .efficientnetB6, classCount: 1000)
+  },
+  makeLayerSuite(
+    name: "EfficientNetB7",
+    inputDimensions: imageNetInput,
+    outputDimensions: imageNetOutput
+  ) {
+    EfficientNet(kind: .efficientnetB7, classCount: 1000)
+  },
+  makeLayerSuite(
+    name: "EfficientNetB8",
+    inputDimensions: imageNetInput,
+    outputDimensions: imageNetOutput
+  ) {
+    EfficientNet(kind: .efficientnetB8, classCount: 1000)
+  },
+  makeLayerSuite(
+    name: "EfficientNetL2",
+    inputDimensions: imageNetInput,
+    outputDimensions: imageNetOutput
+  ) {
+    EfficientNet(kind: .efficientnetL2, classCount: 1000)
+  },
+]

--- a/Benchmarks/Layers/LayerSuite.swift
+++ b/Benchmarks/Layers/LayerSuite.swift
@@ -142,6 +142,7 @@ func makeLayerSuite<CustomLayer>(
   inputDimensions inp: [Int],
   outputDimensions outp: [Int],
   batchSizes: [Int] = [4],
+  backends: [Backend.Value] = [.eager, .x10],
   layer: @escaping () -> CustomLayer
 ) -> BenchmarkSuite
 where
@@ -158,16 +159,16 @@ where
     settings: WarmupIterations(10)
   ) { suite in
     for batchSize in batchSizes {
-      for backend in [Backend(.x10), Backend(.eager)] {
+      for backend in backends {
         suite.benchmark(
-          "forward_b\(batchSize)_\(backend.value)",
-          settings: backend, BatchSize(batchSize),
+          "forward_b\(batchSize)_\(backend)",
+          settings: Backend(backend), BatchSize(batchSize),
           function: makeForwardBenchmark(layer: layer, inputDimensions: inp, outputDimensions: outp)
         )
 
         suite.benchmark(
-          "forward_and_gradient_b\(batchSize)_\(backend.value)",
-          settings: backend, BatchSize(batchSize),
+          "forward_and_gradient_b\(batchSize)_\(backend)",
+          settings: Backend(backend), BatchSize(batchSize),
           function: makeGradientBenchmark(
             layer: layer, inputDimensions: inp, outputDimensions: outp))
       }

--- a/Benchmarks/Layers/LayerSuite.swift
+++ b/Benchmarks/Layers/LayerSuite.swift
@@ -153,13 +153,15 @@ where
   CustomLayer.Output == Tensor<Float>,
   CustomLayer.TangentVector.VectorSpaceScalar == Float
 {
-  let name: String = String(String(reflecting: layer).split(separator: ".").last!)
+  let name = String(String(reflecting: layer).split(separator: ".").last!)
+  let inputString = inp.map { String($0) }.joined(separator: "x")
+  let outputString = outp.map { String($0) }.joined(separator: "x")
 
   return BenchmarkSuite(
-    name: name,
+    name: "\(name)_\(inputString)_\(outputString)",
     settings: WarmupIterations(10)
   ) { suite in
-    for batchSize in [32, 64, 128, 256, 512, 1024] {
+    for batchSize in [128] {
       for backend in [Backend(.x10), Backend(.eager)] {
         suite.benchmark(
           "forward_b\(batchSize)_\(backend.value)",

--- a/Benchmarks/Layers/LayerSuite.swift
+++ b/Benchmarks/Layers/LayerSuite.swift
@@ -1,0 +1,203 @@
+// Copyright 2019 The TensorFlow Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import Benchmark
+import Datasets
+import ImageClassificationModels
+import TensorFlow
+
+func makeSyntheticBatch<Model>(
+  model: Model.Type,
+  batchSize: Int,
+  device: Device
+) -> (Tensor<Float>, Tensor<Int32>)
+where
+  Model: ImageClassificationModel, Model.TangentVector.VectorSpaceScalar == Float
+{
+  let dataset = SyntheticImageDataset<SystemRandomNumberGenerator>(
+    batchSize: batchSize,
+    labels: model.outputLabels,
+    dimensions: model.preferredInputDimensions,
+    entropy: SystemRandomNumberGenerator(),
+    device: device)
+
+  for epochBatches in dataset.training {
+    for batch in epochBatches {
+      return (batch.data, batch.label)
+    }
+  }
+
+  fatalError("unreachable")
+}
+
+func forwardBenchmark<Model>(
+  model modelType: Model.Type
+) -> ((inout BenchmarkState) throws -> Void)
+where
+  Model: ImageClassificationModel, Model.TangentVector.VectorSpaceScalar == Float
+{
+  return { state in
+    let settings = state.settings
+    let device = settings.device
+    let batchSize = settings.batchSize!
+    var model = Model()
+    model.move(to: device)
+    let (images, _) = makeSyntheticBatch(model: modelType, batchSize: batchSize, device: device)
+
+    var sink = TensorShape([])
+
+    while true {
+      do {
+        try state.measure {
+          let result = model(images)
+          // Force materialization of the lazy results.
+          sink = result.shape
+          LazyTensorBarrier()
+        }
+      } catch {
+        if settings.backend == .x10 {
+          // A synchronous barrier is needed for X10 to ensure all execution completes
+          // before tearing down the model.
+          LazyTensorBarrier(wait: true)
+        }
+        throw error
+      }
+    }
+
+    // Control-flow never gets here, but this removes the warning 
+    // about shape being never used.
+    // being never used.
+    fatalError("unrechable \(sink)")
+  }
+}
+
+func gradientBenchmark<Model>(
+  model modelType: Model.Type
+) -> ((inout BenchmarkState) throws -> Void)
+where
+  Model: ImageClassificationModel, Model.TangentVector.VectorSpaceScalar == Float
+{
+  return { state in
+    let settings = state.settings
+    let device = settings.device
+    let batchSize = settings.batchSize!
+    var model = Model()
+    model.move(to: device)
+    let (images, labels) = makeSyntheticBatch(model: modelType, batchSize: batchSize, device: device)
+
+    var sink: Model.TangentVector = Model.TangentVector.zero
+    sink.move(to: device)
+
+    while true {
+      do {
+        try state.measure {
+          let result = TensorFlow.gradient(at: model) { model -> Tensor<Float> in
+            let logits = model(images)
+            return softmaxCrossEntropy(logits: logits, labels: labels)
+          }
+          // Force materialization of the lazy results.
+          sink += result
+          LazyTensorBarrier()
+        }
+      } catch {
+        if settings.backend == .x10 {
+          // A synchronous barrier is needed for X10 to ensure all execution completes
+          // before tearing down the model.
+          LazyTensorBarrier(wait: true)
+        }
+        throw error
+      }
+    }
+
+    // Control-flow never gets here, but this removes the warning 
+    // about shape being never used.
+    // being never used.
+    fatalError("unrechable \(sink)")
+  }
+}
+
+func updateBenchmark<Model>(
+  model modelType: Model.Type
+) -> ((inout BenchmarkState) throws -> Void)
+where
+  Model: ImageClassificationModel, Model.TangentVector.VectorSpaceScalar == Float
+{
+  return { state in
+    let settings = state.settings
+    let device = settings.device
+    let batchSize = settings.batchSize!
+    var model = Model()
+    model.move(to: device)
+    var optimizer = SGD(for: model, learningRate: 0.1)
+    optimizer = SGD(copying: optimizer, to: device)
+    let (images, labels) = makeSyntheticBatch(model: modelType, batchSize: batchSize, device: device)
+
+    while true {
+      do {
+        try state.measure {
+          let 𝛁model = TensorFlow.gradient(at: model) { model -> Tensor<Float> in
+            let logits = model(images)
+            return softmaxCrossEntropy(logits: logits, labels: labels)
+          }
+          optimizer.update(&model, along: 𝛁model)
+          LazyTensorBarrier()
+        }
+      } catch {
+        if settings.backend == .x10 {
+          // A synchronous barrier is needed for X10 to ensure all execution completes
+          // before tearing down the model.
+          LazyTensorBarrier(wait: true)
+        }
+        throw error
+      }
+    }
+  }
+}
+
+func LayerSuite<Model>(
+  model modelType: Model.Type
+) -> BenchmarkSuite
+where
+  Model: ImageClassificationModel, Model.TangentVector.VectorSpaceScalar == Float
+{
+  let name: String = String(String(reflecting: modelType).split(separator: ".").last!)
+
+  return BenchmarkSuite(
+    name: name,
+    settings: WarmupIterations(10)
+  ) { suite in
+    for batchSize in [32, 64, 128, 256, 512, 1024] {
+      for backend in [Backend(.x10), Backend(.eager)] {
+        suite.benchmark(
+          "forward_b\(batchSize)_\(backend.value)",
+          settings: backend, BatchSize(batchSize),
+          function: forwardBenchmark(model: modelType))
+
+        suite.benchmark(
+          "gradient_b\(batchSize)_\(backend.value)",
+          settings: backend, BatchSize(batchSize),
+          function: gradientBenchmark(model: modelType))
+
+        suite.benchmark(
+          "update_b\(batchSize)_\(backend.value)",
+          settings: backend, BatchSize(batchSize),
+          function: updateBenchmark(model: modelType))
+      }
+    }
+  }
+}
+
+let LeNetSuite = LayerSuite(model: LeNet.self)
+let ResNet50Suite = LayerSuite(model: ResNet50.self)
+let ResNet56Suite = LayerSuite(model: ResNet56.self)

--- a/Benchmarks/Layers/LayerSuite.swift
+++ b/Benchmarks/Layers/LayerSuite.swift
@@ -54,14 +54,15 @@ where
       dimensions: inputDimensions,
       device: device)
 
-    var sink: TensorShape = TensorShape([])
+    var sink = makeRandomTensor(
+      batchSize: batchSize, dimensions: outputDimensions, device: device)
 
     while true {
       do {
         try state.measure {
           let result = layer(input)
           // Force materialization of the lazy results.
-          sink = result.shape
+          sink += result
           LazyTensorBarrier()
         }
       } catch {
@@ -76,7 +77,7 @@ where
 
     // Control-flow never gets here, but this removes the warning 
     // about the sink being never used.
-    fatalError("unrechable \(sink)")
+    fatalError("unreachable \(sink)")
   }
 }
 
@@ -163,8 +164,8 @@ where
         suite.benchmark(
           "forward_b\(batchSize)_\(backend)",
           settings: Backend(backend), BatchSize(batchSize),
-          function: makeForwardBenchmark(layer: layer, inputDimensions: inp, outputDimensions: outp)
-        )
+          function: makeForwardBenchmark(
+            layer: layer, inputDimensions: inp, outputDimensions: outp))
 
         suite.benchmark(
           "forward_and_gradient_b\(batchSize)_\(backend)",

--- a/Benchmarks/Layers/LayerSuite.swift
+++ b/Benchmarks/Layers/LayerSuite.swift
@@ -75,8 +75,7 @@ where
     }
 
     // Control-flow never gets here, but this removes the warning 
-    // about shape being never used.
-    // being never used.
+    // about the sink being never used.
     fatalError("unrechable \(sink)")
   }
 }
@@ -133,8 +132,7 @@ where
     }
 
     // Control-flow never gets here, but this removes the warning 
-    // about shape being never used.
-    // being never used.
+    // about the sink being never used.
     fatalError("unrechable \(sink)")
   }
 }

--- a/Benchmarks/Layers/LayerSuite.swift
+++ b/Benchmarks/Layers/LayerSuite.swift
@@ -32,13 +32,12 @@ func makeRandomTensor(
 }
 
 func makeForwardBenchmark<CustomLayer>(
-  layer: CustomLayer.Type,
+  layer makeLayer: @escaping () -> CustomLayer,
   inputDimensions: [Int],
   outputDimensions: [Int]
 ) -> ((inout BenchmarkState) throws -> Void)
 where
   CustomLayer: Layer,
-  CustomLayer: DefaultInit,
   CustomLayer.Input == Tensor<Float>,
   CustomLayer.Output == Tensor<Float>,
   CustomLayer.TangentVector.VectorSpaceScalar == Float
@@ -47,7 +46,7 @@ where
     let settings = state.settings
     let device = settings.device
     let batchSize = settings.batchSize!
-    var layer = CustomLayer()
+    var layer = makeLayer()
     layer.move(to: device)
 
     let input = makeRandomTensor(
@@ -83,13 +82,12 @@ where
 }
 
 func makeGradientBenchmark<CustomLayer>(
-  layer: CustomLayer.Type,
+  layer makeLayer: @escaping () -> CustomLayer,
   inputDimensions: [Int],
   outputDimensions: [Int]
 ) -> ((inout BenchmarkState) throws -> Void)
 where
   CustomLayer: Layer,
-  CustomLayer: DefaultInit,
   CustomLayer.Input == Tensor<Float>,
   CustomLayer.Output == Tensor<Float>,
   CustomLayer.TangentVector.VectorSpaceScalar == Float
@@ -98,7 +96,7 @@ where
     let settings = state.settings
     let device = settings.device
     let batchSize = settings.batchSize!
-    var layer = CustomLayer()
+    var layer = makeLayer()
     layer.move(to: device)
 
     let input = makeRandomTensor(
@@ -142,18 +140,17 @@ where
 }
 
 func makeLayerSuite<CustomLayer>(
-  layer: CustomLayer.Type,
+  name: String,
   inputDimensions inp: [Int],
-  outputDimensions outp: [Int]
+  outputDimensions outp: [Int],
+  layer: @escaping () -> CustomLayer
 ) -> BenchmarkSuite
 where
   CustomLayer: Layer,
-  CustomLayer: DefaultInit,
   CustomLayer.Input == Tensor<Float>,
   CustomLayer.Output == Tensor<Float>,
   CustomLayer.TangentVector.VectorSpaceScalar == Float
 {
-  let name = String(String(reflecting: layer).split(separator: ".").last!)
   let inputString = inp.map { String($0) }.joined(separator: "x")
   let outputString = outp.map { String($0) }.joined(separator: "x")
 

--- a/Benchmarks/Layers/LayerSuite.swift
+++ b/Benchmarks/Layers/LayerSuite.swift
@@ -143,6 +143,7 @@ func makeLayerSuite<CustomLayer>(
   name: String,
   inputDimensions inp: [Int],
   outputDimensions outp: [Int],
+  batchSizes: [Int] = [4],
   layer: @escaping () -> CustomLayer
 ) -> BenchmarkSuite
 where
@@ -158,7 +159,7 @@ where
     name: "\(name)_\(inputString)_\(outputString)",
     settings: WarmupIterations(10)
   ) { suite in
-    for batchSize in [128] {
+    for batchSize in batchSizes {
       for backend in [Backend(.x10), Backend(.eager)] {
         suite.benchmark(
           "forward_b\(batchSize)_\(backend.value)",

--- a/Benchmarks/Layers/LayerSuites.swift
+++ b/Benchmarks/Layers/LayerSuites.swift
@@ -15,6 +15,7 @@
 let layerSuites = Array(
   [
     DenseNetSuites,
+    EfficientNetSuites,
     LeNetSuites,
     ResNetSuites,
     ResNetV2Suites,

--- a/Benchmarks/Layers/LayerSuites.swift
+++ b/Benchmarks/Layers/LayerSuites.swift
@@ -19,6 +19,7 @@ let layerSuites = Array(
     LeNetSuites,
     MobileNetV1Suites,
     MobileNetV2Suites,
+    MobileNetV3Suites,
     ResNetSuites,
     ResNetV2Suites,
   ].joined())

--- a/Benchmarks/Layers/LayerSuites.swift
+++ b/Benchmarks/Layers/LayerSuites.swift
@@ -12,7 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-let suites = Array([
-    layerSuites,
-    modelSuites,
-].joined())
+let layerSuites = [
+  LeNetSuite,
+  ResNet50Suite,
+  ResNet56Suite,
+]

--- a/Benchmarks/Layers/LayerSuites.swift
+++ b/Benchmarks/Layers/LayerSuites.swift
@@ -16,4 +16,5 @@ let layerSuites = Array(
   [
     LeNetSuites,
     ResNetSuites,
+    ResNetV2Suites,
   ].joined())

--- a/Benchmarks/Layers/LayerSuites.swift
+++ b/Benchmarks/Layers/LayerSuites.swift
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-let layerSuites = [
-  LeNetSuite,
-  ResNet50Suite,
-  ResNet56Suite,
-]
+let layerSuites = Array(
+  [
+    LeNetSuites,
+    ResNetSuites,
+  ].joined())

--- a/Benchmarks/Layers/LayerSuites.swift
+++ b/Benchmarks/Layers/LayerSuites.swift
@@ -22,4 +22,5 @@ let layerSuites = Array(
     MobileNetV3Suites,
     ResNetSuites,
     ResNetV2Suites,
+    ShuffleNetV2Suites,
   ].joined())

--- a/Benchmarks/Layers/LayerSuites.swift
+++ b/Benchmarks/Layers/LayerSuites.swift
@@ -24,4 +24,5 @@ let layerSuites = Array(
     ResNetV2Suites,
     ShuffleNetV2Suites,
     SqueezeNetSuites,
+    WideResNetSuites,
   ].joined())

--- a/Benchmarks/Layers/LeNet.swift
+++ b/Benchmarks/Layers/LeNet.swift
@@ -17,8 +17,8 @@ import ImageClassificationModels
 let LeNetSuites = [
   makeLayerSuite(
     name: "LeNet",
-    inputDimensions: cifarInput,
-    outputDimensions: cifarOutput
+    inputDimensions: mnistInput, 
+    outputDimensions: mnistOutput
   ) {
     LeNet()
   }

--- a/Benchmarks/Layers/LeNet.swift
+++ b/Benchmarks/Layers/LeNet.swift
@@ -17,7 +17,7 @@ import ImageClassificationModels
 let LeNetSuites = [
   makeLayerSuite(
     name: "LeNet",
-    inputDimensions: mnistInput, 
+    inputDimensions: mnistInput,
     outputDimensions: mnistOutput
   ) {
     LeNet()

--- a/Benchmarks/Layers/LeNet.swift
+++ b/Benchmarks/Layers/LeNet.swift
@@ -12,7 +12,15 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-let suites = Array([
-    layerSuites,
-    modelSuites,
-].joined())
+// import Benchmark
+// import Datasets
+import ImageClassificationModels
+
+// import TensorFlow
+
+extension LeNet: DefaultInit {}
+
+let LeNetSuite = makeLayerSuite(
+  layer: LeNet.self,
+  inputDimensions: LeNet.preferredInputDimensions,
+  outputDimensions: [LeNet.outputLabels])

--- a/Benchmarks/Layers/LeNet.swift
+++ b/Benchmarks/Layers/LeNet.swift
@@ -14,13 +14,12 @@
 
 import ImageClassificationModels
 
-extension LeNet: DefaultInit {}
-
-let LeNet_28x28x1_10 = makeLayerSuite(
-  layer: LeNet.self,
-  inputDimensions: [28, 28, 1],
-  outputDimensions: [10])
-
 let LeNetSuites = [
-  LeNet_28x28x1_10
+  makeLayerSuite(
+    name: "LeNet",
+    inputDimensions: cifarInput,
+    outputDimensions: cifarOutput
+  ) {
+    LeNet()
+  }
 ]

--- a/Benchmarks/Layers/LeNet.swift
+++ b/Benchmarks/Layers/LeNet.swift
@@ -12,15 +12,15 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// import Benchmark
-// import Datasets
 import ImageClassificationModels
-
-// import TensorFlow
 
 extension LeNet: DefaultInit {}
 
-let LeNetSuite = makeLayerSuite(
+let LeNet_28x28x1_10 = makeLayerSuite(
   layer: LeNet.self,
-  inputDimensions: LeNet.preferredInputDimensions,
-  outputDimensions: [LeNet.outputLabels])
+  inputDimensions: [28, 28, 1],
+  outputDimensions: [10])
+
+let LeNetSuites = [
+  LeNet_28x28x1_10
+]

--- a/Benchmarks/Layers/MobileNetV1.swift
+++ b/Benchmarks/Layers/MobileNetV1.swift
@@ -28,5 +28,5 @@ let MobileNetV1Suites = [
     outputDimensions: imageNetOutput
   ) {
     MobileNetV1(classCount: 1000)
-  }
+  },
 ]

--- a/Benchmarks/Layers/MobileNetV1.swift
+++ b/Benchmarks/Layers/MobileNetV1.swift
@@ -12,12 +12,21 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-let layerSuites = Array(
-  [
-    DenseNetSuites,
-    EfficientNetSuites,
-    LeNetSuites,
-    MobileNetV1Suites,
-    ResNetSuites,
-    ResNetV2Suites,
-  ].joined())
+import ImageClassificationModels
+
+let MobileNetV1Suites = [
+  makeLayerSuite(
+    name: "MobileNetV1",
+    inputDimensions: cifarInput,
+    outputDimensions: cifarOutput
+  ) {
+    MobileNetV1(classCount: 10)
+  },
+  makeLayerSuite(
+    name: "MobileNetV1",
+    inputDimensions: imageNetInput,
+    outputDimensions: imageNetOutput
+  ) {
+    MobileNetV1(classCount: 1000)
+  }
+]

--- a/Benchmarks/Layers/MobileNetV2.swift
+++ b/Benchmarks/Layers/MobileNetV2.swift
@@ -12,13 +12,21 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-let layerSuites = Array(
-  [
-    DenseNetSuites,
-    EfficientNetSuites,
-    LeNetSuites,
-    MobileNetV1Suites,
-    MobileNetV2Suites,
-    ResNetSuites,
-    ResNetV2Suites,
-  ].joined())
+import ImageClassificationModels
+
+let MobileNetV2Suites = [
+  makeLayerSuite(
+    name: "MobileNetV2",
+    inputDimensions: cifarInput,
+    outputDimensions: cifarOutput
+  ) {
+    MobileNetV2(classCount: 10)
+  },
+  makeLayerSuite(
+    name: "MobileNetV2",
+    inputDimensions: imageNetInput,
+    outputDimensions: imageNetOutput
+  ) {
+    MobileNetV2(classCount: 1000)
+  }
+]

--- a/Benchmarks/Layers/MobileNetV3.swift
+++ b/Benchmarks/Layers/MobileNetV3.swift
@@ -14,19 +14,33 @@
 
 import ImageClassificationModels
 
-let MobileNetV2Suites = [
+let MobileNetV3Suites = [
   makeLayerSuite(
-    name: "MobileNetV2",
+    name: "MobileNetV3Small",
     inputDimensions: cifarInput,
     outputDimensions: cifarOutput
   ) {
-    MobileNetV2(classCount: 10)
+    MobileNetV3Small(classCount: 10)
   },
   makeLayerSuite(
-    name: "MobileNetV2",
+    name: "MobileNetV3Small",
     inputDimensions: imageNetInput,
     outputDimensions: imageNetOutput
   ) {
-    MobileNetV2(classCount: 1000)
+    MobileNetV3Small(classCount: 1000)
+  },
+  makeLayerSuite(
+    name: "MobileNetV3Large",
+    inputDimensions: cifarInput,
+    outputDimensions: cifarOutput
+  ) {
+    MobileNetV3Large(classCount: 10)
+  },
+  makeLayerSuite(
+    name: "MobileNetV3Large",
+    inputDimensions: imageNetInput,
+    outputDimensions: imageNetOutput
+  ) {
+    MobileNetV3Large(classCount: 1000)
   },
 ]

--- a/Benchmarks/Layers/MobileNetV3.swift
+++ b/Benchmarks/Layers/MobileNetV3.swift
@@ -18,28 +18,32 @@ let MobileNetV3Suites = [
   makeLayerSuite(
     name: "MobileNetV3Small",
     inputDimensions: cifarInput,
-    outputDimensions: cifarOutput
+    outputDimensions: cifarOutput,
+    backends: [.eager] // Crashes on x10.
   ) {
     MobileNetV3Small(classCount: 10)
   },
   makeLayerSuite(
     name: "MobileNetV3Small",
     inputDimensions: imageNetInput,
-    outputDimensions: imageNetOutput
+    outputDimensions: imageNetOutput,
+    backends: [.eager] // Crashes on x10.
   ) {
     MobileNetV3Small(classCount: 1000)
   },
   makeLayerSuite(
     name: "MobileNetV3Large",
     inputDimensions: cifarInput,
-    outputDimensions: cifarOutput
+    outputDimensions: cifarOutput,
+    backends: [.eager] // Crashes on x10.
   ) {
     MobileNetV3Large(classCount: 10)
   },
   makeLayerSuite(
     name: "MobileNetV3Large",
     inputDimensions: imageNetInput,
-    outputDimensions: imageNetOutput
+    outputDimensions: imageNetOutput,
+    backends: [.eager] // Crashes on x10.
   ) {
     MobileNetV3Large(classCount: 1000)
   },

--- a/Benchmarks/Layers/MobileNetV3.swift
+++ b/Benchmarks/Layers/MobileNetV3.swift
@@ -18,32 +18,28 @@ let MobileNetV3Suites = [
   makeLayerSuite(
     name: "MobileNetV3Small",
     inputDimensions: cifarInput,
-    outputDimensions: cifarOutput,
-    backends: [.eager] // Crashes on x10.
+    outputDimensions: cifarOutput
   ) {
     MobileNetV3Small(classCount: 10)
   },
   makeLayerSuite(
     name: "MobileNetV3Small",
     inputDimensions: imageNetInput,
-    outputDimensions: imageNetOutput,
-    backends: [.eager] // Crashes on x10.
+    outputDimensions: imageNetOutput
   ) {
     MobileNetV3Small(classCount: 1000)
   },
   makeLayerSuite(
     name: "MobileNetV3Large",
     inputDimensions: cifarInput,
-    outputDimensions: cifarOutput,
-    backends: [.eager] // Crashes on x10.
+    outputDimensions: cifarOutput
   ) {
     MobileNetV3Large(classCount: 10)
   },
   makeLayerSuite(
     name: "MobileNetV3Large",
     inputDimensions: imageNetInput,
-    outputDimensions: imageNetOutput,
-    backends: [.eager] // Crashes on x10.
+    outputDimensions: imageNetOutput
   ) {
     MobileNetV3Large(classCount: 1000)
   },

--- a/Benchmarks/Layers/ResNet.swift
+++ b/Benchmarks/Layers/ResNet.swift
@@ -18,12 +18,17 @@ extension ResNet50: DefaultInit {}
 
 extension ResNet56: DefaultInit {}
 
-let ResNet50Suite = makeLayerSuite(
+let ResNet50_224x224x3_1000 = makeLayerSuite(
   layer: ResNet50.self,
-  inputDimensions: ResNet50.preferredInputDimensions,
-  outputDimensions: [ResNet50.outputLabels])
+  inputDimensions: [224, 224, 3],
+  outputDimensions: [1000])
 
-let ResNet56Suite = makeLayerSuite(
+let ResNet56_32x32x3_10 = makeLayerSuite(
   layer: ResNet56.self,
-  inputDimensions: ResNet56.preferredInputDimensions,
-  outputDimensions: [ResNet56.outputLabels])
+  inputDimensions: [32, 32, 3],
+  outputDimensions: [10])
+
+let ResNetSuites = [
+  ResNet50_224x224x3_1000,
+  ResNet56_32x32x3_10,
+]

--- a/Benchmarks/Layers/ResNet.swift
+++ b/Benchmarks/Layers/ResNet.swift
@@ -14,21 +14,81 @@
 
 import ImageClassificationModels
 
-extension ResNet50: DefaultInit {}
-
-extension ResNet56: DefaultInit {}
-
-let ResNet50_224x224x3_1000 = makeLayerSuite(
-  layer: ResNet50.self,
-  inputDimensions: [224, 224, 3],
-  outputDimensions: [1000])
-
-let ResNet56_32x32x3_10 = makeLayerSuite(
-  layer: ResNet56.self,
-  inputDimensions: [32, 32, 3],
-  outputDimensions: [10])
-
 let ResNetSuites = [
-  ResNet50_224x224x3_1000,
-  ResNet56_32x32x3_10,
+  //
+  // Cifar input dimensions. 
+  //
+  makeLayerSuite(
+    name: "ResNet18",
+    inputDimensions: cifarInput,
+    outputDimensions: cifarOutput
+  ) {
+    ResNet(classCount: 10, depth: .resNet18, downsamplingInFirstStage: true)
+  },
+  makeLayerSuite(
+    name: "ResNet34",
+    inputDimensions: cifarInput,
+    outputDimensions: cifarOutput
+  ) {
+    ResNet(classCount: 10, depth: .resNet34, downsamplingInFirstStage: true)
+  },
+  makeLayerSuite(
+    name: "ResNet50",
+    inputDimensions: cifarInput,
+    outputDimensions: cifarOutput
+  ) {
+    ResNet(classCount: 10, depth: .resNet50, downsamplingInFirstStage: true, useLaterStride: false)
+  },
+  makeLayerSuite(
+    name: "ResNet101",
+    inputDimensions: cifarInput,
+    outputDimensions: cifarOutput
+  ) {
+    ResNet(classCount: 10, depth: .resNet101, downsamplingInFirstStage: true)
+  },
+  makeLayerSuite(
+    name: "ResNet152",
+    inputDimensions: cifarInput,
+    outputDimensions: cifarOutput
+  ) {
+    ResNet(classCount: 10, depth: .resNet152, downsamplingInFirstStage: true)
+  },
+  //
+  // ImageNet dimensions.
+  //
+  makeLayerSuite(
+    name: "ResNet18",
+    inputDimensions: imageNetInput,
+    outputDimensions: imageNetOutput
+  ) {
+    ResNet(classCount: 1000, depth: .resNet18)
+  },
+  makeLayerSuite(
+    name: "ResNet34",
+    inputDimensions: imageNetInput,
+    outputDimensions: imageNetOutput
+  ) {
+    ResNet(classCount: 1000, depth: .resNet34)
+  },
+  makeLayerSuite(
+    name: "ResNet50",
+    inputDimensions: imageNetInput,
+    outputDimensions: imageNetOutput
+  ) {
+    ResNet(classCount: 1000, depth: .resNet50, useLaterStride: false)
+  },
+  makeLayerSuite(
+    name: "ResNet101",
+    inputDimensions: imageNetInput,
+    outputDimensions: imageNetOutput
+  ) {
+    ResNet(classCount: 1000, depth: .resNet101)
+  },
+  makeLayerSuite(
+    name: "ResNet152",
+    inputDimensions: imageNetInput,
+    outputDimensions: imageNetOutput
+  ) {
+    ResNet(classCount: 1000, depth: .resNet152)
+  },
 ]

--- a/Benchmarks/Layers/ResNet.swift
+++ b/Benchmarks/Layers/ResNet.swift
@@ -12,7 +12,18 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-let suites = Array([
-    layerSuites,
-    modelSuites,
-].joined())
+import ImageClassificationModels
+
+extension ResNet50: DefaultInit {}
+
+extension ResNet56: DefaultInit {}
+
+let ResNet50Suite = makeLayerSuite(
+  layer: ResNet50.self,
+  inputDimensions: ResNet50.preferredInputDimensions,
+  outputDimensions: [ResNet50.outputLabels])
+
+let ResNet56Suite = makeLayerSuite(
+  layer: ResNet56.self,
+  inputDimensions: ResNet56.preferredInputDimensions,
+  outputDimensions: [ResNet56.outputLabels])

--- a/Benchmarks/Layers/ResNet.swift
+++ b/Benchmarks/Layers/ResNet.swift
@@ -40,6 +40,13 @@ let ResNetSuites = [
     ResNet(classCount: 10, depth: .resNet50, downsamplingInFirstStage: true, useLaterStride: false)
   },
   makeLayerSuite(
+    name: "ResNet56",
+    inputDimensions: cifarInput,
+    outputDimensions: cifarOutput
+  ) {
+    ResNet(classCount: 10, depth: .resNet56, downsamplingInFirstStage: true, useLaterStride: false)
+  },
+  makeLayerSuite(
     name: "ResNet101",
     inputDimensions: cifarInput,
     outputDimensions: cifarOutput
@@ -76,6 +83,13 @@ let ResNetSuites = [
     outputDimensions: imageNetOutput
   ) {
     ResNet(classCount: 1000, depth: .resNet50, useLaterStride: false)
+  },
+  makeLayerSuite(
+    name: "ResNet56",
+    inputDimensions: imageNetInput,
+    outputDimensions: imageNetOutput
+  ) {
+    ResNet(classCount: 1000, depth: .resNet56)
   },
   makeLayerSuite(
     name: "ResNet101",

--- a/Benchmarks/Layers/ResNetV2.swift
+++ b/Benchmarks/Layers/ResNetV2.swift
@@ -1,0 +1,39 @@
+import ImageClassificationModels
+
+let ResNetV2Suites = [
+  makeLayerSuite(
+    name: "ResNet18v2",
+    inputDimensions: imageNetInput,
+    outputDimensions: imageNetOutput
+  ) {
+    ResNetV2(classCount: 1000, depth: .resNet18)
+  },
+  makeLayerSuite(
+    name: "ResNet34v2",
+    inputDimensions: imageNetInput,
+    outputDimensions: imageNetOutput
+  ) {
+    ResNetV2(classCount: 1000, depth: .resNet34)
+  },
+  makeLayerSuite(
+    name: "ResNet50v2",
+    inputDimensions: imageNetInput,
+    outputDimensions: imageNetOutput
+  ) {
+    ResNetV2(classCount: 1000, depth: .resNet50)
+  },
+  makeLayerSuite(
+    name: "ResNet101v2",
+    inputDimensions: imageNetInput,
+    outputDimensions: imageNetOutput
+  ) {
+    ResNetV2(classCount: 1000, depth: .resNet101)
+  },
+  makeLayerSuite(
+    name: "ResNet152v2",
+    inputDimensions: imageNetInput,
+    outputDimensions: imageNetOutput
+  ) {
+    ResNetV2(classCount: 1000, depth: .resNet152)
+  },
+]

--- a/Benchmarks/Layers/ShuffleNetV2.swift
+++ b/Benchmarks/Layers/ShuffleNetV2.swift
@@ -1,0 +1,46 @@
+// Copyright 2019 The TensorFlow Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import ImageClassificationModels
+
+let ShuffleNetV2Suites = [
+  makeLayerSuite(
+    name: "ShuffleNetV2x05",
+    inputDimensions: imageNetInput,
+    outputDimensions: imageNetOutput
+  ) {
+    ShuffleNetV2(kind: .shuffleNetV2x05)
+  },
+  makeLayerSuite(
+    name: "ShuffleNetV2x10",
+    inputDimensions: imageNetInput,
+    outputDimensions: imageNetOutput
+  ) {
+    ShuffleNetV2(kind: .shuffleNetV2x10)
+  },
+  makeLayerSuite(
+    name: "ShuffleNetV2x15",
+    inputDimensions: imageNetInput,
+    outputDimensions: imageNetOutput
+  ) {
+    ShuffleNetV2(kind: .shuffleNetV2x15)
+  },
+  makeLayerSuite(
+    name: "ShuffleNetV2x20",
+    inputDimensions: imageNetInput,
+    outputDimensions: imageNetOutput
+  ) {
+    ShuffleNetV2(kind: .shuffleNetV2x20)
+  },
+]

--- a/Benchmarks/Layers/SqueezeNet.swift
+++ b/Benchmarks/Layers/SqueezeNet.swift
@@ -12,16 +12,21 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-let layerSuites = Array(
-  [
-    DenseNetSuites,
-    EfficientNetSuites,
-    LeNetSuites,
-    MobileNetV1Suites,
-    MobileNetV2Suites,
-    MobileNetV3Suites,
-    ResNetSuites,
-    ResNetV2Suites,
-    ShuffleNetV2Suites,
-    SqueezeNetSuites,
-  ].joined())
+import ImageClassificationModels
+
+let SqueezeNetSuites = [
+  makeLayerSuite(
+    name: "SqueezeNetV1_0",
+    inputDimensions: imageNetInput,
+    outputDimensions: imageNetOutput
+  ) {
+    SqueezeNetV1_0(classCount: 1000)
+  },
+  makeLayerSuite(
+    name: "SqueezeNetV1_1",
+    inputDimensions: imageNetInput,
+    outputDimensions: imageNetOutput
+  ) {
+    SqueezeNetV1_1(classCount: 1000)
+  },
+]

--- a/Benchmarks/Layers/VGG.swift
+++ b/Benchmarks/Layers/VGG.swift
@@ -12,18 +12,21 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-let layerSuites = Array(
-  [
-    DenseNetSuites,
-    EfficientNetSuites,
-    LeNetSuites,
-    MobileNetV1Suites,
-    MobileNetV2Suites,
-    MobileNetV3Suites,
-    ResNetSuites,
-    ResNetV2Suites,
-    ShuffleNetV2Suites,
-    SqueezeNetSuites,
-    VGGSuites,
-    WideResNetSuites,
-  ].joined())
+import ImageClassificationModels
+
+let VGGSuites = [
+  makeLayerSuite(
+    name: "VGG16",
+    inputDimensions: imageNetInput,
+    outputDimensions: imageNetOutput
+  ) {
+    VGG16(classCount: 1000)
+  },
+  makeLayerSuite(
+    name: "VGG19",
+    inputDimensions: imageNetInput,
+    outputDimensions: imageNetOutput
+  ) {
+    VGG19(classCount: 1000)
+  },
+]

--- a/Benchmarks/Layers/WideResNet.swift
+++ b/Benchmarks/Layers/WideResNet.swift
@@ -17,71 +17,71 @@ import ImageClassificationModels
 let WideResNetSuites = [
   makeLayerSuite(
     name: "WideResNet16",
-    inputDimensions: imageNetInput,
-    outputDimensions: imageNetOutput
+    inputDimensions: cifarInput,
+    outputDimensions: cifarOutput
   ) {
     WideResNet(kind: .wideResNet16)
   },
   makeLayerSuite(
     name: "WideResNet16k10",
-    inputDimensions: imageNetInput,
-    outputDimensions: imageNetOutput
+    inputDimensions: cifarInput,
+    outputDimensions: cifarOutput
   ) {
     WideResNet(kind: .wideResNet16k10)
   },
   makeLayerSuite(
     name: "WideResNet22",
-    inputDimensions: imageNetInput,
-    outputDimensions: imageNetOutput
+    inputDimensions: cifarInput,
+    outputDimensions: cifarOutput
   ) {
     WideResNet(kind: .wideResNet22)
   },
   makeLayerSuite(
     name: "WideResNet22k10",
-    inputDimensions: imageNetInput,
-    outputDimensions: imageNetOutput
+    inputDimensions: cifarInput,
+    outputDimensions: cifarOutput
   ) {
     WideResNet(kind: .wideResNet22k10)
   },
   makeLayerSuite(
     name: "WideResNet28",
-    inputDimensions: imageNetInput,
-    outputDimensions: imageNetOutput
+    inputDimensions: cifarInput,
+    outputDimensions: cifarOutput
   ) {
     WideResNet(kind: .wideResNet28)
   },
   makeLayerSuite(
     name: "WideResNet28k12",
-    inputDimensions: imageNetInput,
-    outputDimensions: imageNetOutput
+    inputDimensions: cifarInput,
+    outputDimensions: cifarOutput
   ) {
     WideResNet(kind: .wideResNet28k12)
   },
   makeLayerSuite(
     name: "WideResNet40k1",
-    inputDimensions: imageNetInput,
-    outputDimensions: imageNetOutput
+    inputDimensions: cifarInput,
+    outputDimensions: cifarOutput
   ) {
     WideResNet(kind: .wideResNet40k1)
   },
   makeLayerSuite(
     name: "WideResNet40k2",
-    inputDimensions: imageNetInput,
-    outputDimensions: imageNetOutput
+    inputDimensions: cifarInput,
+    outputDimensions: cifarOutput
   ) {
     WideResNet(kind: .wideResNet40k2)
   },
   makeLayerSuite(
     name: "WideResNet40k4",
-    inputDimensions: imageNetInput,
-    outputDimensions: imageNetOutput
+    inputDimensions: cifarInput,
+    outputDimensions: cifarOutput
   ) {
     WideResNet(kind: .wideResNet40k4)
   },
   makeLayerSuite(
     name: "WideResNet40k8",
-    inputDimensions: imageNetInput,
-    outputDimensions: imageNetOutput
+    inputDimensions: cifarInput,
+    outputDimensions: cifarOutput
   ) {
     WideResNet(kind: .wideResNet40k8)
   },

--- a/Benchmarks/Layers/WideResNet.swift
+++ b/Benchmarks/Layers/WideResNet.swift
@@ -1,0 +1,88 @@
+// Copyright 2019 The TensorFlow Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import ImageClassificationModels
+
+let WideResNetSuites = [
+  makeLayerSuite(
+    name: "WideResNet16",
+    inputDimensions: imageNetInput,
+    outputDimensions: imageNetOutput
+  ) {
+    WideResNet(kind: .wideResNet16)
+  },
+  makeLayerSuite(
+    name: "WideResNet16k10",
+    inputDimensions: imageNetInput,
+    outputDimensions: imageNetOutput
+  ) {
+    WideResNet(kind: .wideResNet16k10)
+  },
+  makeLayerSuite(
+    name: "WideResNet22",
+    inputDimensions: imageNetInput,
+    outputDimensions: imageNetOutput
+  ) {
+    WideResNet(kind: .wideResNet22)
+  },
+  makeLayerSuite(
+    name: "WideResNet22k10",
+    inputDimensions: imageNetInput,
+    outputDimensions: imageNetOutput
+  ) {
+    WideResNet(kind: .wideResNet22k10)
+  },
+  makeLayerSuite(
+    name: "WideResNet28",
+    inputDimensions: imageNetInput,
+    outputDimensions: imageNetOutput
+  ) {
+    WideResNet(kind: .wideResNet28)
+  },
+  makeLayerSuite(
+    name: "WideResNet28k12",
+    inputDimensions: imageNetInput,
+    outputDimensions: imageNetOutput
+  ) {
+    WideResNet(kind: .wideResNet28k12)
+  },
+  makeLayerSuite(
+    name: "WideResNet40k1",
+    inputDimensions: imageNetInput,
+    outputDimensions: imageNetOutput
+  ) {
+    WideResNet(kind: .wideResNet40k1)
+  },
+  makeLayerSuite(
+    name: "WideResNet40k2",
+    inputDimensions: imageNetInput,
+    outputDimensions: imageNetOutput
+  ) {
+    WideResNet(kind: .wideResNet40k2)
+  },
+  makeLayerSuite(
+    name: "WideResNet40k4",
+    inputDimensions: imageNetInput,
+    outputDimensions: imageNetOutput
+  ) {
+    WideResNet(kind: .wideResNet40k4)
+  },
+  makeLayerSuite(
+    name: "WideResNet40k8",
+    inputDimensions: imageNetInput,
+    outputDimensions: imageNetOutput
+  ) {
+    WideResNet(kind: .wideResNet40k8)
+  },
+]

--- a/Benchmarks/Models/ModelSuites.swift
+++ b/Benchmarks/Models/ModelSuites.swift
@@ -12,7 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-let suites = Array([
-    layerSuites,
-    modelSuites,
-].joined())
+let modelSuites = [
+  LeNetMNIST,
+  ResNetCIFAR10,
+  ResNetImageNet,
+  WordSegScore,
+  WordSegScoreAndGradient,
+  WordSegViterbi,
+]

--- a/Benchmarks/Suites.swift
+++ b/Benchmarks/Suites.swift
@@ -13,7 +13,10 @@
 // limitations under the License.
 
 let suites = [
+  LeNetSuite,
   LeNetMNIST,
+  ResNet50Suite,
+  ResNet56Suite,
   ResNetCIFAR10,
   ResNetImageNet,
   WordSegScore,

--- a/Benchmarks/Suites.swift
+++ b/Benchmarks/Suites.swift
@@ -12,7 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-let suites = Array([
+let suites = Array(
+  [
     layerSuites,
     modelSuites,
-].joined())
+  ].joined())


### PR DESCRIPTION
This PR builds upon upon #612 and adds infra for fine-grain benchmarks for arbitrary `Layer<Float>`:

* Performance of the forward pass
* Performance of the gradient + forward pass 

Primary objective of these benchmarks is to evaluate performance of autodiff code generation. The difference between two benchmarks is the time taken by backwards pass that we want to improve upon.

The PR includes all of our image classification models, and all of their variants on common input sizes (Mnist, Cifar, ImageNet).

I also hand-picked a common largest batch size which works for all of the image classification models in eager mode on V100. it's relatively small but it allows us to compare benchmarks at the same batch size. 
