### PR TITLE
Adding modes to opened files

### DIFF
--- a/Checkpoints/CheckpointIndexReader.swift
+++ b/Checkpoints/CheckpointIndexReader.swift
@@ -45,7 +45,7 @@ class CheckpointIndexReader {
     var atEndOfFile: Bool { return index >= (binaryData.count - footerSize - 1) }
 
     init(file: URL, fileSystem: FileSystem = FoundationFileSystem()) throws {
-        let indexFile = fileSystem.open(file.path)
+        let indexFile = fileSystem.open(file.path, mode: [.read])
         let fileData = try indexFile.read()
         if fileData[0] == 0 {
             binaryData = fileData

--- a/Checkpoints/CheckpointReader.swift
+++ b/Checkpoints/CheckpointReader.swift
@@ -279,7 +279,7 @@ open class CheckpointReader {
             do {
                 // It is far too slow to read the shards in each time a tensor is accessed, so we
                 // read the entire shard into an in-memory cache on first access.
-                let shardFile = fileSystem.open(file.path)
+                let shardFile = fileSystem.open(file.path, mode: [.read])
                 let shardBytes = try shardFile.read()
                 shardCache[file] = shardBytes
                 return shardBytes

--- a/Checkpoints/CheckpointWriter.swift
+++ b/Checkpoints/CheckpointWriter.swift
@@ -50,7 +50,7 @@ open class CheckpointWriter {
         let indexWriter = CheckpointIndexWriter(tensors: tensors)
         let indexHeader = indexWriter.serializedHeader()
         let headerLocation = directory.appendingPathComponent("\(name).index")
-        let headerFile = fileSystem.open(headerLocation.path)
+        let headerFile = fileSystem.open(headerLocation.path, mode: [.write])
         try headerFile.write(indexHeader)
 
         // TODO: Handle splitting into multiple shards.
@@ -79,7 +79,7 @@ open class CheckpointWriter {
             }
         }
 
-        let outputFile = fileSystem.open(shardFile.path)
+        let outputFile = fileSystem.open(shardFile.path, mode: [.write])
         try outputFile.write(outputBuffer)
     }
 }

--- a/Support/FileSystem.swift
+++ b/Support/FileSystem.swift
@@ -25,7 +25,8 @@ public protocol FileSystem {
   ///
   /// - Parameters:
   ///   - path: The path of the file to be opened.
-  func open(_ path: String) -> File
+  ///   - mode: Options for the mode of the file.
+  func open(_ path: String, mode: Set<FileMode>) -> File
 }
 
 public protocol File {
@@ -33,4 +34,10 @@ public protocol File {
   func read(position: Int, count: Int) throws -> Data
   func write(_ value: Data) throws
   func write(_ value: Data, position: Int) throws
+}
+
+public enum FileMode {
+  case read
+  case write
+  case append
 }

--- a/Support/FoundationFileSystem.swift
+++ b/Support/FoundationFileSystem.swift
@@ -25,33 +25,52 @@ public struct FoundationFileSystem: FileSystem {
           attributes: nil)
   }
 
-  public func open(_ filename: String) -> File {
-    return FoundationFile(path: filename)
+  public func open(_ filename: String, mode: Set<FileMode>) -> File {
+    return FoundationFile(path: filename, mode: mode)
   }
 }
 
 public struct FoundationFile: File {
   public let location: URL
+  public let mode: Set<FileMode>
   
-  public init(path: String) {
+  public init(path: String, mode: Set<FileMode>) {
     self.location = URL(fileURLWithPath: path)
+    self.mode = mode
   }
   
   public func read() throws -> Data {
+    precondition(mode.contains(.read))
     return try Data(contentsOf: location, options: .alwaysMapped)
   }
   
   public func read(position: Int, count: Int) throws -> Data {
+    precondition(mode.contains(.read))
     // TODO: Incorporate file offset.
     return try Data(contentsOf: location, options: .alwaysMapped)
   }
 
   public func write(_ value: Data) throws {
-    try self.write(value, position: 0)
+    precondition(mode.contains(.write))
+    if mode.contains(.append) {
+      guard let handle = FileHandle(forWritingAtPath: location.path) else {
+        throw FoundationFileError.fileNotWriteable(path: location.path)
+      }
+      handle.seekToEndOfFile()
+      handle.write(value)
+      handle.closeFile()
+    } else {
+      try self.write(value, position: 0)
+    }
   }
 
   public func write(_ value: Data, position: Int) throws {
+    precondition(mode.contains(.write))
     // TODO: Incorporate file offset.
     try value.write(to: location)
   }
+}
+
+public enum FoundationFileError: Error {
+  case fileNotWriteable(path: String)
 }


### PR DESCRIPTION
To support file systems that need to know the mode of a file upon opening it, this adds an initial three options for opening a file: `.read`, `.write`, and `.append`. Combinations of these can represent read-only, write-only, read-write, and appending-write files.