### PR TITLE
Add `datasetFilePath` argument for benchmarks

### DIFF
--- a/BenchmarksCore/BenchmarkArguments.swift
+++ b/BenchmarksCore/BenchmarkArguments.swift
@@ -34,16 +34,20 @@ public struct BenchmarkArguments: ParsableArguments {
   @Flag(help: "Use real data.")
   var real: Bool
 
+  @Option(name: .customLong("datasetFilePath"), help: "File path for dataset loading.")
+  var datasetFilePath: String?
+
   public init() {}
 
   public init(arguments: Benchmark.BenchmarkArguments, batchSize: Int?, eager: Bool, x10: Bool,
-              synthetic: Bool, real: Bool) {
+              synthetic: Bool, real: Bool, datasetFilePath: String?) {
     self.arguments = arguments
     self.batchSize = batchSize
     self.eager = eager
     self.x10 = x10
     self.synthetic = synthetic
     self.real = real
+    self.datasetFilePath = datasetFilePath
   }
 
   public mutating func validate() throws {
@@ -77,6 +81,9 @@ public struct BenchmarkArguments: ParsableArguments {
     }
     if real {
       settings.append(Synthetic(false))
+    }
+    if let value = datasetFilePath {
+      settings.append(DatasetFilePath(value))
     }
 
     return settings

--- a/BenchmarksCore/BenchmarkSettings.swift
+++ b/BenchmarksCore/BenchmarkSettings.swift
@@ -47,6 +47,13 @@ public struct Backend: BenchmarkSetting {
   }
 }
 
+public struct DatasetFilePath: BenchmarkSetting {
+  var value: String
+  init(_ value: String) {
+    self.value = value
+  }
+}
+
 public extension BenchmarkSettings {
   var batchSize: Int? {
     return self[BatchSize.self]?.value
@@ -82,6 +89,10 @@ public extension BenchmarkSettings {
     case .eager: return Device.defaultTFEager
     case .x10: return Device.defaultXLA
     }
+  }
+
+  var datasetFilePath: String? {
+    return self[DatasetFilePath.self]?.value
   }
 }
 

--- a/BenchmarksCore/Models/WordSeg.swift
+++ b/BenchmarksCore/Models/WordSeg.swift
@@ -71,7 +71,13 @@ func wordSegBenchmark(_ operation: @escaping (SNLM, CharacterSequence, Device) -
 
     state.start()
 
-    let dataset = try WordSegDataset()
+    let dataset: WordSegDataset
+    if let trainingFilePath = settings.datasetFilePath {
+      dataset = try WordSegDataset(training: trainingFilePath)
+    } else {
+      dataset = try WordSegDataset()
+    }
+
     let sentence = try testSentence(
       length: length,
       alphabet: dataset.alphabet)


### PR DESCRIPTION
Adds `datasetFilePath` argument and passes the value to WordSeg benchmarks. This is useful for specifying file locations other than the default download location.