### PR TITLE
Remove camelCase override

### DIFF
--- a/BenchmarksCore/BenchmarkArguments.swift
+++ b/BenchmarksCore/BenchmarkArguments.swift
@@ -19,7 +19,7 @@ public struct BenchmarkArguments: ParsableArguments {
   @OptionGroup()
   var arguments: Benchmark.BenchmarkArguments
 
-  @Option(name: .customLong("batchSize"), help: "Size of a single batch.")
+  @Option(help: "Size of a single batch.")
   var batchSize: Int?
 
   @Flag(help: "Use eager backend.")
@@ -34,7 +34,7 @@ public struct BenchmarkArguments: ParsableArguments {
   @Flag(help: "Use real data.")
   var real: Bool
 
-  @Option(name: .customLong("datasetFilePath"), help: "File path for dataset loading.")
+  @Option(help: "File path for dataset loading.")
   var datasetFilePath: String?
 
   public init() {}


### PR DESCRIPTION
Fixes #636 

Removes camelCase overrides for benchmark arguments, using the [swift-argument-parser](https://github.com/apple/swift-argument-parser) default provided by [swift-benchmark](https://github.com/google/swift-benchmark). This changes the `batchSize` argument to `batch-size` and `datasetFilePath` to `dataset-file-path`.