### PR TITLE
Implement Proximal Policy Optimization

### DIFF
--- a/Gym/PPO/ActorCritic.swift
+++ b/Gym/PPO/ActorCritic.swift
@@ -1,3 +1,17 @@
+// Copyright 2020 The TensorFlow Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 import TensorFlow
 
 struct ActorNet: Layer {

--- a/Gym/PPO/ActorCritic.swift
+++ b/Gym/PPO/ActorCritic.swift
@@ -108,7 +108,7 @@ class ActorCritic {
         )
     }
 
-    func act(state: Tensor<Float>, memory: PPOMemory) -> Int32 {
+    func act(state: Tensor<Float>) -> (Int32, Float) {
         // Input to the network needs to be 2D (BATCH_SIZE x STATE_SIZE)
         let state = Tensor<Float>([state])
         let actionProbs = self.actorNetwork(state).flattened()
@@ -116,11 +116,6 @@ class ActorCritic {
         let action = dist.sample().scalarized()
         let logProb = dist.logProbabilities.makeNumpyArray()[action]
 
-        let convertedStates: [Float] = Array(numpy: state.makeNumpyArray().flatten())!
-        memory.states.append(convertedStates)
-        memory.actions.append(action)
-        memory.logProbs.append(Float(logProb)!)
-
-        return action
+        return (action, Float(logProb)!)
     }
 }

--- a/Gym/PPO/ActorCritic.swift
+++ b/Gym/PPO/ActorCritic.swift
@@ -110,8 +110,7 @@ struct ActorCritic: Layer {
 
     @differentiable
     func callAsFunction(_ state: Tensor<Float>) -> Categorical<Int32> {
-        // Input to the network needs to be 2D (BATCH_SIZE x STATE_SIZE)
-        let state = Tensor<Float>([state])
+        precondition(state.rank == 2, "The input must be 2-D ([batch size, state size]).")
         let actionProbs = self.actorNetwork(state).flattened()
         let dist = Categorical<Int32>(probabilities: actionProbs)
         return dist

--- a/Gym/PPO/ActorCritic.swift
+++ b/Gym/PPO/ActorCritic.swift
@@ -1,0 +1,76 @@
+import TensorFlow
+
+struct ActorNet: Layer {
+    typealias Input = Tensor<Float>
+    typealias Output = Tensor<Float>
+
+    var l1, l2, l3: Dense<Float>
+
+    init(observationSize: Int, hiddenSize: Int, actionCount: Int) {
+        l1 = Dense<Float>(inputSize: observationSize, outputSize: hiddenSize, activation: tanh, weightInitializer: heNormal())
+        l2 = Dense<Float>(inputSize: hiddenSize, outputSize: hiddenSize, activation: tanh, weightInitializer: heNormal())
+        l3 = Dense<Float>(inputSize: hiddenSize, outputSize: actionCount, activation: softmax, weightInitializer: heNormal())
+    }
+
+    @differentiable
+    func callAsFunction(_ input: Input) -> Output {
+        return input.sequenced(through: l1, l2, l3)
+    }
+}
+
+struct CriticNet: Layer {
+    typealias Input = Tensor<Float>
+    typealias Output = Tensor<Float>
+
+    var l1, l2, l3: Dense<Float>
+
+    init(observationSize: Int, hiddenSize: Int) {
+        l1 = Dense<Float>(inputSize: observationSize, outputSize: hiddenSize, activation: relu, weightInitializer: heNormal())
+        l2 = Dense<Float>(inputSize: hiddenSize, outputSize: hiddenSize, activation: relu, weightInitializer: heNormal())
+        l3 = Dense<Float>(inputSize: hiddenSize, outputSize: 1, weightInitializer: heNormal())
+    }
+
+    @differentiable
+    func callAsFunction(_ input: Input) -> Output {
+        return input.sequenced(through: l1, l2, l3)
+    }
+}
+
+class ActorCritic {
+    var actorNet: ActorNet
+    var criticNet: CriticNet
+
+    init(observationSize: Int, hiddenSize: Int, actionCount: Int) {
+        self.actorNet = ActorNet(observationSize: observationSize, hiddenSize: hiddenSize, actionCount: actionCount)
+        self.criticNet = CriticNet(observationSize: observationSize, hiddenSize: hiddenSize)
+    }
+
+    func act(state: Tensor<Float>, memory: Memory) -> Int32 {
+        // state needs to be 2D (BATCH_SIZE x STATE_SIZE)
+        let state = Tensor<Float>([state])
+        let actionProbs = self.actorNet(state).flattened()
+        let dist = Categorical<Int32>(probabilities: actionProbs)
+        let action = dist.sample().scalarized()
+        let logProb = dist.logProbabilities.makeNumpyArray()[action]
+
+        let convertedStates: [Float] = Array(numpy: state.makeNumpyArray().flatten())!
+        memory.states.append(convertedStates)
+        memory.actions.append(action)
+        memory.logProbs.append(Float(logProb)!)
+
+        return action
+    }
+
+    func evaluate(state: Tensor<Float>, action: Tensor<Int32>) -> ([Float], [Float], Float) {
+        let actionProbs = self.actorNet(state).flattened()
+        let dist = Categorical<Int32>(probabilities: actionProbs)
+
+        let stateValue = self.criticNet(state)
+        let entropy: Tensor<Float> = dist.entropy()
+
+        let convertedActionLogProbs: [Float] = Array(numpy: dist.logProbabilities.makeNumpyArray())!
+        let convertedStateValue: [Float] = Array(numpy: stateValue.makeNumpyArray().flatten())!
+
+        return (convertedActionLogProbs, convertedStateValue, entropy.scalarized())
+    }
+}

--- a/Gym/PPO/ActorCritic.swift
+++ b/Gym/PPO/ActorCritic.swift
@@ -67,15 +67,4 @@ class ActorCritic {
 
         return action
     }
-
-    func evaluate(state: Tensor<Float>, action: Tensor<Int32>) -> (Tensor<Float>, Tensor<Float>, Tensor<Float>) {
-        let npIndices = np.stack([np.arange(action.shape[0], dtype: np.int32), action.makeNumpyArray()], axis: 1)
-        let tfIndices = Tensor<Int32>(numpy: npIndices)!
-        let actionProbs = self.actorNet(state).dimensionGathering(atIndices: tfIndices)
-
-        let dist = Categorical<Int32>(probabilities: actionProbs)
-        let stateValue = self.criticNet(state).flattened()
-
-        return (dist.logProbabilities, stateValue, dist.entropy())
-    }
 }

--- a/Gym/PPO/ActorCritic.swift
+++ b/Gym/PPO/ActorCritic.swift
@@ -14,7 +14,11 @@
 
 import TensorFlow
 
-struct ActorNet: Layer {
+/// The actor network that returns a probability for each action.
+///
+/// Actor-Critic methods has an actor network and a critic network. The actor network is the policy
+/// of the agent: it is used to select actions.
+struct ActorNetwork: Layer {
     typealias Input = Tensor<Float>
     typealias Output = Tensor<Float>
 
@@ -47,7 +51,12 @@ struct ActorNet: Layer {
     }
 }
 
-struct CriticNet: Layer {
+/// The critic network that returns the estimated value of each action, given a state.
+///
+/// Actor-Critic methods has an actor network and a critic network. The critic network is used to
+/// estimate the value of the state-action pair. With these value functions, the critic can evaluate
+/// the actions made by the actor.
+struct CriticNetwork: Layer {
     typealias Input = Tensor<Float>
     typealias Output = Tensor<Float>
 
@@ -79,17 +88,21 @@ struct CriticNet: Layer {
     }
 }
 
+/// The actor-critic that contains actor and critic networks for action selection and evaluation.
+///
+/// Weight are often shared between the actor network and the critic network, but in this example,
+/// they are separated networks.
 class ActorCritic {
-    var actorNet: ActorNet
-    var criticNet: CriticNet
+    var actorNetwork: ActorNetwork
+    var criticNetwork: CriticNetwork
 
     init(observationSize: Int, hiddenSize: Int, actionCount: Int) {
-        self.actorNet = ActorNet(
+        self.actorNetwork = ActorNetwork(
             observationSize: observationSize,
             hiddenSize: hiddenSize,
             actionCount: actionCount
         )
-        self.criticNet = CriticNet(
+        self.criticNetwork = CriticNetwork(
             observationSize: observationSize,
             hiddenSize: hiddenSize
         )
@@ -98,7 +111,7 @@ class ActorCritic {
     func act(state: Tensor<Float>, memory: PPOMemory) -> Int32 {
         // Input to the network needs to be 2D (BATCH_SIZE x STATE_SIZE)
         let state = Tensor<Float>([state])
-        let actionProbs = self.actorNet(state).flattened()
+        let actionProbs = self.actorNetwork(state).flattened()
         let dist = Categorical<Int32>(probabilities: actionProbs)
         let action = dist.sample().scalarized()
         let logProb = dist.logProbabilities.makeNumpyArray()[action]

--- a/Gym/PPO/ActorCritic.swift
+++ b/Gym/PPO/ActorCritic.swift
@@ -114,7 +114,6 @@ struct ActorCritic: Layer {
         let state = Tensor<Float>([state])
         let actionProbs = self.actorNetwork(state).flattened()
         let dist = Categorical<Int32>(probabilities: actionProbs)
-
         return dist
     }
 }

--- a/Gym/PPO/ActorCritic.swift
+++ b/Gym/PPO/ActorCritic.swift
@@ -7,9 +7,24 @@ struct ActorNet: Layer {
     var l1, l2, l3: Dense<Float>
 
     init(observationSize: Int, hiddenSize: Int, actionCount: Int) {
-        l1 = Dense<Float>(inputSize: observationSize, outputSize: hiddenSize, activation: tanh, weightInitializer: heNormal())
-        l2 = Dense<Float>(inputSize: hiddenSize, outputSize: hiddenSize, activation: tanh, weightInitializer: heNormal())
-        l3 = Dense<Float>(inputSize: hiddenSize, outputSize: actionCount, activation: softmax, weightInitializer: heNormal())
+        l1 = Dense<Float>(
+            inputSize: observationSize,
+            outputSize: hiddenSize,
+            activation: tanh,
+            weightInitializer: heNormal()
+        )
+        l2 = Dense<Float>(
+            inputSize: hiddenSize,
+            outputSize: hiddenSize,
+            activation: tanh,
+            weightInitializer: heNormal()
+        )
+        l3 = Dense<Float>(
+            inputSize: hiddenSize,
+            outputSize: actionCount,
+            activation: softmax,
+            weightInitializer: heNormal()
+        )
     }
 
     @differentiable
@@ -25,9 +40,23 @@ struct CriticNet: Layer {
     var l1, l2, l3: Dense<Float>
 
     init(observationSize: Int, hiddenSize: Int) {
-        l1 = Dense<Float>(inputSize: observationSize, outputSize: hiddenSize, activation: relu, weightInitializer: heNormal())
-        l2 = Dense<Float>(inputSize: hiddenSize, outputSize: hiddenSize, activation: relu, weightInitializer: heNormal())
-        l3 = Dense<Float>(inputSize: hiddenSize, outputSize: 1, weightInitializer: heNormal())
+        l1 = Dense<Float>(
+            inputSize: observationSize,
+            outputSize: hiddenSize,
+            activation: relu,
+            weightInitializer: heNormal()
+        )
+        l2 = Dense<Float>(
+            inputSize: hiddenSize,
+            outputSize: hiddenSize,
+            activation: relu,
+            weightInitializer: heNormal()
+        )
+        l3 = Dense<Float>(
+            inputSize: hiddenSize,
+            outputSize: 1,
+            weightInitializer: heNormal()
+        )
     }
 
     @differentiable
@@ -52,8 +81,8 @@ class ActorCritic {
         )
     }
 
-    func act(state: Tensor<Float>, memory: Memory) -> Int32 {
-        // state needs to be 2D (BATCH_SIZE x STATE_SIZE)
+    func act(state: Tensor<Float>, memory: PPOMemory) -> Int32 {
+        // Input to the network needs to be 2D (BATCH_SIZE x STATE_SIZE)
         let state = Tensor<Float>([state])
         let actionProbs = self.actorNet(state).flattened()
         let dist = Categorical<Int32>(probabilities: actionProbs)

--- a/Gym/PPO/ActorCritic.swift
+++ b/Gym/PPO/ActorCritic.swift
@@ -41,8 +41,15 @@ class ActorCritic {
     var criticNet: CriticNet
 
     init(observationSize: Int, hiddenSize: Int, actionCount: Int) {
-        self.actorNet = ActorNet(observationSize: observationSize, hiddenSize: hiddenSize, actionCount: actionCount)
-        self.criticNet = CriticNet(observationSize: observationSize, hiddenSize: hiddenSize)
+        self.actorNet = ActorNet(
+            observationSize: observationSize,
+            hiddenSize: hiddenSize,
+            actionCount: actionCount
+        )
+        self.criticNet = CriticNet(
+            observationSize: observationSize,
+            hiddenSize: hiddenSize
+        )
     }
 
     func act(state: Tensor<Float>, memory: Memory) -> Int32 {

--- a/Gym/PPO/ActorCritic.swift
+++ b/Gym/PPO/ActorCritic.swift
@@ -92,7 +92,7 @@ struct CriticNetwork: Layer {
 ///
 /// Weight are often shared between the actor network and the critic network, but in this example,
 /// they are separated networks.
-class ActorCritic {
+struct ActorCritic: Layer {
     var actorNetwork: ActorNetwork
     var criticNetwork: CriticNetwork
 
@@ -108,14 +108,13 @@ class ActorCritic {
         )
     }
 
-    func act(state: Tensor<Float>) -> (Int32, Float) {
+    @differentiable
+    func callAsFunction(_ state: Tensor<Float>) -> Categorical<Int32> {
         // Input to the network needs to be 2D (BATCH_SIZE x STATE_SIZE)
         let state = Tensor<Float>([state])
         let actionProbs = self.actorNetwork(state).flattened()
         let dist = Categorical<Int32>(probabilities: actionProbs)
-        let action = dist.sample().scalarized()
-        let logProb = dist.logProbabilities.makeNumpyArray()[action]
 
-        return (action, Float(logProb)!)
+        return dist
     }
 }

--- a/Gym/PPO/Agent.swift
+++ b/Gym/PPO/Agent.swift
@@ -59,31 +59,10 @@ class PPOAgent {
             hiddenSize: hiddenSize,
             actionCount: actionCount
         )
-        self.oldActorCritic = ActorCritic(
-            observationSize: observationSize,
-            hiddenSize: hiddenSize,
-            actionCount: actionCount
-        )
+        self.oldActorCritic = self.actorCritic
         self.actorOptimizer = Adam(for: actorCritic.actorNetwork, learningRate: learningRate)
         self.criticOptimizer = Adam(for: actorCritic.criticNetwork, learningRate: learningRate)
 
-        // Copy actorCritic to oldActorCritic
-        self.updateOldActorCritic()
-    }
-
-    func updateOldActorCritic() {
-        self.oldActorCritic.criticNetwork.l1.weight = self.actorCritic.criticNetwork.l1.weight
-        self.oldActorCritic.criticNetwork.l1.bias = self.actorCritic.criticNetwork.l1.bias
-        self.oldActorCritic.criticNetwork.l2.weight = self.actorCritic.criticNetwork.l2.weight
-        self.oldActorCritic.criticNetwork.l2.bias = self.actorCritic.criticNetwork.l2.bias
-        self.oldActorCritic.criticNetwork.l3.weight = self.actorCritic.criticNetwork.l3.weight
-        self.oldActorCritic.criticNetwork.l3.bias = self.actorCritic.criticNetwork.l3.bias
-        self.oldActorCritic.actorNetwork.l1.weight = self.actorCritic.actorNetwork.l1.weight
-        self.oldActorCritic.actorNetwork.l1.bias = self.actorCritic.actorNetwork.l1.bias
-        self.oldActorCritic.actorNetwork.l2.weight = self.actorCritic.actorNetwork.l2.weight
-        self.oldActorCritic.actorNetwork.l2.bias = self.actorCritic.actorNetwork.l2.bias
-        self.oldActorCritic.actorNetwork.l3.weight = self.actorCritic.actorNetwork.l3.weight
-        self.oldActorCritic.actorNetwork.l3.bias = self.actorCritic.actorNetwork.l3.bias
     }
 
     func update(memory: inout PPOMemory) {
@@ -142,6 +121,6 @@ class PPOAgent {
             self.criticOptimizer.update(&self.actorCritic.criticNetwork, along: criticGradients)
             criticLosses.append(criticLoss.scalarized())
         }
-        self.updateOldActorCritic()
+        self.oldActorCritic = self.actorCritic
     }
 }

--- a/Gym/PPO/Agent.swift
+++ b/Gym/PPO/Agent.swift
@@ -23,8 +23,6 @@ import TensorFlow
 class PPOAgent {
     /// The learning rate for both the actor and the critic.
     let learningRate: Float
-    // TODO: Remove since we don't have KL penalty
-    let betas: [Float]
     /// The discount factor that measures how much to weight to give to future
     /// rewards when calculating the action value.
     let discount: Float
@@ -45,14 +43,12 @@ class PPOAgent {
         hiddenSize: Int,
         actionCount: Int,
         learningRate: Float,
-        betas: [Float],
         discount: Float,
         epochs: Int,
         clipEpsilon: Float,
         entropyCoefficient: Float
     ) {
         self.learningRate = learningRate
-        self.betas = betas
         self.discount = discount
         self.epochs = epochs
         self.clipEpsilon = clipEpsilon
@@ -98,7 +94,7 @@ class PPOAgent {
             if memory.isDones[i] {
                 discountedReward = 0
             }
-            discountedReward = memory.rewards[i] + (gamma * discountedReward)
+            discountedReward = memory.rewards[i] + (discount * discountedReward)
             rewards.insert(discountedReward, at: 0)
         }
         var tfRewards = Tensor<Float>(rewards)

--- a/Gym/PPO/Agent.swift
+++ b/Gym/PPO/Agent.swift
@@ -70,7 +70,7 @@ class PPOAgent {
     }
 
     func step(env: PythonObject, state: PythonObject) -> (PythonObject, Bool, Float) {
-        let tfState: Tensor<Float> = Tensor<Float>(numpy: np.array(state, dtype: np.float32))!
+        let tfState: Tensor<Float> = Tensor<Float>(numpy: np.array([state], dtype: np.float32))!
         let dist: Categorical<Int32> = oldActorCritic(tfState)
         let action: Int32 = dist.sample().scalarized()
         let (newState, reward, isDone, _) = env.step(action).tuple4

--- a/Gym/PPO/Agent.swift
+++ b/Gym/PPO/Agent.swift
@@ -14,13 +14,27 @@
 
 import TensorFlow
 
+/// Agent that uses the Proximal Policy Optimization (PPO).
+///
+/// Proximal Policy Optimization is an algorithm that trains an actor (policy) and a critic (value
+/// function) using a clipped objective function. The clipped objective function simplifies the
+/// update equation from its predecessor Trust Region Policy Optimization (TRPO). For more
+/// information, check Proximal Policy Optimization Algorithms (Schulman et al., 2017).
 class PPOAgent {
+    /// The learning rate for both the actor and the critic.
     let learningRate: Float
+    // TODO: Remove since we don't have KL penalty
     let betas: [Float]
-    let gamma: Float
+    /// The discount factor that measures how much to weight to give to future
+    /// rewards when calculating the action value.
+    let discount: Float
+    /// Number of epochs to run minibatch updates once enough trajectory segments are collected.
     let epochs: Int
+    /// Parameter to clip the probability ratio.
     let clipEpsilon: Float
+    /// Coefficient for the entropy bonus added to the objective.
     let entropyCoefficient: Float
+
     var actorCritic: ActorCritic
     var oldActorCritic: ActorCritic
     var actorOptimizer: Adam<ActorNetwork>
@@ -32,14 +46,14 @@ class PPOAgent {
         actionCount: Int,
         learningRate: Float,
         betas: [Float],
-        gamma: Float,
+        discount: Float,
         epochs: Int,
         clipEpsilon: Float,
         entropyCoefficient: Float
     ) {
         self.learningRate = learningRate
         self.betas = betas
-        self.gamma = gamma
+        self.discount = discount
         self.epochs = epochs
         self.clipEpsilon = clipEpsilon
         self.entropyCoefficient = entropyCoefficient

--- a/Gym/PPO/Agent.swift
+++ b/Gym/PPO/Agent.swift
@@ -21,6 +21,8 @@ import TensorFlow
 /// update equation from its predecessor Trust Region Policy Optimization (TRPO). For more
 /// information, check Proximal Policy Optimization Algorithms (Schulman et al., 2017).
 class PPOAgent {
+    // Cache for trajectory segments for minibatch updates.
+    var memory: PPOMemory
     /// The learning rate for both the actor and the critic.
     let learningRate: Float
     /// The discount factor that measures how much to weight to give to future
@@ -54,6 +56,8 @@ class PPOAgent {
         self.clipEpsilon = clipEpsilon
         self.entropyCoefficient = entropyCoefficient
 
+        self.memory = PPOMemory()
+
         self.actorCritic = ActorCritic(
             observationSize: observationSize,
             hiddenSize: hiddenSize,
@@ -62,10 +66,9 @@ class PPOAgent {
         self.oldActorCritic = self.actorCritic
         self.actorOptimizer = Adam(for: actorCritic.actorNetwork, learningRate: learningRate)
         self.criticOptimizer = Adam(for: actorCritic.criticNetwork, learningRate: learningRate)
-
     }
 
-    func update(memory: inout PPOMemory) {
+    func update() {
         // Discount rewards for advantage estimation
         var rewards: [Float] = []
         var discountedReward: Float = 0
@@ -122,5 +125,6 @@ class PPOAgent {
             criticLosses.append(criticLoss.scalarized())
         }
         self.oldActorCritic = self.actorCritic
+        memory.removeAll()
     }
 }

--- a/Gym/PPO/Categorical.swift
+++ b/Gym/PPO/Categorical.swift
@@ -53,13 +53,9 @@ extension Tensor: DifferentiableBatchable where Scalar: TensorFlowFloatingPoint 
     if outerDimCount == 1 {
       return self
     }
-    // TODO: Remove this hack once the S4TF auto-diff memory leak is fixed.
-    let newShape = Swift.withoutDerivative(at: self.shape) { shape -> [Int] in 
-      var newShape = [-1]
-      for i in outerDimCount..<shape.count {
-        newShape.append(shape[i])
-      }
-      return newShape
+    var newShape = [-1]
+    for i in outerDimCount..<rank {
+      newShape.append(shape[i])
     }
     return reshaped(to: TensorShape(newShape))
   }

--- a/Gym/PPO/Categorical.swift
+++ b/Gym/PPO/Categorical.swift
@@ -1,0 +1,156 @@
+import TensorFlow
+
+public protocol Batchable {
+  func flattenedBatch(outerDimCount: Int) -> Self
+  func unflattenedBatch(outerDims: [Int]) -> Self
+}
+
+public protocol DifferentiableBatchable: Batchable, Differentiable {
+  @differentiable(wrt: self)
+  func flattenedBatch(outerDimCount: Int) -> Self
+
+  @differentiable(wrt: self)
+  func unflattenedBatch(outerDims: [Int]) -> Self
+}
+
+extension Tensor: Batchable {
+  public func flattenedBatch(outerDimCount: Int) -> Tensor {
+    if outerDimCount == 1 {
+      return self
+    }
+    var newShape = [-1]
+    for i in outerDimCount..<rank {
+      newShape.append(shape[i])
+    }
+    return reshaped(to: TensorShape(newShape))
+  }
+
+  public func unflattenedBatch(outerDims: [Int]) -> Tensor {
+    if rank > 1 {
+      return reshaped(to: TensorShape(outerDims + shape.dimensions[1...]))
+    }
+    return reshaped(to: TensorShape(outerDims))
+  }
+}
+
+extension Tensor: DifferentiableBatchable where Scalar: TensorFlowFloatingPoint {
+  @differentiable(wrt: self)
+  public func flattenedBatch(outerDimCount: Int) -> Tensor {
+    if outerDimCount == 1 {
+      return self
+    }
+    // TODO: Remove this hack once the S4TF auto-diff memory leak is fixed.
+    let newShape = Swift.withoutDerivative(at: self.shape) { shape -> [Int] in 
+      var newShape = [-1]
+      for i in outerDimCount..<shape.count {
+        newShape.append(shape[i])
+      }
+      return newShape
+    }
+    return reshaped(to: TensorShape(newShape))
+  }
+
+  @differentiable(wrt: self)
+  public func unflattenedBatch(outerDims: [Int]) -> Tensor {
+    if rank > 1 {
+      return reshaped(to: TensorShape(outerDims + shape.dimensions[1...]))
+    }
+    return reshaped(to: TensorShape(outerDims))
+  }
+}
+
+public protocol Distribution {
+  associatedtype Value
+
+  func logProbability(of value: Value) -> Tensor<Float>
+  func entropy() -> Tensor<Float>
+
+  /// Returns the mode of this distribution. If the distribution has multiple modes, then one of
+  /// them is sampled randomly (and uniformly) and returned.
+  func mode() -> Value
+
+  /// Returns a random sample drawn from this distribution.
+  func sample() -> Value
+}
+
+public extension Distribution {
+  func probability(of value: Value) -> Tensor<Float> {
+    exp(logProbability(of: value))
+  }
+}
+
+public protocol DifferentiableDistribution: Distribution, Differentiable {
+  @differentiable(wrt: self)
+  func logProbability(of value: Value) -> Tensor<Float>
+
+  @differentiable(wrt: self)
+  func entropy() -> Tensor<Float>
+}
+
+extension DifferentiableDistribution {
+  @inlinable
+  @differentiable(wrt: self)
+  public func probability(of value: Value) -> Tensor<Float> {
+    exp(logProbability(of: value))
+  }
+}
+
+public struct Categorical<Scalar: TensorFlowIndex>: DifferentiableDistribution, KeyPathIterable {
+  /// Log-probabilities of this categorical distribution.
+  public var logProbabilities: Tensor<Float>
+
+  @inlinable
+  @differentiable(wrt: logProbabilities)
+  public init(logProbabilities: Tensor<Float>) {
+    self.logProbabilities = logProbabilities
+  }
+
+  @inlinable
+  
+  @differentiable(wrt: probabilities)
+  public init(probabilities: Tensor<Float>) {
+    self.logProbabilities = log(probabilities)
+  }
+
+  @inlinable
+  @differentiable(wrt: logits)
+  public init(logits: Tensor<Float>) {
+    self.logProbabilities = logSoftmax(logits)
+  }
+
+  @inlinable
+  @differentiable(wrt: self)
+  public func logProbability(of value: Tensor<Scalar>) -> Tensor<Float> {
+    let outerDimCount = logProbabilities.rank - 1
+    return -softmaxCrossEntropy(
+      logits: logProbabilities.flattenedBatch(outerDimCount: outerDimCount),
+      labels: Tensor<Int32>(value).flattenedBatch(outerDimCount: outerDimCount)
+    ).unflattenedBatch(outerDims: [Int](logProbabilities.shape.dimensions[0..<outerDimCount]))
+  }
+
+  @inlinable
+  @differentiable(wrt: self)
+  public func entropy() -> Tensor<Float> {
+    -(logProbabilities * exp(logProbabilities)).sum(squeezingAxes: -1)
+  }
+
+  @inlinable
+  public func mode() -> Tensor<Scalar> {
+    Tensor<Scalar>(logProbabilities.argmax(squeezingAxis: 1))
+  }
+
+  @inlinable
+  public func sample() -> Tensor<Scalar> {
+    let seed = Context.local.randomSeed
+    let outerDimCount = self.logProbabilities.rank - 1
+    let logProbabilities = self.logProbabilities.flattenedBatch(outerDimCount: outerDimCount)
+    let multinomial: Tensor<Scalar> = _Raw.multinomial(
+      logits: logProbabilities,
+      numSamples: Tensor<Int32>(1),
+      seed: Int64(seed.graph),
+      seed2: Int64(seed.op))
+    let flattenedSamples = multinomial.gathering(atIndices: Tensor<Int32>(0), alongAxis: 1)
+    return flattenedSamples.unflattenedBatch(
+      outerDims: [Int](self.logProbabilities.shape.dimensions[0..<outerDimCount]))
+  }
+}

--- a/Gym/PPO/Categorical.swift
+++ b/Gym/PPO/Categorical.swift
@@ -14,6 +14,8 @@
 
 import TensorFlow
 
+// Below code comes from eaplatanios/swift-rl:
+// https://github.com/eaplatanios/swift-rl/blob/master/Sources/ReinforcementLearning/Utilities/Protocols.swift
 public protocol Batchable {
   func flattenedBatch(outerDimCount: Int) -> Self
   func unflattenedBatch(outerDims: [Int]) -> Self
@@ -69,6 +71,8 @@ extension Tensor: DifferentiableBatchable where Scalar: TensorFlowFloatingPoint 
   }
 }
 
+// Below code comes from eaplatanios/swift-rl:
+// https://github.com/eaplatanios/swift-rl/blob/master/Sources/ReinforcementLearning/Distributions/Distribution.swift
 public protocol Distribution {
   associatedtype Value
 
@@ -83,6 +87,8 @@ public protocol DifferentiableDistribution: Distribution, Differentiable {
   func entropy() -> Tensor<Float>
 }
 
+// Below code comes from eaplatanios/swift-rl:
+// https://github.com/eaplatanios/swift-rl/blob/master/Sources/ReinforcementLearning/Distributions/Categorical.swift
 public struct Categorical<Scalar: TensorFlowIndex>: DifferentiableDistribution, KeyPathIterable {
   /// Log-probabilities of this categorical distribution.
   public var logProbabilities: Tensor<Float>

--- a/Gym/PPO/Categorical.swift
+++ b/Gym/PPO/Categorical.swift
@@ -1,3 +1,17 @@
+// Copyright 2020 The TensorFlow Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 import TensorFlow
 
 public protocol Batchable {

--- a/Gym/PPO/Gathering.swift
+++ b/Gym/PPO/Gathering.swift
@@ -1,0 +1,45 @@
+
+// Copyright 2020 The TensorFlow Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+import TensorFlow
+
+extension Tensor where Scalar: TensorFlowFloatingPoint {
+  @inlinable
+  @differentiable(wrt: self)
+  public func dimensionGathering<Index: TensorFlowIndex>(
+    atIndices indices: Tensor<Index>
+  ) -> Tensor {
+    return _Raw.gatherNd(params: self, indices: indices)
+  }
+
+  /// Derivative of `_Raw.gatherNd`.
+  ///
+  /// Ported from TensorFlow Python reference implementation:
+  /// https://github.com/tensorflow/tensorflow/blob/r2.2/tensorflow/python/ops/array_grad.py#L691-L701
+  @inlinable
+  @derivative(of: dimensionGathering)
+  func _vjpDimensionGathering<Index: TensorFlowIndex>(
+    atIndices indices: Tensor<Index>
+  ) -> (value: Tensor, pullback: (Tensor) -> Tensor) {
+    let shapeTensor = Tensor<Index>(self.shapeTensor)
+    let value = _Raw.gatherNd(params: self, indices: indices)
+    return (
+      value,
+      { v in
+        let dparams = _Raw.scatterNd(indices: indices, updates: v, shape: shapeTensor)
+        return dparams
+      }
+    )
+  }
+}

--- a/Gym/PPO/Gathering.swift
+++ b/Gym/PPO/Gathering.swift
@@ -12,6 +12,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
 import TensorFlow
 
 extension Tensor where Scalar: TensorFlowFloatingPoint {

--- a/Gym/PPO/Gathering.swift
+++ b/Gym/PPO/Gathering.swift
@@ -1,4 +1,3 @@
-
 // Copyright 2020 The TensorFlow Authors. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/Gym/PPO/Memory.swift
+++ b/Gym/PPO/Memory.swift
@@ -21,7 +21,15 @@ class PPOMemory {
 
     init() {}
 
-    func clear_memory() {
+    func append(state: [Float], action: Int32, reward: Float, logProb: Float, isDone: Bool) {
+        states.append(state)
+        actions.append(action)
+        logProbs.append(logProb)
+        rewards.append(reward)
+        isDones.append(isDone)
+    }
+
+    func removeAll() {
         states.removeAll()
         actions.removeAll()
         rewards.removeAll()

--- a/Gym/PPO/Memory.swift
+++ b/Gym/PPO/Memory.swift
@@ -1,0 +1,17 @@
+class Memory {
+    var states: [[Float]] = []
+    var actions: [Int32] = []
+    var rewards: [Float] = []
+    var logProbs: [Float] = []
+    var isDones: [Bool] = []
+
+    init() {}
+
+    func clear_memory() {
+        states.removeAll()
+        actions.removeAll()
+        rewards.removeAll()
+        logProbs.removeAll()
+        isDones.removeAll()
+    }
+}

--- a/Gym/PPO/Memory.swift
+++ b/Gym/PPO/Memory.swift
@@ -12,11 +12,21 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+/// A cache saving all rollouts for batch updates.
+///
+/// PPO first collects fixed-length trajectory segments then updates weights. All the trajectory
+/// segments are discarded after the update.
 struct PPOMemory {
+    /// The states that the agent observed.
     var states: [[Float]] = []
+    /// The actions that the agent took.
     var actions: [Int32] = []
+    /// The rewards that the agent received from the environment after taking
+    /// an action.
     var rewards: [Float] = []
+    /// The log probabilities of the chosen action.
     var logProbs: [Float] = []
+    /// The episode-terminal flag that the agent received after taking an action.
     var isDones: [Bool] = []
 
     init() {}

--- a/Gym/PPO/Memory.swift
+++ b/Gym/PPO/Memory.swift
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-class PPOMemory {
+struct PPOMemory {
     var states: [[Float]] = []
     var actions: [Int32] = []
     var rewards: [Float] = []
@@ -21,7 +21,7 @@ class PPOMemory {
 
     init() {}
 
-    func append(state: [Float], action: Int32, reward: Float, logProb: Float, isDone: Bool) {
+    mutating func append(state: [Float], action: Int32, reward: Float, logProb: Float, isDone: Bool) {
         states.append(state)
         actions.append(action)
         logProbs.append(logProb)
@@ -29,7 +29,7 @@ class PPOMemory {
         isDones.append(isDone)
     }
 
-    func removeAll() {
+    mutating func removeAll() {
         states.removeAll()
         actions.removeAll()
         rewards.removeAll()

--- a/Gym/PPO/Memory.swift
+++ b/Gym/PPO/Memory.swift
@@ -1,4 +1,4 @@
-class Memory {
+class PPOMemory {
     var states: [[Float]] = []
     var actions: [Int32] = []
     var rewards: [Float] = []

--- a/Gym/PPO/Memory.swift
+++ b/Gym/PPO/Memory.swift
@@ -1,3 +1,17 @@
+// Copyright 2020 The TensorFlow Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 class PPOMemory {
     var states: [[Float]] = []
     var actions: [Int32] = []

--- a/Gym/PPO/PPO.swift
+++ b/Gym/PPO/PPO.swift
@@ -1,5 +1,6 @@
 import TensorFlow
 
+
 class PPO {
     let lr: Float
     let betas: [Float]
@@ -37,5 +38,54 @@ class PPO {
         // TODO: Implement
         var rewards: [Float] = []
         var discounted_reward: Float = 0
+        for i in (0..<memory.rewards.count).reversed() {
+            if memory.isDones[i] {
+                discounted_reward = 0
+            }
+            discounted_reward = memory.rewards[i] + (gamma * discounted_reward)
+            rewards.insert(discounted_reward, at: 0)
+        }
+        var tfRewards = Tensor<Float>(rewards)
+        tfRewards = (tfRewards - tfRewards.mean()) / (tfRewards.standardDeviation() + 1e-5)
+
+        let old_states: Tensor<Float> = Tensor<Float>(numpy: np.array(memory.states, dtype: np.float32))!
+        let old_actions: Tensor<Int32> = Tensor<Int32>(numpy: np.array(memory.actions, dtype: np.int32))!
+        let old_logprobs: Tensor<Float> = Tensor<Float>(numpy: np.array(memory.logProbs, dtype: np.float32))!
+
+        // TODO: Optimize both critic and actor
+        var net = self.actorCritic.criticNet
+        let optimizer = Adam(for: net, learningRate: lr)
+
+        for _ in 0..<K_epochs {
+            let (_, gradients) = valueWithGradient(at: net) { net -> Tensor<Float> in
+                let (logProbs, state_values, dist_entropy) = self.actorCritic.evaluate(state: old_states, action: old_actions)
+                let ratios: Tensor<Float> = exp(logProbs - old_logprobs)
+
+                let advantages: Tensor<Float> = tfRewards - state_values
+                let surr1: Tensor<Float> = ratios * advantages
+                let surr2: Tensor<Float> = ratios.clipped(min:1 - self.eps_clip, max: 1 + self.eps_clip) * advantages
+                // TODO(seungjaeryanlee): Find how to find minimum
+                // let loss1: PythonObject =  -1 * np.minimum(surr1.makeNumpyArray(), surr2.makeNumpyArray())
+                let loss1: Tensor<Float> = 0 * surr1 + -1 * surr2
+                let loss2: Tensor<Float> = 0.5 * pow(state_values - tfRewards, 2)
+                let loss3: Tensor<Float> = Tensor<Float>(-0.01 * dist_entropy)
+                let loss: Tensor<Float> = loss1 + loss2 + loss3
+
+                return loss.mean()
+            }
+            // TODO: Fix gradients all being zero
+            // print(loss)
+            // print(gradients)
+
+            optimizer.update(&net, along: gradients)
+        }
+        self.oldActorCritic.criticNet.l1.weight = self.actorCritic.criticNet.l1.weight
+        self.oldActorCritic.criticNet.l1.bias = self.actorCritic.criticNet.l1.bias
+        self.oldActorCritic.criticNet.l2.weight = self.actorCritic.criticNet.l2.weight
+        self.oldActorCritic.criticNet.l2.bias = self.actorCritic.criticNet.l2.bias
+        self.oldActorCritic.actorNet.l1.weight = self.actorCritic.actorNet.l1.weight
+        self.oldActorCritic.actorNet.l1.bias = self.actorCritic.actorNet.l1.bias
+        self.oldActorCritic.actorNet.l2.weight = self.actorCritic.actorNet.l2.weight
+        self.oldActorCritic.actorNet.l2.bias = self.actorCritic.actorNet.l2.bias
     }
 }

--- a/Gym/PPO/PPO.swift
+++ b/Gym/PPO/PPO.swift
@@ -1,0 +1,41 @@
+import TensorFlow
+
+class PPO {
+    let lr: Float
+    let betas: [Float]
+    let gamma: Float
+    let K_epochs: Int
+    let eps_clip: Float
+    var actorCritic: ActorCritic
+    var oldActorCritic: ActorCritic
+    var actorOptimizer: Adam<ActorNet>
+    var criticOptimizer: Adam<CriticNet>
+
+    init(observationSize: Int, hiddenSize: Int, actionCount: Int, lr: Float, betas: [Float], gamma: Float, K_epochs: Int, eps_clip: Float) {
+        self.lr = lr
+        self.betas = betas
+        self.gamma = gamma
+        self.K_epochs = K_epochs
+        self.eps_clip = eps_clip
+
+        self.actorCritic = ActorCritic(
+            observationSize: observationSize,
+            hiddenSize: hiddenSize,
+            actionCount: actionCount
+        )
+        self.oldActorCritic = ActorCritic(
+            observationSize: observationSize,
+            hiddenSize: hiddenSize,
+            actionCount: actionCount
+        )
+        // TODO: Copy actorCritic to oldActorCritic
+        self.actorOptimizer = Adam(for: actorCritic.actorNet, learningRate: lr)
+        self.criticOptimizer = Adam(for: actorCritic.criticNet, learningRate: lr)
+    }
+
+    func update(memory: Memory) {
+        // TODO: Implement
+        var rewards: [Float] = []
+        var discounted_reward: Float = 0
+    }
+}

--- a/Gym/PPO/PPO.swift
+++ b/Gym/PPO/PPO.swift
@@ -1,5 +1,18 @@
-import TensorFlow
+// Copyright 2020 The TensorFlow Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
+import TensorFlow
 
 class PPOAgent {
     let learningRate: Float

--- a/Gym/PPO/PPO.swift
+++ b/Gym/PPO/PPO.swift
@@ -97,7 +97,8 @@ class PPO {
                 let surrogateObjective1: Tensor<Float> = ratios * advantages
                 let surrogateObjective2: Tensor<Float> = ratios.clipped(min:1 - self.eps_clip, max: 1 + self.eps_clip) * advantages
                 let mainObjective = -1 * Tensor(stacking: [surrogateObjective1, surrogateObjective2]).min(alongAxes: 0).flattened()
-                let entropyBonus: Tensor<Float> = -0.01 * Tensor<Float>(dist.entropy())
+                // TODO(seungjaeryanlee): Magic number move to main.swift
+                let entropyBonus: Tensor<Float> = -0.0001 * Tensor<Float>(dist.entropy())
                 let loss: Tensor<Float> = mainObjective + entropyBonus
 
                 return loss.mean()

--- a/Gym/PPO/PPO.swift
+++ b/Gym/PPO/PPO.swift
@@ -76,7 +76,7 @@ class PPOAgent {
         self.oldActorCritic.actorNetwork.l3.bias = self.actorCritic.actorNetwork.l3.bias
     }
 
-    func update(memory: PPOMemory) {
+    func update(memory: inout PPOMemory) {
         // Discount rewards for advantage estimation
         var rewards: [Float] = []
         var discountedReward: Float = 0

--- a/Gym/PPO/PPO.swift
+++ b/Gym/PPO/PPO.swift
@@ -89,11 +89,9 @@ class PPO {
                 let advantages: Tensor<Float> = tfRewards - state_values
                 let surr1: Tensor<Float> = ratios * advantages
                 let surr2: Tensor<Float> = ratios.clipped(min:1 - self.eps_clip, max: 1 + self.eps_clip) * advantages
-                // TODO (seungjaeryanlee): Find how to find minimum
-                // let loss1: PythonObject =  -1 * np.minimum(surr1.makeNumpyArray(), surr2.makeNumpyArray())
-                let loss1: Tensor<Float> = 0 * surr1 + -1 * surr2
+                let loss1 = -1 * Tensor(stacking: [surr1, surr2]).min(alongAxes: 0).flattened()
                 let loss2: Tensor<Float> = 0.5 * pow(state_values - tfRewards, 2)
-                let loss3: Tensor<Float> = Tensor<Float>(-0.01 * dist_entropy)
+                let loss3: Tensor<Float> = -0.01 * Tensor<Float>(dist_entropy)
                 let loss: Tensor<Float> = loss1 + loss2 + loss3
 
                 return loss.mean()

--- a/Gym/PPO/main.swift
+++ b/Gym/PPO/main.swift
@@ -73,7 +73,7 @@ var agent: PPOAgent = PPOAgent(
 var timestep: Int = 0
 var episodeReturn: Float = 0
 var episodeReturns: [Float] = []
-var averageReturn: Float = 0
+var maxEpisodeReturn: Float = -1
 for episodeIndex in 1..<maxEpisodes+1 {
     var state = env.reset()
     for _ in 0..<maxTimesteps {
@@ -97,10 +97,13 @@ for episodeIndex in 1..<maxEpisodes+1 {
             timestep = 0
         }
 
-        averageReturn += Float(reward)!
         episodeReturn += Float(reward)!
         if Bool(done)! == true {
             episodeReturns.append(episodeReturn)
+            if maxEpisodeReturn < episodeReturn {
+                maxEpisodeReturn = episodeReturn
+                print(String(format: "Episode: %4d | Return: %6.2f", episodeIndex, episodeReturn))
+            }
             episodeReturn = 0
             break
         }
@@ -108,12 +111,9 @@ for episodeIndex in 1..<maxEpisodes+1 {
         state = newState
     }
 
-    if episodeIndex % logInterval == 0 {
-        averageReturn = Float(averageReturn) / Float(logInterval)
-        print(String(format: "Episode: %4d | Average Return: %6.2f", episodeIndex, averageReturn))
-    }
-
-    if Float(averageReturn) > (Float(logInterval) * Float(solvedReward)) {
+    // Break when CartPole is solved for 10 consecutive episodes
+    if episodeReturns.suffix(10).reduce(0, +) == 200 * 10 {
+        print(String(format: "Solved in %d episodes!", episodeIndex))
         break
     }
 }
@@ -123,5 +123,6 @@ plt.plot(episodeReturns)
 plt.title("Proximal Policy Optimization on CartPole-v0")
 plt.xlabel("Episode")
 plt.ylabel("Episode Return")
+// TODO: Save figure to /tmp/
 plt.savefig("ppoEpisodeReturns.png")
 plt.clf()

--- a/Gym/PPO/main.swift
+++ b/Gym/PPO/main.swift
@@ -27,12 +27,13 @@ let actionCount: Int = Int(env.action_space.n)!
 // Network HP
 let hiddenSize: Int = 128
 // Optimizer HP
-let lr: Float = 0.0003
+let learningRate: Float = 0.0003
 // TODO(seungjaeryanlee): Not used
 let betas: [Float] = [0.9, 0.999]
 let gamma: Float = 0.99
-let K_epochs: Int = 10
-let eps_clip: Float = 0.1
+let epochs: Int = 10
+let clipEpsilon: Float = 0.1
+let entropyCoefficient: Float = 0.0001
 // Interaction
 let maxEpisodes: Int = 1000
 let maxTimesteps: Int = 200
@@ -41,70 +42,58 @@ let updateTimestep: Int = 1000
 let logInterval: Int = 20
 let solvedReward: Float = 199
 
-var memory: Memory = Memory()
-var ppo = PPO(
+var memory: PPOMemory = PPOMemory()
+var agent: PPOAgent = PPOAgent(
     observationSize: observationSize,
     hiddenSize: hiddenSize,
     actionCount: actionCount,
-    lr: lr,
+    learningRate: learningRate,
     betas: betas,
     gamma: gamma,
-    K_epochs: K_epochs,
-    eps_clip: eps_clip
+    epochs: epochs,
+    clipEpsilon: clipEpsilon,
+    entropyCoefficient: entropyCoefficient
 )
 
 // Training loop
 var timestep: Int = 0
-var runningReward: Float = 0
-var averageLength: Float = 0
 var episodeReturn: Float = 0
 var episodeReturns: [Float] = []
-var bestEpisodeReturn: Float = 0
+var averageReturn: Float = 0
 for episodeIndex in 1..<maxEpisodes+1 {
     var state = env.reset()
-    var t: Int = 1
     for _ in 0..<maxTimesteps {
         timestep += 1
         let tfState = Tensor<Float>(numpy: np.array(state, dtype: np.float32))!
-        let action: Int32 = ppo.oldActorCritic.act(state: tfState, memory: memory)
+        let action: Int32 = agent.oldActorCritic.act(state: tfState, memory: memory)
         let (newState, reward, done, _) = env.step(action).tuple4
         memory.rewards.append(Float(reward)!)
         memory.isDones.append(Bool(done)!)
 
         if timestep % updateTimestep == 0 {
-            ppo.update(memory: memory)
+            agent.update(memory: memory)
             memory.clear_memory()
             timestep = 0
         }
 
-        runningReward += Float(reward)!
+        averageReturn += Float(reward)!
         episodeReturn += Float(reward)!
         if Bool(done)! == true {
-            if bestEpisodeReturn < episodeReturn {
-                print("Return: \(episodeReturn)")
-                bestEpisodeReturn = episodeReturn
-            }
             episodeReturns.append(episodeReturn)
             episodeReturn = 0
             break
         }
 
-        t += 1
         state = newState
     }
 
-    averageLength += Float(t)
-
-    if Float(runningReward) > (Float(logInterval) * Float(solvedReward)) {
-        print("########## Solved! ##########")
-        break
+    if episodeIndex % logInterval == 0 {
+        averageReturn = Float(averageReturn) / Float(logInterval)
+        print(String(format: "Episode: %4d | Average Return: %6.2f", episodeIndex, averageReturn))
     }
 
-    if episodeIndex % logInterval == 0 {
-        averageLength = Float(averageLength) / Float(logInterval)
-        runningReward = Float(runningReward) / Float(logInterval)
-
-        print(String(format: "Episode: %4d | Average Length %5.2f | Running Reward: %5.2f", episodeIndex, averageLength, runningReward))
+    if Float(averageReturn) > (Float(logInterval) * Float(solvedReward)) {
+        break
     }
 }
 

--- a/Gym/PPO/main.swift
+++ b/Gym/PPO/main.swift
@@ -93,7 +93,7 @@ for episodeIndex in 1..<maxEpisodes+1 {
         )
 
         if timestep % updateTimestep == 0 {
-            agent.update(memory: memory)
+            agent.update(memory: &memory)
             memory.removeAll()
             timestep = 0
         }

--- a/Gym/PPO/main.swift
+++ b/Gym/PPO/main.swift
@@ -82,23 +82,24 @@ for episodeIndex in 1..<maxEpisodes+1 {
         let dist: Categorical<Int32> = agent.oldActorCritic(tfState)
         let action: Int32 = dist.sample().scalarized()
         let logProb: Float = Float(dist.logProbabilities.makeNumpyArray()[action])!
-        let (newState, reward, done, _) = env.step(action).tuple4
+        let (newState, reward, isDone, _) = env.step(action).tuple4
 
-        let convertedStates: [Float] = Array(numpy: tfState.makeNumpyArray().flatten())!
-        memory.states.append(convertedStates)
-        memory.actions.append(action)
-        memory.logProbs.append(logProb)
-        memory.rewards.append(Float(reward)!)
-        memory.isDones.append(Bool(done)!)
+        memory.append(
+            state: Array(numpy: tfState.makeNumpyArray().flatten())!,
+            action: action,
+            reward: Float(reward)!,
+            logProb: logProb,
+            isDone: Bool(isDone)!
+        )
 
         if timestep % updateTimestep == 0 {
             agent.update(memory: memory)
-            memory.clear_memory()
+            memory.removeAll()
             timestep = 0
         }
 
         episodeReturn += Float(reward)!
-        if Bool(done)! == true {
+        if Bool(isDone)! == true {
             episodeReturns.append(episodeReturn)
             if maxEpisodeReturn < episodeReturn {
                 maxEpisodeReturn = episodeReturn

--- a/Gym/PPO/main.swift
+++ b/Gym/PPO/main.swift
@@ -44,7 +44,7 @@ let hiddenSize: Int = 128
 let learningRate: Float = 0.0003
 // TODO(seungjaeryanlee): Not used
 let betas: [Float] = [0.9, 0.999]
-let gamma: Float = 0.99
+let discount: Float = 0.99
 let epochs: Int = 10
 let clipEpsilon: Float = 0.1
 let entropyCoefficient: Float = 0.0001

--- a/Gym/PPO/main.swift
+++ b/Gym/PPO/main.swift
@@ -85,7 +85,7 @@ for episodeIndex in 1..<maxEpisodes+1 {
         let (newState, reward, isDone, _) = env.step(action).tuple4
 
         memory.append(
-            state: Array(numpy: tfState.makeNumpyArray().flatten())!,
+            state: Array(state)!,
             action: action,
             reward: Float(reward)!,
             logProb: logProb,

--- a/Gym/PPO/main.swift
+++ b/Gym/PPO/main.swift
@@ -91,7 +91,7 @@ for episodeIndex in 1..<maxEpisodes+1 {
         let tfState: Tensor<Float> = Tensor<Float>(numpy: np.array(state, dtype: np.float32))!
         let dist: Categorical<Int32> = agent.oldActorCritic(tfState)
         let action: Int32 = dist.sample().scalarized()
-        let logProb: Float = Float(dist.logProbabilities.makeNumpyArray()[action])!
+        let logProb: Float = dist.logProbabilities[Int(action)].scalarized()
         let (newState, reward, isDone, _) = env.step(action).tuple4
 
         memory.append(
@@ -109,7 +109,7 @@ for episodeIndex in 1..<maxEpisodes+1 {
         }
 
         episodeReturn += Float(reward)!
-        if Bool(isDone)! == true {
+        if Bool(isDone)! {
             episodeReturns.append(episodeReturn)
             if maxEpisodeReturn < episodeReturn {
                 maxEpisodeReturn = episodeReturn

--- a/Gym/PPO/main.swift
+++ b/Gym/PPO/main.swift
@@ -25,17 +25,18 @@ let actionCount: Int = Int(env.action_space.n)!
 
 // Hyperparameters
 // Network HP
-let hiddenSize: Int = 64
+let hiddenSize: Int = 128
 // Optimizer HP
-let lr: Float = 0.002
+let lr: Float = 0.0003
+// TODO(seungjaeryanlee): Not used
 let betas: [Float] = [0.9, 0.999]
 let gamma: Float = 0.99
-let K_epochs: Int = 4
-let eps_clip: Float = 0.2
+let K_epochs: Int = 10
+let eps_clip: Float = 0.1
 // Interaction
-let maxEpisodes: Int = 500
-let maxTimesteps: Int = 300
-let updateTimestep: Int = 2000
+let maxEpisodes: Int = 1000
+let maxTimesteps: Int = 200
+let updateTimestep: Int = 1000
 // Log
 let logInterval: Int = 20
 let solvedReward: Float = 199

--- a/Gym/PPO/main.swift
+++ b/Gym/PPO/main.swift
@@ -1,0 +1,94 @@
+import PythonKit
+import TensorFlow
+
+// Force unwrapping with `!` does not provide source location when unwrapping `nil`, so we instead
+// make a utility function for debuggability.
+fileprivate extension Optional {
+    func unwrapped(file: StaticString = #filePath, line: UInt = #line) -> Wrapped {
+        guard let unwrapped = self else {
+            fatalError("Value is nil", file: (file), line: line)
+        }
+        return unwrapped
+    }
+}
+
+// Initialize Python. This comment is a hook for internal use, do not remove.
+
+let np = Python.import("numpy")
+let gym = Python.import("gym")
+
+
+let env = gym.make("CartPole-v0")
+let observationSize: Int = Int(env.observation_space.shape[0])!
+let actionCount: Int = Int(env.action_space.n)!
+
+// Hyperparameters
+// Network HP
+let hiddenSize: Int = 64
+// Optimizer HP
+let lr: Float = 0.002
+let betas: [Float] = [0.9, 0.999]
+let gamma: Float = 0.99
+let K_epochs: Int = 4
+let eps_clip: Float = 0.2
+// Interaction
+let max_episodes: Int = 500
+let max_timesteps: Int = 300
+let update_timestep: Int = 2000
+// Log
+let log_interval: Int = 20
+let solved_reward: Float = 199
+
+var memory: Memory = Memory()
+var ppo = PPO(
+    observationSize: observationSize,
+    hiddenSize: hiddenSize,
+    actionCount: actionCount,
+    lr: lr,
+    betas: betas,
+    gamma: gamma,
+    K_epochs: K_epochs,
+    eps_clip: eps_clip
+)
+
+// Training loop
+var timestep: Int = 0
+var running_reward: Float = 0
+var avg_length: Float = 0
+for i_episode in 1..<max_episodes+1 {
+    var state = env.reset()
+    var t: Int = 0
+    for t in 0..<max_timesteps {
+        timestep += 1
+        let action: Int32 = ppo.oldActorCritic.act(state: Tensor<Float>(numpy: np.array(state, dtype: np.float32))!, memory: memory)
+        var (state, reward, done, _) = env.step(action).tuple4
+
+        memory.rewards.append(Float(reward)!)
+        memory.isDones.append(Bool(done)!)
+
+        if timestep % update_timestep == 0 {
+            ppo.update(memory: memory)
+            memory.clear_memory()
+            timestep = 0
+        }
+
+        running_reward += Float(reward)!
+        if Bool(done)! == true {
+            break
+        }
+    }
+
+    avg_length += Float(t)
+
+    if Float(running_reward) > (Float(log_interval) * Float(solved_reward)) {
+        print("########## Solved! ##########")
+        break
+    }
+
+    if i_episode % log_interval == 0 {
+        avg_length = Float(avg_length) / Float(log_interval)
+        running_reward = Float(running_reward) / Float(log_interval)
+
+        print(String(format: "Episode: %4d | Average Length %5.2f | Running Reward: %5.2f", i_episode, avg_length, running_reward))
+    }
+}

--- a/Gym/PPO/main.swift
+++ b/Gym/PPO/main.swift
@@ -78,8 +78,10 @@ for episodeIndex in 1..<maxEpisodes+1 {
     var state = env.reset()
     for _ in 0..<maxTimesteps {
         timestep += 1
-        let tfState = Tensor<Float>(numpy: np.array(state, dtype: np.float32))!
-        let (action, logProb) = agent.oldActorCritic.act(state: tfState)
+        let tfState: Tensor<Float> = Tensor<Float>(numpy: np.array(state, dtype: np.float32))!
+        let dist: Categorical<Int32> = agent.oldActorCritic(tfState)
+        let action: Int32 = dist.sample().scalarized()
+        let logProb: Float = Float(dist.logProbabilities.makeNumpyArray()[action])!
         let (newState, reward, done, _) = env.step(action).tuple4
 
         let convertedStates: [Float] = Array(numpy: tfState.makeNumpyArray().flatten())!

--- a/Gym/PPO/main.swift
+++ b/Gym/PPO/main.swift
@@ -1,3 +1,17 @@
+// Copyright 2020 The TensorFlow Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 import PythonKit
 import TensorFlow
 

--- a/Gym/PPO/main.swift
+++ b/Gym/PPO/main.swift
@@ -38,23 +38,34 @@ let observationSize: Int = Int(env.observation_space.shape[0])!
 let actionCount: Int = Int(env.action_space.n)!
 
 // Hyperparameters
-// Network HP
+/// The size of the hidden layer of the 2-layer actor network and critic network. The actor network
+/// has the shape observationSize - hiddenSize - actionCount, and the critic network has the same
+/// shape but with a single output node.
 let hiddenSize: Int = 128
-// Optimizer HP
+/// The learning rate for both the actor and the critic.
 let learningRate: Float = 0.0003
-// TODO(seungjaeryanlee): Not used
-let betas: [Float] = [0.9, 0.999]
+/// The discount factor. This measures how much to "discount" the future rewards
+/// that the agent will receive. The discount factor must be from 0 to 1
+/// (inclusive). Discount factor of 0 means that the agent only considers the
+/// immediate reward and disregards all future rewards. Discount factor of 1
+/// means that the agent values all rewards equally, no matter how distant
+/// in the future they may be. Denoted gamma in the PPO paper.
 let discount: Float = 0.99
+/// Number of epochs to run minibatch updates once enough trajectory segments are collected. Denoted
+/// K in the PPO paper.
 let epochs: Int = 10
+/// Parameter to clip the probability ratio. The ratio is clipped to [1-clipEpsilon, 1+clipEpsilon].
+/// Denoted epsilon in the PPO paper.
 let clipEpsilon: Float = 0.1
+/// Coefficient for the entropy bonus added to the objective. Denoted c_2 in the PPO paper.
 let entropyCoefficient: Float = 0.0001
-// Interaction
+/// Maximum number of episodes to train the agent. The training is terminated
+/// early if maximum score is achieved consecutively 10 times.
 let maxEpisodes: Int = 1000
+/// Maximum timestep per episode.
 let maxTimesteps: Int = 200
+/// The length of the trajectory segment. Denoted T in the PPO paper.
 let updateTimestep: Int = 1000
-// Log
-let logInterval: Int = 20
-let solvedReward: Float = 199
 
 var memory: PPOMemory = PPOMemory()
 var agent: PPOAgent = PPOAgent(
@@ -62,8 +73,7 @@ var agent: PPOAgent = PPOAgent(
     hiddenSize: hiddenSize,
     actionCount: actionCount,
     learningRate: learningRate,
-    betas: betas,
-    gamma: gamma,
+    discount: discount,
     epochs: epochs,
     clipEpsilon: clipEpsilon,
     entropyCoefficient: entropyCoefficient

--- a/Gym/PPO/main.swift
+++ b/Gym/PPO/main.swift
@@ -67,7 +67,6 @@ let maxTimesteps: Int = 200
 /// The length of the trajectory segment. Denoted T in the PPO paper.
 let updateTimestep: Int = 1000
 
-var memory: PPOMemory = PPOMemory()
 var agent: PPOAgent = PPOAgent(
     observationSize: observationSize,
     hiddenSize: hiddenSize,
@@ -94,7 +93,7 @@ for episodeIndex in 1..<maxEpisodes+1 {
         let logProb: Float = dist.logProbabilities[Int(action)].scalarized()
         let (newState, reward, isDone, _) = env.step(action).tuple4
 
-        memory.append(
+        agent.memory.append(
             state: Array(state)!,
             action: action,
             reward: Float(reward)!,
@@ -103,8 +102,7 @@ for episodeIndex in 1..<maxEpisodes+1 {
         )
 
         if timestep % updateTimestep == 0 {
-            agent.update(memory: &memory)
-            memory.removeAll()
+            agent.update()
             timestep = 0
         }
 

--- a/Gym/PPO/main.swift
+++ b/Gym/PPO/main.swift
@@ -57,8 +57,8 @@ var running_reward: Float = 0
 var avg_length: Float = 0
 for i_episode in 1..<max_episodes+1 {
     var state = env.reset()
-    var t: Int = 0
-    for t in 0..<max_timesteps {
+    var t: Int = 1
+    for _ in 0..<max_timesteps {
         timestep += 1
         let action: Int32 = ppo.oldActorCritic.act(state: Tensor<Float>(numpy: np.array(state, dtype: np.float32))!, memory: memory)
         var (state, reward, done, _) = env.step(action).tuple4
@@ -76,6 +76,8 @@ for i_episode in 1..<max_episodes+1 {
         if Bool(done)! == true {
             break
         }
+
+        t += 1
     }
 
     avg_length += Float(t)

--- a/Gym/PPO/main.swift
+++ b/Gym/PPO/main.swift
@@ -79,8 +79,13 @@ for episodeIndex in 1..<maxEpisodes+1 {
     for _ in 0..<maxTimesteps {
         timestep += 1
         let tfState = Tensor<Float>(numpy: np.array(state, dtype: np.float32))!
-        let action: Int32 = agent.oldActorCritic.act(state: tfState, memory: memory)
+        let (action, logProb) = agent.oldActorCritic.act(state: tfState)
         let (newState, reward, done, _) = env.step(action).tuple4
+
+        let convertedStates: [Float] = Array(numpy: tfState.makeNumpyArray().flatten())!
+        memory.states.append(convertedStates)
+        memory.actions.append(action)
+        memory.logProbs.append(logProb)
         memory.rewards.append(Float(reward)!)
         memory.isDones.append(Bool(done)!)
 

--- a/Gym/PPO/main.swift
+++ b/Gym/PPO/main.swift
@@ -134,6 +134,5 @@ plt.plot(episodeReturns)
 plt.title("Proximal Policy Optimization on CartPole-v0")
 plt.xlabel("Episode")
 plt.ylabel("Episode Return")
-// TODO: Save figure to /tmp/
-plt.savefig("ppoEpisodeReturns.png")
+plt.savefig("/tmp/ppoEpisodeReturns.png")
 plt.clf()

--- a/Gym/PPO/main.swift
+++ b/Gym/PPO/main.swift
@@ -16,6 +16,7 @@ fileprivate extension Optional {
 
 let np = Python.import("numpy")
 let gym = Python.import("gym")
+let plt = Python.import("matplotlib.pyplot")
 
 
 let env = gym.make("CartPole-v0")
@@ -55,6 +56,9 @@ var ppo = PPO(
 var timestep: Int = 0
 var runningReward: Float = 0
 var averageLength: Float = 0
+var episodeReturn: Float = 0
+var episodeReturns: [Float] = []
+var bestEpisodeReturn: Float = 0
 for episodeIndex in 1..<maxEpisodes+1 {
     var state = env.reset()
     var t: Int = 1
@@ -73,7 +77,14 @@ for episodeIndex in 1..<maxEpisodes+1 {
         }
 
         runningReward += Float(reward)!
+        episodeReturn += Float(reward)!
         if Bool(done)! == true {
+            if bestEpisodeReturn < episodeReturn {
+                print("Return: \(episodeReturn)")
+                bestEpisodeReturn = episodeReturn
+            }
+            episodeReturns.append(episodeReturn)
+            episodeReturn = 0
             break
         }
 
@@ -95,3 +106,11 @@ for episodeIndex in 1..<maxEpisodes+1 {
         print(String(format: "Episode: %4d | Average Length %5.2f | Running Reward: %5.2f", episodeIndex, averageLength, runningReward))
     }
 }
+
+// Save learning curve
+plt.plot(episodeReturns)
+plt.title("Proximal Policy Optimization on CartPole-v0")
+plt.xlabel("Episode")
+plt.ylabel("Episode Return")
+plt.savefig("ppoEpisodeReturns.png")
+plt.clf()

--- a/Package.swift
+++ b/Package.swift
@@ -53,6 +53,7 @@ let package = Package(
         .target(name: "Gym-FrozenLake", path: "Gym/FrozenLake"),
         .target(name: "Gym-CartPole", path: "Gym/CartPole"),
         .target(name: "Gym-Blackjack", path: "Gym/Blackjack"),
+        .target(name: "Gym-PPO", path: "Gym/PPO"),
         .target(
             name: "VGG-Imagewoof",
             dependencies: ["Datasets", "ImageClassificationModels", "TrainingLoop"],


### PR DESCRIPTION
Like DQN (PR #617), Proximal Policy Optimization (PPO) is another widely used reinforcement learning algorithm. Proposed by [Schulman et al. in 2017](https://github.com/tensorflow/swift-models/pull/617), PPO is an on-policy policy gradient algorithm that serves as a standard baselines for both environments with discrete and continuous action spaces.

There are two versions of PPO: PPO-Clip and PPO-Penalty. This code implements PPO-Clip, the more popular version.

## TODO

- [x] Fix existing issues
  - [x] Optimize both `actorNet` and `criticNet`
  - [x] Compute `loss1` using the the minimum of surrogate losses `surr1` and `surr2`
  - [x] Fix gradients not being computed correctly and set to zero
- [x] Find hyperparameters with consistent performance on CartPole
  - ~If performance is subpar, will implement [GAE](https://arxiv.org/abs/1506.02438)~
- [x] Refactor and document code
  - [x] Refactor the `Categorical` distribution from swift-rl
  - [x] Add documentation comments for hyperparameters
  - [x] Add documentation comments for structs and classes
    - [x] PPOMemory
    - [x] ActorNetwork
    - [x] CriticNetwork
    - [x] ActorCritic
    - [x] PPOAgent