### PR TITLE
Shift x10 transformations from the BERT-CoLA example into the CoLA dataset

### DIFF
--- a/Datasets/CoLA/CoLA.swift
+++ b/Datasets/CoLA/CoLA.swift
@@ -114,7 +114,7 @@ extension CoLA {
     maxSequenceLength: Int,
     batchSize: Int,
     entropy: Entropy,
-    on: Device,
+    on device: Device,
     exampleMap: @escaping (CoLAExample) -> LabeledTextBatch
   ) throws {
     self.directoryURL = taskDirectoryURL.appendingPathComponent("CoLA")
@@ -159,8 +159,8 @@ extension CoLA {
     ).lazy.map { (batches: Batches) -> LazyMapSequence<Batches, LabeledTextBatch> in
       batches.lazy.map{ 
         (
-          data: $0.map(\.data).paddedAndCollated(on: on, to: maxSequenceLength),
-          label: Tensor(copying: Tensor($0.map(\.label)), to: on)
+          data: $0.map(\.data).paddedAndCollated(on: device, to: maxSequenceLength),
+          label: Tensor(copying: Tensor($0.map(\.label)), to: device)
         )
       }
     }
@@ -168,8 +168,8 @@ extension CoLA {
     // Create the validation collection of batches.
     validationBatches = validationExamples.inBatches(of: batchSize / maxSequenceLength).lazy.map{ 
       (
-        data: $0.map(\.data).paddedAndCollated(on: on, to: maxSequenceLength),
-        label: Tensor(copying: Tensor($0.map(\.label)), to: on)
+        data: $0.map(\.data).paddedAndCollated(on: device, to: maxSequenceLength),
+        label: Tensor(copying: Tensor($0.map(\.label)), to: device)
       )
     }
   }

--- a/Datasets/CoLA/CoLA.swift
+++ b/Datasets/CoLA/CoLA.swift
@@ -114,7 +114,7 @@ extension CoLA {
     maxSequenceLength: Int,
     batchSize: Int,
     entropy: Entropy,
-    on device: Device,
+    on device: Device = .default,
     exampleMap: @escaping (CoLAExample) -> LabeledTextBatch
   ) throws {
     self.directoryURL = taskDirectoryURL.appendingPathComponent("CoLA")
@@ -159,7 +159,7 @@ extension CoLA {
     ).lazy.map { (batches: Batches) -> LazyMapSequence<Batches, LabeledTextBatch> in
       batches.lazy.map{ 
         (
-          data: $0.map(\.data).paddedAndCollated(on: device, to: maxSequenceLength),
+          data: $0.map(\.data).paddedAndCollated(to: maxSequenceLength, on: device),
           label: Tensor(copying: Tensor($0.map(\.label)), to: device)
         )
       }
@@ -168,7 +168,7 @@ extension CoLA {
     // Create the validation collection of batches.
     validationBatches = validationExamples.inBatches(of: batchSize / maxSequenceLength).lazy.map{ 
       (
-        data: $0.map(\.data).paddedAndCollated(on: device, to: maxSequenceLength),
+        data: $0.map(\.data).paddedAndCollated(to: maxSequenceLength, on: device),
         label: Tensor(copying: Tensor($0.map(\.label)), to: device)
       )
     }
@@ -184,7 +184,7 @@ extension CoLA where Entropy == SystemRandomNumberGenerator {
     taskDirectoryURL: URL,
     maxSequenceLength: Int,
     batchSize: Int,
-    on: Device,
+    on device: Device = .default,
     exampleMap: @escaping (CoLAExample) -> LabeledTextBatch
   ) throws {
     try self.init(
@@ -192,7 +192,7 @@ extension CoLA where Entropy == SystemRandomNumberGenerator {
       maxSequenceLength: maxSequenceLength,
       batchSize: batchSize,
       entropy: SystemRandomNumberGenerator(),
-      on: on,
+      on: device,
       exampleMap: exampleMap
     )
   }

--- a/Datasets/CoLA/CoLA.swift
+++ b/Datasets/CoLA/CoLA.swift
@@ -114,6 +114,7 @@ extension CoLA {
     maxSequenceLength: Int,
     batchSize: Int,
     entropy: Entropy,
+    on: Device,
     exampleMap: @escaping (CoLAExample) -> LabeledTextBatch
   ) throws {
     self.directoryURL = taskDirectoryURL.appendingPathComponent("CoLA")
@@ -158,8 +159,8 @@ extension CoLA {
     ).lazy.map { (batches: Batches) -> LazyMapSequence<Batches, LabeledTextBatch> in
       batches.lazy.map{ 
         (
-          data: $0.map(\.data).paddedAndCollated(to: maxSequenceLength),
-          label: Tensor($0.map(\.label))
+          data: $0.map(\.data).paddedAndCollated(on: on, to: maxSequenceLength),
+          label: Tensor(copying: Tensor($0.map(\.label)), to: on)
         )
       }
     }
@@ -167,8 +168,8 @@ extension CoLA {
     // Create the validation collection of batches.
     validationBatches = validationExamples.inBatches(of: batchSize / maxSequenceLength).lazy.map{ 
       (
-        data: $0.map(\.data).paddedAndCollated(to: maxSequenceLength),
-        label: Tensor($0.map(\.label))
+        data: $0.map(\.data).paddedAndCollated(on: on, to: maxSequenceLength),
+        label: Tensor(copying: Tensor($0.map(\.label)), to: on)
       )
     }
   }
@@ -183,6 +184,7 @@ extension CoLA where Entropy == SystemRandomNumberGenerator {
     taskDirectoryURL: URL,
     maxSequenceLength: Int,
     batchSize: Int,
+    on: Device,
     exampleMap: @escaping (CoLAExample) -> LabeledTextBatch
   ) throws {
     try self.init(
@@ -190,6 +192,7 @@ extension CoLA where Entropy == SystemRandomNumberGenerator {
       maxSequenceLength: maxSequenceLength,
       batchSize: batchSize,
       entropy: SystemRandomNumberGenerator(),
+      on: on,
       exampleMap: exampleMap
     )
   }

--- a/Examples/BERT-CoLA/main.swift
+++ b/Examples/BERT-CoLA/main.swift
@@ -65,8 +65,8 @@ var cola = try CoLA(
   entropy: SystemRandomNumberGenerator(),
   on: device
 ) { (example: CoLAExample) -> CoLA.LabeledTextBatch in
-  // in this closure, both the input and output text batches must be eager
-  // since the text is not padded and x10 requires stable shapes
+  // In this closure, both the input and output text batches must be eager
+  // since the text is not padded and x10 requires stable shapes.
   let textBatch = bertClassifier.bert.preprocess(
     sequences: [example.sentence],
     maxSequenceLength: maxSequenceLength)

--- a/Examples/BERT-CoLA/main.swift
+++ b/Examples/BERT-CoLA/main.swift
@@ -65,7 +65,8 @@ var cola = try CoLA(
   entropy: SystemRandomNumberGenerator(),
   on: device
 ) { (example: CoLAExample) -> CoLA.LabeledTextBatch in
-  // must be eager, since the text has not been padded yet
+  // in this closure, both the input and output text batches must be eager
+  // since the text is not padded and x10 requires stable shapes
   let textBatch = bertClassifier.bert.preprocess(
     sequences: [example.sentence],
     maxSequenceLength: maxSequenceLength)

--- a/Examples/BERT-CoLA/main.swift
+++ b/Examples/BERT-CoLA/main.swift
@@ -19,13 +19,7 @@ import TensorFlow
 import TextModels
 import x10_optimizers_optimizer
 
-// Until https://github.com/tensorflow/swift-apis/issues/993 is fixed, default to the eager-mode
-// device on macOS instead of X10.
-#if os(macOS)
-  let device = Device.defaultTFEager
-#else
-  let device = Device.defaultXLA
-#endif
+let device = Device.defaultXLA
 
 var bertPretrained: BERT.PreTrainedModel
 if CommandLine.arguments.count >= 2 {

--- a/Support/Text/TextBatch.swift
+++ b/Support/Text/TextBatch.swift
@@ -55,7 +55,7 @@ extension TextBatch: Collatable {
 extension Collection where Element == TextBatch {
   /// Returns the elements of `self`, padded to `maxLength` if specified
   /// or the maximum length of the elements in `self` otherwise.
-  public func paddedAndCollated(on device: Device, to maxLength: Int? = nil) -> TextBatch {
+  public func paddedAndCollated(to maxLength: Int? = nil, on device: Device = .default) -> TextBatch {
     let maxLength = maxLength ?? self.map { $0.tokenIds.shape[1] }.max()!
     let paddedTexts = self.map { text -> TextBatch in
       let paddingSize = maxLength - text.tokenIds.shape[1]

--- a/Support/Text/TextBatch.swift
+++ b/Support/Text/TextBatch.swift
@@ -55,20 +55,20 @@ extension TextBatch: Collatable {
 extension Collection where Element == TextBatch {
   /// Returns the elements of `self`, padded to `maxLength` if specified
   /// or the maximum length of the elements in `self` otherwise.
-  public func paddedAndCollated(to maxLength: Int? = nil) -> TextBatch {
+  public func paddedAndCollated(on: Device, to maxLength: Int? = nil) -> TextBatch {
     let maxLength = maxLength ?? self.map { $0.tokenIds.shape[1] }.max()!
     let paddedTexts = self.map { text -> TextBatch in
       let paddingSize = maxLength - text.tokenIds.shape[1]
       return TextBatch(
-        tokenIds: text.tokenIds.padded(forSizes: [
+        tokenIds: Tensor(copying: text.tokenIds.padded(forSizes: [
           (before: 0, after: 0),
-          (before: 0, after: paddingSize)]),
-        tokenTypeIds: text.tokenTypeIds.padded(forSizes: [
+          (before: 0, after: paddingSize)]), to: on),
+        tokenTypeIds: Tensor(copying: text.tokenTypeIds.padded(forSizes: [
           (before: 0, after: 0),
-          (before: 0, after: paddingSize)]),
-        mask: text.mask.padded(forSizes: [
+          (before: 0, after: paddingSize)]), to: on),
+        mask: Tensor(copying: text.mask.padded(forSizes: [
           (before: 0, after: 0),
-          (before: 0, after: paddingSize)]))
+          (before: 0, after: paddingSize)]), to: on))
     }
 
     if count == 1 { return paddedTexts.first! }

--- a/Support/Text/TextBatch.swift
+++ b/Support/Text/TextBatch.swift
@@ -55,20 +55,20 @@ extension TextBatch: Collatable {
 extension Collection where Element == TextBatch {
   /// Returns the elements of `self`, padded to `maxLength` if specified
   /// or the maximum length of the elements in `self` otherwise.
-  public func paddedAndCollated(on: Device, to maxLength: Int? = nil) -> TextBatch {
+  public func paddedAndCollated(on device: Device, to maxLength: Int? = nil) -> TextBatch {
     let maxLength = maxLength ?? self.map { $0.tokenIds.shape[1] }.max()!
     let paddedTexts = self.map { text -> TextBatch in
       let paddingSize = maxLength - text.tokenIds.shape[1]
       return TextBatch(
         tokenIds: Tensor(copying: text.tokenIds.padded(forSizes: [
           (before: 0, after: 0),
-          (before: 0, after: paddingSize)]), to: on),
+          (before: 0, after: paddingSize)]), to: device),
         tokenTypeIds: Tensor(copying: text.tokenTypeIds.padded(forSizes: [
           (before: 0, after: 0),
-          (before: 0, after: paddingSize)]), to: on),
+          (before: 0, after: paddingSize)]), to: device),
         mask: Tensor(copying: text.mask.padded(forSizes: [
           (before: 0, after: 0),
-          (before: 0, after: paddingSize)]), to: on))
+          (before: 0, after: paddingSize)]), to: device))
     }
 
     if count == 1 { return paddedTexts.first! }


### PR DESCRIPTION
Eliminates device copying in the example code by allowing users to specify a device to load CoLA onto.