### PR TITLE
Don't override --warmup-iterations in perfzero integration

### DIFF
--- a/Benchmarks/Models/LeNetMNIST.swift
+++ b/Benchmarks/Models/LeNetMNIST.swift
@@ -19,7 +19,7 @@ import TensorFlow
 
 let LeNetMNIST = BenchmarkSuite(
   name: "LeNetMNIST",
-  settings: BatchSize(128), WarmupIterations(1)
+  settings: BatchSize(128), WarmupIterations(2)
 ) { suite in
 
   func inference(state: inout BenchmarkState) throws {

--- a/Benchmarks/Models/ResNetCIFAR10.swift
+++ b/Benchmarks/Models/ResNetCIFAR10.swift
@@ -19,7 +19,7 @@ import TensorFlow
 
 let ResNetCIFAR10 = BenchmarkSuite(
   name: "ResNetCIFAR10",
-  settings: BatchSize(128), WarmupIterations(1), Synthetic(true)
+  settings: BatchSize(128), WarmupIterations(2), Synthetic(true)
 ) { suite in
 
   func inference(state: inout BenchmarkState) throws {

--- a/Benchmarks/Models/ResNetImageNet.swift
+++ b/Benchmarks/Models/ResNetImageNet.swift
@@ -19,7 +19,7 @@ import TensorFlow
 
 let ResNetImageNet = BenchmarkSuite(
   name: "ResNetImageNet",
-  settings: BatchSize(128), WarmupIterations(1), Synthetic(true)
+  settings: BatchSize(128), WarmupIterations(2), Synthetic(true)
 ) { suite in
 
   func inference(state: inout BenchmarkState) throws {

--- a/Benchmarks/__init__.py
+++ b/Benchmarks/__init__.py
@@ -53,10 +53,9 @@ cwd = '/workspace/benchmarks/perfzero/workspace/site-packages/swift-models'
 
 def run_swift_benchmark(name):
   print('running swift benchmark {}'.format(name))
-  # TODO: Remove the need for 2 warmup batches when we have better-shaped zero tangent vectors.
   output = subp.check_output([
       'swift', 'run', '-c', 'release', 'Benchmarks', 
-      '--filter', name, '--warmup-iterations', '2', '--format', 'json',
+      '--filter', name, '--format', 'json',
       # Run each benchmark for up to 5 minutes.
       '--min-time', '300',  
   ], cwd=cwd)


### PR DESCRIPTION
This change addresses accidental change for startup_time measurement when run within perfzero.

Instead of overriding warmup iterations in python wrapper, we rely on better per-suite defaults.