### PR TITLE
reset accuracy statistics each epoch and between training and validation

### DIFF
--- a/TrainingLoop/TrainingStatistics.swift
+++ b/TrainingLoop/TrainingStatistics.swift
@@ -66,6 +66,8 @@ public class TrainingStatistics {
     case .trainingStart, .validationStart:
       totalBatchLoss = nil
       totalBatches = nil
+      totalCorrect = nil
+      totalExamples = nil
     case .batchEnd:
       if metrics.contains(.accuracy) {
         measureAccuracy(loop)


### PR DESCRIPTION
Currently I think accuracy is averaged across all epochs and across training and inference runs.  Reseting accuracy statistics to `nil` at the start of training and validation makes them per epoch and resets the totals between training and inference.  This mimics how average loss works.

Some MNIST results below show how prior to this change the accuracy is low for all epochs because of averaging across epochs.  It also shows that the training and validation accuracy before change are always similar because the average is across both.  After this change initial validation accuracy is higher but eventually the model overfits and validation accuracy is below training accuracy.  

Output from `swift run -c release LeNet-MNIST` after these changes:

    Epoch 1/12
    468/468 [==============================] - loss: 0.5188 - accuracy: 0.8371
    79/79 [==============================] - loss: 0.2192 - accuracy: 0.9282
    Epoch 2/12
    468/468 [==============================] - loss: 0.1190 - accuracy: 0.9633
    79/79 [==============================] - loss: 0.0755 - accuracy: 0.9752
    Epoch 3/12
    468/468 [==============================] - loss: 0.0825 - accuracy: 0.9743
    79/79 [==============================] - loss: 0.0590 - accuracy: 0.9799
    Epoch 4/12
    468/468 [==============================] - loss: 0.0668 - accuracy: 0.9792
    79/79 [==============================] - loss: 0.0594 - accuracy: 0.9813
    Epoch 5/12
    468/468 [==============================] - loss: 0.0543 - accuracy: 0.9829
    79/79 [==============================] - loss: 0.0481 - accuracy: 0.9843
    Epoch 6/12
    468/468 [==============================] - loss: 0.0471 - accuracy: 0.9855
    79/79 [==============================] - loss: 0.0431 - accuracy: 0.9845
    Epoch 7/12
    468/468 [==============================] - loss: 0.0415 - accuracy: 0.9869
    79/79 [==============================] - loss: 0.0438 - accuracy: 0.9836
    Epoch 8/12
    468/468 [==============================] - loss: 0.0362 - accuracy: 0.9886
    79/79 [==============================] - loss: 0.0394 - accuracy: 0.9859
    Epoch 9/12
    468/468 [==============================] - loss: 0.0320 - accuracy: 0.9897
    79/79 [==============================] - loss: 0.0375 - accuracy: 0.9876
    Epoch 10/12
    468/468 [==============================] - loss: 0.0291 - accuracy: 0.9908
    79/79 [==============================] - loss: 0.0399 - accuracy: 0.9865
    Epoch 11/12
    468/468 [==============================] - loss: 0.0255 - accuracy: 0.9919
    79/79 [==============================] - loss: 0.0377 - accuracy: 0.9877
    Epoch 12/12
    468/468 [==============================] - loss: 0.0236 - accuracy: 0.9922
    79/79 [==============================] - loss: 0.0418 - accuracy: 0.9863

Output from `swift run -c release LeNet-MNIST` before these changes:

    Epoch 1/12
    468/468 [==============================] - loss: 0.4605 - accuracy: 0.8548
    79/79 [==============================] - loss: 0.1306 - accuracy: 0.8694
    Epoch 2/12
    468/468 [==============================] - loss: 0.1166 - accuracy: 0.9133
    79/79 [==============================] - loss: 0.0823 - accuracy: 0.9176
    Epoch 3/12
    468/468 [==============================] - loss: 0.0828 - accuracy: 0.9346
    79/79 [==============================] - loss: 0.0644 - accuracy: 0.9367
    Epoch 4/12
    468/468 [==============================] - loss: 0.0675 - accuracy: 0.9461
    79/79 [==============================] - loss: 0.0595 - accuracy: 0.9474
    Epoch 5/12
    468/468 [==============================] - loss: 0.0554 - accuracy: 0.9536
    79/79 [==============================] - loss: 0.0514 - accuracy: 0.9544
    Epoch 6/12
    468/468 [==============================] - loss: 0.0486 - accuracy: 0.9589
    79/79 [==============================] - loss: 0.0624 - accuracy: 0.9595
    Epoch 7/12
    468/468 [==============================] - loss: 0.0424 - accuracy: 0.9628
    79/79 [==============================] - loss: 0.0460 - accuracy: 0.9633
    Epoch 8/12
    468/468 [==============================] - loss: 0.0369 - accuracy: 0.9661
    79/79 [==============================] - loss: 0.0396 - accuracy: 0.9664
    Epoch 9/12
    468/468 [==============================] - loss: 0.0331 - accuracy: 0.9687
    79/79 [==============================] - loss: 0.0492 - accuracy: 0.9689
    Epoch 10/12
    468/468 [==============================] - loss: 0.0302 - accuracy: 0.9708
    79/79 [==============================] - loss: 0.0418 - accuracy: 0.9710
    Epoch 11/12
    468/468 [==============================] - loss: 0.0275 - accuracy: 0.9726
    79/79 [==============================] - loss: 0.0352 - accuracy: 0.9728
    Epoch 12/12
    468/468 [==============================] - loss: 0.0240 - accuracy: 0.9742
    79/79 [==============================] - loss: 0.0402 - accuracy: 0.9744