### PR TITLE
Bump swift-argument-parser to 0.2.0

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -24,7 +24,7 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/apple/swift-protobuf.git", from: "1.10.0"),
-        .package(url: "https://github.com/apple/swift-argument-parser", .upToNextMinor(from: "0.0.1")),
+        .package(url: "https://github.com/apple/swift-argument-parser", .upToNextMinor(from: "0.2.0")),
         .package(url: "https://github.com/google/swift-benchmark", .branch("master")),
     ],
     targets: [


### PR DESCRIPTION
Since 0.2.0 contains some incompatibilities, let's update sooner rather than later.

This matches swift-benchmark's [recent update](https://github.com/google/swift-benchmark/pull/65).