### PR TITLE
[WordSeg] Fix pullback for `Array.update(at:to:)`.

### DIFF
--- a/Models/Text/WordSeg/Model.swift
+++ b/Models/Text/WordSeg/Model.swift
@@ -335,10 +335,11 @@ extension Array {
     value: (),
     pullback: (inout TangentVector) -> Element.TangentVector
   ) where Element: Differentiable {
+    let elementZero = self[index].zeroTangentVector
     update(at: index, to: value)
     func pullback(_ dSelf: inout TangentVector) -> Element.TangentVector {
       let dElement = dSelf[index]
-      dSelf.base[index] = dElement.zeroTangentVector
+      dSelf.base[index] = elementZero
       return dElement
     }
     return ((), pullback)


### PR DESCRIPTION
The pullback of `Array.update(at:to:)` resets `dSelf.base[index]` to a zero value.

For correctness, it should use the value of `self[index].zeroTangentVector` before
the update occurs, not `dElement.zeroTangentVector`.

---

Fixes `WordSegProbeLayerTests.testProbeEncoder` after the `2020-07-28 master -> merge`.

Previously, the test passed due to an incorrect definition of `Array.TangentVector.zeroTangentVectorInitializer`, which was fixed in https://github.com/apple/swift/pull/32948.