### PR TITLE
Add support for electra

### DIFF
--- a/Examples/BERT-CoLA/main.swift
+++ b/Examples/BERT-CoLA/main.swift
@@ -27,6 +27,8 @@ if CommandLine.arguments.count >= 2 {
         bertPretrained = BERT.PreTrainedModel.albertBase
     } else if CommandLine.arguments[1].lowercased() == "roberta" {
         bertPretrained = BERT.PreTrainedModel.robertaBase
+    } else if CommandLine.arguments[1].lowercased() == "electra" {
+        bertPretrained = BERT.PreTrainedModel.electraBase
     } else {
         bertPretrained = BERT.PreTrainedModel.bertBase(cased: false, multilingual: false)
     }

--- a/Models/Text/BERT.swift
+++ b/Models/Text/BERT.swift
@@ -550,6 +550,7 @@ extension BERT {
             let bertPrefix = "https://storage.googleapis.com/bert_models/2018_"
             let robertaPrefix = "https://storage.googleapis.com/s4tf-hosted-binaries/checkpoints/Text/RoBERTa"
             let albertPrefix = "https://storage.googleapis.com/tfhub-modules/google/albert"
+            let electraPrefix = "https://storage.googleapis.com/electra-data/electra_"
             switch self {
             case .bertBase(false, false):
                 return URL(string: "\(bertPrefix)10_18/\(subDirectory).zip")!
@@ -574,9 +575,9 @@ extension BERT {
             case .albertBase, .albertLarge, .albertXLarge, .albertXXLarge:
                 return URL(string: "\(albertPrefix)_\(subDirectory)/1.tar.gz")!
             case .electraBase:
-                return URL(string: "\(electraPrefix)base.zip")
+                return URL(string: "\(electraPrefix)base.zip")!
             case .electraLarge:
-                return URL(string: "\(electraPrefix)large.zip")
+                return URL(string: "\(electraPrefix)large.zip")!
             }
         }
 
@@ -790,22 +791,22 @@ extension BERT {
         switch variant {
         case .bert, .albert, .roberta:    
             tokenEmbedding.embeddings =
-                Tensor(checkpointReader.loadTensor(named: "bert/embeddings/word_embeddings"))
+                reader.readTensor(name: "bert/embeddings/word_embeddings")
             positionEmbedding.embeddings =
-                Tensor(checkpointReader.loadTensor(named: "bert/embeddings/position_embeddings"))
+                reader.readTensor(name: "bert/embeddings/position_embeddings")
             embeddingLayerNorm.offset =
-                Tensor(checkpointReader.loadTensor(named: "bert/embeddings/LayerNorm/beta"))
+                reader.readTensor(name: "bert/embeddings/LayerNorm/beta")
             embeddingLayerNorm.scale =
-                Tensor(checkpointReader.loadTensor(named: "bert/embeddings/LayerNorm/gamma"))
+                reader.readTensor(name: "bert/embeddings/LayerNorm/gamma")
         case .electra:
             tokenEmbedding.embeddings =
-                Tensor(checkpointReader.loadTensor(named: "electra/embeddings/word_embeddings"))
+                reader.readTensor(name: "electra/embeddings/word_embeddings")
             positionEmbedding.embeddings =
-                Tensor(checkpointReader.loadTensor(named: "electra/embeddings/position_embeddings"))
+                reader.readTensor(name: "electra/embeddings/position_embeddings")
             embeddingLayerNorm.offset =
-                Tensor(checkpointReader.loadTensor(named: "electra/embeddings/LayerNorm/beta"))
+                reader.readTensor(name: "electra/embeddings/LayerNorm/beta")
             embeddingLayerNorm.scale =
-                Tensor(checkpointReader.loadTensor(named: "electra/embeddings/LayerNorm/gamma"))
+                reader.readTensor(name: "electra/embeddings/LayerNorm/gamma")
         }
         switch variant {
         case .bert, .albert:
@@ -814,7 +815,7 @@ extension BERT {
         case .roberta: ()
         case .electra:
             tokenTypeEmbedding.embeddings =
-                Tensor(checkpointReader.loadTensor(named: "electra/embeddings/token_type_embeddings"))    
+                reader.readTensor(name: "electra/embeddings/token_type_embeddings")    
         }
         switch variant {
         case .bert, .roberta:
@@ -835,37 +836,37 @@ extension BERT {
             for layerIndex in encoderLayers.indices {
                 let prefix = "electra/encoder/layer_\(layerIndex)"
                 encoderLayers[layerIndex].multiHeadAttention.queryWeight =
-                    Tensor(checkpointReader.loadTensor(named: "\(prefix)/attention/self/query/kernel"))
+                    reader.readTensor(name:  "\(prefix)/attention/self/query/kernel")
                 encoderLayers[layerIndex].multiHeadAttention.queryBias =
-                    Tensor(checkpointReader.loadTensor(named: "\(prefix)/attention/self/query/bias"))
+                    reader.readTensor(name:  "\(prefix)/attention/self/query/bias")
                 encoderLayers[layerIndex].multiHeadAttention.keyWeight =
-                    Tensor(checkpointReader.loadTensor(named: "\(prefix)/attention/self/key/kernel"))
+                    reader.readTensor(name:  "\(prefix)/attention/self/key/kernel")
                 encoderLayers[layerIndex].multiHeadAttention.keyBias =
-                    Tensor(checkpointReader.loadTensor(named: "\(prefix)/attention/self/key/bias"))
+                    reader.readTensor(name:  "\(prefix)/attention/self/key/bias")
                 encoderLayers[layerIndex].multiHeadAttention.valueWeight =
-                    Tensor(checkpointReader.loadTensor(named: "\(prefix)/attention/self/value/kernel"))
+                    reader.readTensor(name:  "\(prefix)/attention/self/value/kernel")
                 encoderLayers[layerIndex].multiHeadAttention.valueBias =
-                    Tensor(checkpointReader.loadTensor(named: "\(prefix)/attention/self/value/bias"))
+                    reader.readTensor(name:  "\(prefix)/attention/self/value/bias")
                 encoderLayers[layerIndex].attentionWeight =
-                    Tensor(checkpointReader.loadTensor(named: "\(prefix)/attention/output/dense/kernel"))
+                    reader.readTensor(name:  "\(prefix)/attention/output/dense/kernel")
                 encoderLayers[layerIndex].attentionBias =
-                    Tensor(checkpointReader.loadTensor(named: "\(prefix)/attention/output/dense/bias"))
+                    reader.readTensor(name:  "\(prefix)/attention/output/dense/bias")
                 encoderLayers[layerIndex].attentionLayerNorm.offset =
-                    Tensor(checkpointReader.loadTensor(named: "\(prefix)/attention/output/LayerNorm/beta"))
+                    reader.readTensor(name:  "\(prefix)/attention/output/LayerNorm/beta")
                 encoderLayers[layerIndex].attentionLayerNorm.scale =
-                    Tensor(checkpointReader.loadTensor(named: "\(prefix)/attention/output/LayerNorm/gamma"))
+                    reader.readTensor(name:  "\(prefix)/attention/output/LayerNorm/gamma")
                 encoderLayers[layerIndex].intermediateWeight =
-                    Tensor(checkpointReader.loadTensor(named: "\(prefix)/intermediate/dense/kernel"))
+                    reader.readTensor(name:  "\(prefix)/intermediate/dense/kernel")
                 encoderLayers[layerIndex].intermediateBias =
-                    Tensor(checkpointReader.loadTensor(named: "\(prefix)/intermediate/dense/bias"))
+                    reader.readTensor(name:  "\(prefix)/intermediate/dense/bias")
                 encoderLayers[layerIndex].outputWeight =
-                    Tensor(checkpointReader.loadTensor(named: "\(prefix)/output/dense/kernel"))
+                    reader.readTensor(name:  "\(prefix)/output/dense/kernel")
                 encoderLayers[layerIndex].outputBias =
-                    Tensor(checkpointReader.loadTensor(named: "\(prefix)/output/dense/bias"))
+                    reader.readTensor(name:  "\(prefix)/output/dense/bias")
                 encoderLayers[layerIndex].outputLayerNorm.offset =
-                    Tensor(checkpointReader.loadTensor(named: "\(prefix)/output/LayerNorm/beta"))
+                    reader.readTensor(name:  "\(prefix)/output/LayerNorm/beta")
                 encoderLayers[layerIndex].outputLayerNorm.scale =
-                    Tensor(checkpointReader.loadTensor(named: "\(prefix)/output/LayerNorm/gamma"))
+                    reader.readTensor(name:  "\(prefix)/output/LayerNorm/gamma")
             }
         }
     }

--- a/Models/Text/BERT.swift
+++ b/Models/Text/BERT.swift
@@ -58,6 +58,8 @@ extension Embedding: Regularizable {
 ///       https://arxiv.org/pdf/1907.11692.pdf).
 ///   - [ALBERT: A Lite BERT for Self-Supervised Learning of Language Representations](
 ///       https://arxiv.org/pdf/1909.11942.pdf).
+/// -   [ELECTRA: Pre-training Text Encoders as Discriminators Rather Than Generators](
+///       https://arxiv.org/abs/2003.10555.pdf)
 public struct BERT: Module, Regularizable {
     // TODO: Convert to a generic constraint once TF-427 is resolved.
     public typealias Scalar = Float
@@ -153,7 +155,7 @@ public struct BERT: Module, Regularizable {
 
         let embeddingSize: Int = {
             switch variant {
-            case .bert, .roberta: return hiddenSize
+            case .bert, .roberta, .electra: return hiddenSize
             case let .albert(embeddingSize, _): return embeddingSize
             }
         }()
@@ -180,7 +182,7 @@ public struct BERT: Module, Regularizable {
         // [0, 1, 2, ..., sequenceLength - 1], so we can just perform a slice.
         let positionPaddingIndex = { () -> Int in
             switch variant {
-            case .bert, .albert: return 0
+            case .bert, .albert, .electra: return 0
             case .roberta: return 2
             }
         }()
@@ -199,7 +201,7 @@ public struct BERT: Module, Regularizable {
         // Add an embedding projection layer if using the ALBERT variant.
         self.embeddingProjection = {
             switch variant {
-            case .bert, .roberta: return []
+            case .bert, .roberta, .electra: return []
             case let .albert(embeddingSize, _):
                 // TODO: [AD] Change to optional once supported.
                 return [Dense<Scalar>(
@@ -211,7 +213,7 @@ public struct BERT: Module, Regularizable {
         }()
 
         switch variant {
-        case .bert, .roberta:
+        case .bert, .roberta, .electra:
         self.encoderLayers = (0..<hiddenLayerCount).map { _ in
             TransformerEncoderLayer(
                 hiddenSize: hiddenSize,
@@ -264,7 +266,7 @@ public struct BERT: Module, Regularizable {
         var totalLength = sequences.map { $0.count }.reduce(0, +)
         let totalLengthLimit = { () -> Int in
             switch variant {
-            case .bert, .albert: return maxSequenceLength - 1 - sequences.count
+            case .bert, .albert, .electra: return maxSequenceLength - 1 - sequences.count
             case .roberta: return maxSequenceLength - 1 - 2 * sequences.count
             }
         }()
@@ -327,7 +329,7 @@ public struct BERT: Module, Regularizable {
         let tokenTypeEmbeddings = tokenTypeEmbedding(input.tokenTypeIds)
         let positionPaddingIndex: Int
         switch variant {
-        case .bert, .albert: positionPaddingIndex = 0
+        case .bert, .albert, .electra: positionPaddingIndex = 0
         case .roberta: positionPaddingIndex = 2
         }
         let positionEmbeddings = positionEmbedding.embeddings.slice(
@@ -338,7 +340,7 @@ public struct BERT: Module, Regularizable {
 
         // Add token type embeddings if needed, based on which BERT variant is being used.
         switch variant {
-        case .bert, .albert: embeddings = embeddings + tokenTypeEmbeddings
+        case .bert, .albert, .electra: embeddings = embeddings + tokenTypeEmbeddings
         case .roberta: break
         }
 
@@ -361,7 +363,7 @@ public struct BERT: Module, Regularizable {
 
         // Run the stacked transformer.
         switch variant {
-        case .bert, .roberta:
+        case .bert, .roberta, .electra:
             for layerIndex in 0..<(withoutDerivative(at: encoderLayers) { $0.count }) {
                 transformerInput = encoderLayers[layerIndex](TransformerInput(
                 sequence: transformerInput,
@@ -398,6 +400,10 @@ extension BERT {
         ///             https://arxiv.org/pdf/1909.11942.pdf).
         case albert(embeddingSize: Int, hiddenGroupCount: Int)
 
+        /// - Source: [ELECTRA: Pre-training Text Encoders as Discriminators Rather Than Generators]
+        ///              https://arxiv.org/abs/2003.10555
+        case electra
+
         public var description: String {
             switch self {
             case .bert:
@@ -406,6 +412,8 @@ extension BERT {
                 return "roberta"
             case let .albert(embeddingSize, hiddenGroupCount):
                 return "albert-E-\(embeddingSize)-G-\(hiddenGroupCount)"
+            case .electra:
+                return "electra"
             }
         }
     }
@@ -512,6 +520,8 @@ extension BERT {
         case albertLarge
         case albertXLarge
         case albertXXLarge
+        case electraBase
+        case electraLarge
 
         /// The name of this pre-trained model.
         public var name: String {
@@ -530,6 +540,8 @@ extension BERT {
             case .albertLarge: return "ALBERT Large"
             case .albertXLarge: return "ALBERT xLarge"
             case .albertXXLarge: return "ALBERT xxLarge"
+            case .electraBase: return "ELECTRA Base"
+            case .electraLarge: return "ELECTRA Large"
             }
         }
 
@@ -561,6 +573,10 @@ extension BERT {
                 return URL(string: "\(robertaPrefix)/large.zip")!
             case .albertBase, .albertLarge, .albertXLarge, .albertXXLarge:
                 return URL(string: "\(albertPrefix)_\(subDirectory)/1.tar.gz")!
+            case .electraBase:
+                return URL(string: "\(electraPrefix)base.zip")
+            case .electraLarge:
+                return URL(string: "\(electraPrefix)large.zip")
             }
         }
 
@@ -572,6 +588,8 @@ extension BERT {
                 return .roberta
             case .albertBase, .albertLarge, .albertXLarge, .albertXXLarge:
                 return .albert(embeddingSize: 128, hiddenGroupCount: 1)
+            case .electraBase, .electraLarge:
+                return .electra
             }
         }
 
@@ -581,6 +599,7 @@ extension BERT {
             case let .bertLarge(cased, _): return cased
             case .robertaBase, .robertaLarge: return true
             case .albertBase, .albertLarge, .albertXLarge, .albertXXLarge: return false
+            case .electraBase, .electraLarge: return false
             }
         }
 
@@ -594,6 +613,8 @@ extension BERT {
             case .albertLarge: return 1024
             case .albertXLarge: return 2048
             case .albertXXLarge: return 4096
+            case .electraBase: return 768
+            case .electraLarge: return 1024
             }
         }
 
@@ -607,6 +628,8 @@ extension BERT {
             case .albertLarge: return 24
             case .albertXLarge: return 24
             case .albertXXLarge: return 12
+            case .electraBase: return 12
+            case .electraLarge: return 24
             }
         }
 
@@ -620,6 +643,8 @@ extension BERT {
             case .albertLarge: return 16
             case .albertXLarge: return 16
             case .albertXXLarge: return 64
+            case .electraBase: return 12
+            case .electraLarge: return 16
             }
         }
 
@@ -633,6 +658,8 @@ extension BERT {
             case .albertLarge: return 4096
             case .albertXLarge: return 8192
             case .albertXXLarge: return 16384
+            case .electraBase: return 3072
+            case .electraLarge: return 4096
             }
         }
 
@@ -653,6 +680,8 @@ extension BERT {
             case .albertLarge: return "large"
             case .albertXLarge: return "xLarge"
             case .albertXXLarge: return "xxLarge"
+            case .electraBase: return "electra_base"
+            case .electraLarge: return "electra_large"
             }
         }
 
@@ -675,7 +704,7 @@ extension BERT {
             // Load the appropriate vocabulary file.
             let vocabulary: Vocabulary = {
                 switch self {
-                case .bertBase, .bertLarge:
+                case .bertBase, .bertLarge, .electraBase, .electraLarge:
                     let vocabularyURL = storage.appendingPathComponent("vocab.txt")
                     return try! Vocabulary(fromFile: vocabularyURL)
                 case .robertaBase, .robertaLarge:
@@ -696,7 +725,8 @@ extension BERT {
             // Create the tokenizer and load any necessary files.
             let tokenizer: Tokenizer = try {
                 switch self {
-                case .bertBase, .bertLarge, .albertBase, .albertLarge, .albertXLarge, .albertXXLarge:
+                case .bertBase, .bertLarge, .albertBase, .albertLarge, .albertXLarge, .albertXXLarge,
+                .electraBase, .electraLarge:
                     return BERTTokenizer(
                         vocabulary: vocabulary,
                         caseSensitive: caseSensitive,
@@ -757,15 +787,34 @@ extension BERT {
     /// - Parameters:
     ///   - reader: CheckpointReader object to load tensors from.
     public mutating func loadTensors(_ reader: CheckpointReader) {
-        tokenEmbedding.embeddings = reader.readTensor(name: "bert/embeddings/word_embeddings")
-        positionEmbedding.embeddings = reader.readTensor(name: "bert/embeddings/position_embeddings")
-        embeddingLayerNorm.offset = reader.readTensor(name: "bert/embeddings/LayerNorm/beta")
-        embeddingLayerNorm.scale = reader.readTensor(name: "bert/embeddings/LayerNorm/gamma")
+        switch variant {
+        case .bert, .albert, .roberta:    
+            tokenEmbedding.embeddings =
+                Tensor(checkpointReader.loadTensor(named: "bert/embeddings/word_embeddings"))
+            positionEmbedding.embeddings =
+                Tensor(checkpointReader.loadTensor(named: "bert/embeddings/position_embeddings"))
+            embeddingLayerNorm.offset =
+                Tensor(checkpointReader.loadTensor(named: "bert/embeddings/LayerNorm/beta"))
+            embeddingLayerNorm.scale =
+                Tensor(checkpointReader.loadTensor(named: "bert/embeddings/LayerNorm/gamma"))
+        case .electra:
+            tokenEmbedding.embeddings =
+                Tensor(checkpointReader.loadTensor(named: "electra/embeddings/word_embeddings"))
+            positionEmbedding.embeddings =
+                Tensor(checkpointReader.loadTensor(named: "electra/embeddings/position_embeddings"))
+            embeddingLayerNorm.offset =
+                Tensor(checkpointReader.loadTensor(named: "electra/embeddings/LayerNorm/beta"))
+            embeddingLayerNorm.scale =
+                Tensor(checkpointReader.loadTensor(named: "electra/embeddings/LayerNorm/gamma"))
+        }
         switch variant {
         case .bert, .albert:
             tokenTypeEmbedding.embeddings =
                 reader.readTensor(name: "bert/embeddings/token_type_embeddings")
         case .roberta: ()
+        case .electra:
+            tokenTypeEmbedding.embeddings =
+                Tensor(checkpointReader.loadTensor(named: "electra/embeddings/token_type_embeddings"))    
         }
         switch variant {
         case .bert, .roberta:
@@ -781,6 +830,42 @@ extension BERT {
             for layerIndex in encoderLayers.indices {
                 let prefix = "bert/encoder/transformer/group_\(layerIndex)/inner_group_0"
                 encoderLayers[layerIndex].load(albert: reader, prefix: prefix)
+            }
+        case .electra:
+            for layerIndex in encoderLayers.indices {
+                let prefix = "electra/encoder/layer_\(layerIndex)"
+                encoderLayers[layerIndex].multiHeadAttention.queryWeight =
+                    Tensor(checkpointReader.loadTensor(named: "\(prefix)/attention/self/query/kernel"))
+                encoderLayers[layerIndex].multiHeadAttention.queryBias =
+                    Tensor(checkpointReader.loadTensor(named: "\(prefix)/attention/self/query/bias"))
+                encoderLayers[layerIndex].multiHeadAttention.keyWeight =
+                    Tensor(checkpointReader.loadTensor(named: "\(prefix)/attention/self/key/kernel"))
+                encoderLayers[layerIndex].multiHeadAttention.keyBias =
+                    Tensor(checkpointReader.loadTensor(named: "\(prefix)/attention/self/key/bias"))
+                encoderLayers[layerIndex].multiHeadAttention.valueWeight =
+                    Tensor(checkpointReader.loadTensor(named: "\(prefix)/attention/self/value/kernel"))
+                encoderLayers[layerIndex].multiHeadAttention.valueBias =
+                    Tensor(checkpointReader.loadTensor(named: "\(prefix)/attention/self/value/bias"))
+                encoderLayers[layerIndex].attentionWeight =
+                    Tensor(checkpointReader.loadTensor(named: "\(prefix)/attention/output/dense/kernel"))
+                encoderLayers[layerIndex].attentionBias =
+                    Tensor(checkpointReader.loadTensor(named: "\(prefix)/attention/output/dense/bias"))
+                encoderLayers[layerIndex].attentionLayerNorm.offset =
+                    Tensor(checkpointReader.loadTensor(named: "\(prefix)/attention/output/LayerNorm/beta"))
+                encoderLayers[layerIndex].attentionLayerNorm.scale =
+                    Tensor(checkpointReader.loadTensor(named: "\(prefix)/attention/output/LayerNorm/gamma"))
+                encoderLayers[layerIndex].intermediateWeight =
+                    Tensor(checkpointReader.loadTensor(named: "\(prefix)/intermediate/dense/kernel"))
+                encoderLayers[layerIndex].intermediateBias =
+                    Tensor(checkpointReader.loadTensor(named: "\(prefix)/intermediate/dense/bias"))
+                encoderLayers[layerIndex].outputWeight =
+                    Tensor(checkpointReader.loadTensor(named: "\(prefix)/output/dense/kernel"))
+                encoderLayers[layerIndex].outputBias =
+                    Tensor(checkpointReader.loadTensor(named: "\(prefix)/output/dense/bias"))
+                encoderLayers[layerIndex].outputLayerNorm.offset =
+                    Tensor(checkpointReader.loadTensor(named: "\(prefix)/output/LayerNorm/beta"))
+                encoderLayers[layerIndex].outputLayerNorm.scale =
+                    Tensor(checkpointReader.loadTensor(named: "\(prefix)/output/LayerNorm/gamma"))
             }
         }
     }


### PR DESCRIPTION
Clone #534 

The build issues have been fixed.

The `electra-small` model is not supported due to a different hidden size than the formula permits, I mentioned this issue in #534 as well.

> Although the hidden_size = embedding_size generally for Electra, but in the case of electra_small, the embedding size is 128 while the hidden size is 256, any idea how I could solve in that particular case?

Other than that, build passes.