### PR TITLE
Pin swift-benchmark to a specific revision.

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -25,7 +25,7 @@ let package = Package(
     dependencies: [
         .package(url: "https://github.com/apple/swift-protobuf.git", from: "1.10.0"),
         .package(url: "https://github.com/apple/swift-argument-parser", .upToNextMinor(from: "0.2.0")),
-        .package(url: "https://github.com/google/swift-benchmark", .branch("master")),
+        .package(url: "https://github.com/google/swift-benchmark", .revision("f70bf472b00aeaa05e2374373568c2fe459c11c7")),
     ],
     targets: [
         .target(name: "Batcher", path: "Batcher"),


### PR DESCRIPTION
Swift-Benchmark currently has an unstable API. This change pins
Swift-Benchmark to an explicit revision to ensure stable builds.