### PR TITLE
change Package.swift package name

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -4,7 +4,7 @@
 import PackageDescription
 
 let package = Package(
-    name: "TensorFlowModels",
+    name: "swift-models",
     platforms: [
         .macOS(.v10_13),
     ],


### PR DESCRIPTION
It seems that the package name in `Package.swift` needs to match the github repo name to be able to depend on the libraries that this exports.

Here is how I am trying to depend on the libraries:

```swift
// swift-tools-version:5.3

import PackageDescription

let package = Package(
  name: "DeepBeeTracking",
  products: [
    .executable(name: "TrainUNet", targets: ["TrainUNet"])
  ],
  dependencies: [
    .package(url: "https://github.com/tensorflow/swift-models.git", .branch("master")),
  ],
  targets: [
    .target(
      name: "DeepBeeTrackingDatasets",
      dependencies: [
        .product(name: "Datasets", package: "TensorFlowDatasets"),
        .product(name: "ModelSupport", package: "TensorFlowDatasets"),
      ]),
    .target(
      name: "TrainUNet",
      dependencies: ["DeepBeeTrackingDatasets"]),
  ]
))
```

This produces the error:
```
/usr/local/google/home/marcrasi/git/DeepBeeTracking: error: unknown package 'TensorFlowDatasets' in dependencies of target 'DeepBeeTrackingDatasets'
/usr/local/google/home/marcrasi/git/DeepBeeTracking: error: unknown package 'TensorFlowDatasets' in dependencies of target 'DeepBeeTrackingDatasets'
```

If I change `package: "TensorFlowDatasets"` to `package: "swift-models"` in my `Package.swift`, the error becomes:

```
'DeepBeeTracking' /usr/local/google/home/marcrasi/git/DeepBeeTracking: error: product dependency 'Datasets' in package 'swift-models' not found
'DeepBeeTracking' /usr/local/google/home/marcrasi/git/DeepBeeTracking: error: product dependency 'ModelSupport' in package 'swift-models' not found
```

The name change in this PR fixes the problem.