### PR TITLE
Add platform arguments to benchmarks

### DIFF
--- a/BenchmarksCore/BenchmarkArguments.swift
+++ b/BenchmarksCore/BenchmarkArguments.swift
@@ -28,6 +28,15 @@ public struct BenchmarkArguments: ParsableArguments {
   @Flag(help: "Use X10 backend.")
   var x10: Bool = false
 
+  @Flag(help: "Use CPU platform.")
+  var cpu: Bool = false
+
+  @Flag(help: "Use GPU platform.")
+  var gpu: Bool = false
+
+  @Flag(help: "Use TPU platform.")
+  var tpu: Bool = false
+
   @Flag(help: "Use synthetic data.")
   var synthetic: Bool = false 
 
@@ -40,11 +49,15 @@ public struct BenchmarkArguments: ParsableArguments {
   public init() {}
 
   public init(arguments: Benchmark.BenchmarkArguments, batchSize: Int?, eager: Bool, x10: Bool,
-              synthetic: Bool, real: Bool, datasetFilePath: String?) {
+              cpu: Bool, gpu: Bool, tpu: Bool, synthetic: Bool, real: Bool,
+              datasetFilePath: String?) {
     self.arguments = arguments
     self.batchSize = batchSize
     self.eager = eager
     self.x10 = x10
+    self.cpu = cpu
+    self.gpu = gpu
+    self.tpu = tpu
     self.synthetic = synthetic
     self.real = real
     self.datasetFilePath = datasetFilePath
@@ -62,6 +75,11 @@ public struct BenchmarkArguments: ParsableArguments {
       throw ValidationError(
         "Can't specify both --eager and --x10 backends.")
     }
+
+    guard !(cpu && gpu) || !(cpu && tpu) || !(gpu && tpu) else {
+      throw ValidationError(
+        "Can't specify multiple platforms.")
+    }
   }
 
   public var settings: [BenchmarkSetting] {
@@ -75,6 +93,15 @@ public struct BenchmarkArguments: ParsableArguments {
     }
     if eager {
       settings.append(Backend(.eager))
+    }
+    if cpu {
+      settings.append(Platform(.cpu))
+    }
+    if gpu {
+      settings.append(Platform(.gpu))
+    }
+    if tpu {
+      settings.append(Platform(.tpu))
     }
     if synthetic {
       settings.append(Synthetic(true))

--- a/BenchmarksCore/BenchmarkSettings.swift
+++ b/BenchmarksCore/BenchmarkSettings.swift
@@ -106,11 +106,16 @@ public extension BenchmarkSettings {
     let _ = _ExecutionContext.global
 
     switch backend {
-    case .eager: return Device.defaultTFEager
+    case .eager:
+      switch platform {
+      case .cpu: return Device(kind: .CPU, ordinal: 0, backend: .TF_EAGER)
+      case .gpu: return Device(kind: .GPU, ordinal: 0, backend: .TF_EAGER)
+      case .tpu: fatalError("TFEager is unsupported on TPU.")
+      }
     case .x10:
       switch platform {
-      case .cpu: return Device.defaultXLA
-      case .gpu: return Device.defaultXLA
+      case .cpu: return Device(kind: .CPU, ordinal: 0, backend: .XLA)
+      case .gpu: return Device(kind: .GPU, ordinal: 0, backend: .XLA)
       case .tpu: return (Device.allDevices.filter { $0.kind == .TPU }).first!
       }
     }

--- a/BenchmarksCore/BenchmarkSettings.swift
+++ b/BenchmarksCore/BenchmarkSettings.swift
@@ -53,6 +53,7 @@ public struct Platform: BenchmarkSetting {
     self.value = value
   }
   public enum Value {
+    case `default`
     case cpu
     case gpu
     case tpu
@@ -108,12 +109,14 @@ extension BenchmarkSettings {
     switch backend {
     case .eager:
       switch platform {
+      case .default: return Device.defaultTFEager
       case .cpu: return Device(kind: .CPU, ordinal: 0, backend: .TF_EAGER)
       case .gpu: return Device(kind: .GPU, ordinal: 0, backend: .TF_EAGER)
       case .tpu: fatalError("TFEager is unsupported on TPU.")
       }
     case .x10:
       switch platform {
+      case .default: return Device.defaultXLA
       case .cpu: return Device(kind: .CPU, ordinal: 0, backend: .XLA)
       case .gpu: return Device(kind: .GPU, ordinal: 0, backend: .XLA)
       case .tpu: return (Device.allDevices.filter { $0.kind == .TPU }).first!
@@ -130,7 +133,7 @@ public let defaultSettings: [BenchmarkSetting] = [
   TimeUnit(.s),
   InverseTimeUnit(.s),
   Backend(.eager),
-  Platform(.cpu),
+  Platform(.default),
   Synthetic(false),
   Columns([
     "name",


### PR DESCRIPTION
Adds 3 new arguments for specifying platform for benchmarks: `--cpu`, `--gpu`, `--tpu`. This allows us to set the proper device for connecting to TPUs outside of colab, where `Device.defaultXLA` does not automatically pick up TPUs.

+ Lint.