### PR TITLE
[Models/ImageClassification] For transfer learning, apply @_Freezable property wrapper on all Layer conforming properties

### DIFF
--- a/Models/ImageClassification/DenseNet121.swift
+++ b/Models/ImageClassification/DenseNet121.swift
@@ -20,7 +20,7 @@ import TensorFlow
 // https://arxiv.org/pdf/1608.06993.pdf
 
 public struct DenseNet121: Layer {
-    public var conv = Conv(
+    @_Freezable public var conv = Conv(
         filterSize: 7,
         stride: 2,
         inputFilterCount: 3,
@@ -31,15 +31,15 @@ public struct DenseNet121: Layer {
         strides: (2, 2),
         padding: .same
     )
-    public var denseBlock1 = DenseBlock(repetitionCount: 6, inputFilterCount: 64)
-    public var transitionLayer1 = TransitionLayer(inputFilterCount: 256)
-    public var denseBlock2 = DenseBlock(repetitionCount: 12, inputFilterCount: 128)
-    public var transitionLayer2 = TransitionLayer(inputFilterCount: 512)
-    public var denseBlock3 = DenseBlock(repetitionCount: 24, inputFilterCount: 256)
-    public var transitionLayer3 = TransitionLayer(inputFilterCount: 1024)
-    public var denseBlock4 = DenseBlock(repetitionCount: 16, inputFilterCount: 512)
+    @_Freezable public var denseBlock1 = DenseBlock(repetitionCount: 6, inputFilterCount: 64)
+    @_Freezable public var transitionLayer1 = TransitionLayer(inputFilterCount: 256)
+    @_Freezable public var denseBlock2 = DenseBlock(repetitionCount: 12, inputFilterCount: 128)
+    @_Freezable public var transitionLayer2 = TransitionLayer(inputFilterCount: 512)
+    @_Freezable public var denseBlock3 = DenseBlock(repetitionCount: 24, inputFilterCount: 256)
+    @_Freezable public var transitionLayer3 = TransitionLayer(inputFilterCount: 1024)
+    @_Freezable public var denseBlock4 = DenseBlock(repetitionCount: 16, inputFilterCount: 512)
     public var globalAvgPool = GlobalAvgPool2D<Float>()
-    public var dense: Dense<Float>
+    @_Freezable public var dense: Dense<Float>
 
     public init(classCount: Int) {
         dense = Dense(inputSize: 1024, outputSize: classCount)

--- a/Models/ImageClassification/EfficientNet.swift
+++ b/Models/ImageClassification/EfficientNet.swift
@@ -206,22 +206,22 @@ struct MBConvBlockStack: Layer {
 
 public struct EfficientNet: Layer {
     @noDerivative let zeroPad = ZeroPadding2D<Float>(padding: ((0, 1), (0, 1)))
-    var inputConv: Conv2D<Float>
+    @_Freezable var inputConv: Conv2D<Float>
     var inputConvBatchNorm: BatchNorm<Float>
-    var initialMBConv: InitialMBConvBlock
+    @_Freezable var initialMBConv: InitialMBConvBlock
 
-    var residualBlockStack1: MBConvBlockStack
-    var residualBlockStack2: MBConvBlockStack
-    var residualBlockStack3: MBConvBlockStack
-    var residualBlockStack4: MBConvBlockStack
-    var residualBlockStack5: MBConvBlockStack
-    var residualBlockStack6: MBConvBlockStack
+    @_Freezable var residualBlockStack1: MBConvBlockStack
+    @_Freezable var residualBlockStack2: MBConvBlockStack
+    @_Freezable var residualBlockStack3: MBConvBlockStack
+    @_Freezable var residualBlockStack4: MBConvBlockStack
+    @_Freezable var residualBlockStack5: MBConvBlockStack
+    @_Freezable var residualBlockStack6: MBConvBlockStack
 
-    var outputConv: Conv2D<Float>
+    @_Freezable var outputConv: Conv2D<Float>
     var outputConvBatchNorm: BatchNorm<Float>
     var avgPool = GlobalAvgPool2D<Float>()
     var dropoutProb: Dropout<Float>
-    var outputClassifier: Dense<Float>
+    @_Freezable var outputClassifier: Dense<Float>
 
     /// default settings are efficientnetB0 (baseline) network
     /// resolution is here to show what the network can take as input, it doesn't set anything!

--- a/Models/ImageClassification/LeNet-5.swift
+++ b/Models/ImageClassification/LeNet-5.swift
@@ -23,14 +23,14 @@ import TensorFlow
 // Additionally, ReLU is used instead of sigmoid activations.
 
 public struct LeNet: Layer {
-    public var conv1 = Conv2D<Float>(filterShape: (5, 5, 1, 6), padding: .same, activation: relu)
+    @_Freezable public var conv1 = Conv2D<Float>(filterShape: (5, 5, 1, 6), padding: .same, activation: relu)
     public var pool1 = AvgPool2D<Float>(poolSize: (2, 2), strides: (2, 2))
-    public var conv2 = Conv2D<Float>(filterShape: (5, 5, 6, 16), activation: relu)
+    @_Freezable public var conv2 = Conv2D<Float>(filterShape: (5, 5, 6, 16), activation: relu)
     public var pool2 = AvgPool2D<Float>(poolSize: (2, 2), strides: (2, 2))
     public var flatten = Flatten<Float>()
-    public var fc1 = Dense<Float>(inputSize: 400, outputSize: 120, activation: relu)
-    public var fc2 = Dense<Float>(inputSize: 120, outputSize: 84, activation: relu)
-    public var fc3 = Dense<Float>(inputSize: 84, outputSize: 10)
+    @_Freezable public var fc1 = Dense<Float>(inputSize: 400, outputSize: 120, activation: relu)
+    @_Freezable public var fc2 = Dense<Float>(inputSize: 120, outputSize: 84, activation: relu)
+    @_Freezable public var fc3 = Dense<Float>(inputSize: 84, outputSize: 10)
 
     public init() {}
 

--- a/Models/ImageClassification/MobileNetV1.swift
+++ b/Models/ImageClassification/MobileNetV1.swift
@@ -102,23 +102,23 @@ public struct MobileNetV1: Layer {
     @noDerivative let classCount: Int
     @noDerivative let scaledFilterShape: Int
 
-    public var convBlock1: ConvBlock
-    public var dConvBlock1: DepthwiseConvBlock
-    public var dConvBlock2: DepthwiseConvBlock
-    public var dConvBlock3: DepthwiseConvBlock
-    public var dConvBlock4: DepthwiseConvBlock
-    public var dConvBlock5: DepthwiseConvBlock
-    public var dConvBlock6: DepthwiseConvBlock
-    public var dConvBlock7: DepthwiseConvBlock
-    public var dConvBlock8: DepthwiseConvBlock
-    public var dConvBlock9: DepthwiseConvBlock
-    public var dConvBlock10: DepthwiseConvBlock
-    public var dConvBlock11: DepthwiseConvBlock
-    public var dConvBlock12: DepthwiseConvBlock
-    public var dConvBlock13: DepthwiseConvBlock
+    @_Freezable public var convBlock1: ConvBlock
+    @_Freezable public var dConvBlock1: DepthwiseConvBlock
+    @_Freezable public var dConvBlock2: DepthwiseConvBlock
+    @_Freezable public var dConvBlock3: DepthwiseConvBlock
+    @_Freezable public var dConvBlock4: DepthwiseConvBlock
+    @_Freezable public var dConvBlock5: DepthwiseConvBlock
+    @_Freezable public var dConvBlock6: DepthwiseConvBlock
+    @_Freezable public var dConvBlock7: DepthwiseConvBlock
+    @_Freezable public var dConvBlock8: DepthwiseConvBlock
+    @_Freezable public var dConvBlock9: DepthwiseConvBlock
+    @_Freezable public var dConvBlock10: DepthwiseConvBlock
+    @_Freezable public var dConvBlock11: DepthwiseConvBlock
+    @_Freezable public var dConvBlock12: DepthwiseConvBlock
+    @_Freezable public var dConvBlock13: DepthwiseConvBlock
     public var avgPool = GlobalAvgPool2D<Float>()
     public var dropoutLayer: Dropout<Float>
-    public var convLast: Conv2D<Float>
+    @_Freezable public var convLast: Conv2D<Float>
 
     public init(
         classCount: Int, widthMultiplier: Float = 1.0, depthMultiplier: Int = 1,

--- a/Models/ImageClassification/MobileNetV2.swift
+++ b/Models/ImageClassification/MobileNetV2.swift
@@ -158,22 +158,22 @@ public struct InvertedBottleneckBlockStack: Layer {
 
 public struct MobileNetV2: Layer {
     @noDerivative public let zeroPad = ZeroPadding2D<Float>(padding: ((0, 1), (0, 1)))
-    public var inputConv: Conv2D<Float>
+    @_Freezable public var inputConv: Conv2D<Float>
     public var inputConvBatchNorm: BatchNorm<Float>
-    public var initialInvertedBottleneck: InitialInvertedBottleneckBlock
+    @_Freezable public var initialInvertedBottleneck: InitialInvertedBottleneckBlock
 
-    public var residualBlockStack1: InvertedBottleneckBlockStack
-    public var residualBlockStack2: InvertedBottleneckBlockStack
-    public var residualBlockStack3: InvertedBottleneckBlockStack
-    public var residualBlockStack4: InvertedBottleneckBlockStack
-    public var residualBlockStack5: InvertedBottleneckBlockStack
+    @_Freezable public var residualBlockStack1: InvertedBottleneckBlockStack
+    @_Freezable public var residualBlockStack2: InvertedBottleneckBlockStack
+    @_Freezable public var residualBlockStack3: InvertedBottleneckBlockStack
+    @_Freezable public var residualBlockStack4: InvertedBottleneckBlockStack
+    @_Freezable public var residualBlockStack5: InvertedBottleneckBlockStack
 
-    public var invertedBottleneckBlock16: InvertedBottleneckBlock
+    @_Freezable public var invertedBottleneckBlock16: InvertedBottleneckBlock
 
-    public var outputConv: Conv2D<Float>
+    @_Freezable public var outputConv: Conv2D<Float>
     public var outputConvBatchNorm: BatchNorm<Float>
     public var avgPool = GlobalAvgPool2D<Float>()
-    public var outputClassifier: Dense<Float>
+    @_Freezable public var outputClassifier: Dense<Float>
 
     public init(classCount: Int = 1000, widthMultiplier: Float = 1.0) {
         inputConv = Conv2D<Float>(

--- a/Models/ImageClassification/MobileNetV3.swift
+++ b/Models/ImageClassification/MobileNetV3.swift
@@ -230,32 +230,32 @@ public struct InvertedResidualBlock: Layer {
 
 public struct MobileNetV3Large: Layer {
     @noDerivative public let zeroPad = ZeroPadding2D<Float>(padding: ((0, 1), (0, 1)))
-    public var inputConv: Conv2D<Float>
+    @_Freezable public var inputConv: Conv2D<Float>
     public var inputConvBatchNorm: BatchNorm<Float>
 
-    public var invertedResidualBlock1: InitialInvertedResidualBlock
-    public var invertedResidualBlock2: InvertedResidualBlock
-    public var invertedResidualBlock3: InvertedResidualBlock
-    public var invertedResidualBlock4: InvertedResidualBlock
-    public var invertedResidualBlock5: InvertedResidualBlock
-    public var invertedResidualBlock6: InvertedResidualBlock
-    public var invertedResidualBlock7: InvertedResidualBlock
-    public var invertedResidualBlock8: InvertedResidualBlock
-    public var invertedResidualBlock9: InvertedResidualBlock
-    public var invertedResidualBlock10: InvertedResidualBlock
-    public var invertedResidualBlock11: InvertedResidualBlock
-    public var invertedResidualBlock12: InvertedResidualBlock
-    public var invertedResidualBlock13: InvertedResidualBlock
-    public var invertedResidualBlock14: InvertedResidualBlock
-    public var invertedResidualBlock15: InvertedResidualBlock
+    @_Freezable public var invertedResidualBlock1: InitialInvertedResidualBlock
+    @_Freezable public var invertedResidualBlock2: InvertedResidualBlock
+    @_Freezable public var invertedResidualBlock3: InvertedResidualBlock
+    @_Freezable public var invertedResidualBlock4: InvertedResidualBlock
+    @_Freezable public var invertedResidualBlock5: InvertedResidualBlock
+    @_Freezable public var invertedResidualBlock6: InvertedResidualBlock
+    @_Freezable public var invertedResidualBlock7: InvertedResidualBlock
+    @_Freezable public var invertedResidualBlock8: InvertedResidualBlock
+    @_Freezable public var invertedResidualBlock9: InvertedResidualBlock
+    @_Freezable public var invertedResidualBlock10: InvertedResidualBlock
+    @_Freezable public var invertedResidualBlock11: InvertedResidualBlock
+    @_Freezable public var invertedResidualBlock12: InvertedResidualBlock
+    @_Freezable public var invertedResidualBlock13: InvertedResidualBlock
+    @_Freezable public var invertedResidualBlock14: InvertedResidualBlock
+    @_Freezable public var invertedResidualBlock15: InvertedResidualBlock
 
-    public var outputConv: Conv2D<Float>
+    @_Freezable public var outputConv: Conv2D<Float>
     public var outputConvBatchNorm: BatchNorm<Float>
 
     public var avgPool = GlobalAvgPool2D<Float>()
-    public var finalConv: Conv2D<Float>
+    @_Freezable public var finalConv: Conv2D<Float>
     public var dropoutLayer: Dropout<Float>
-    public var classiferConv: Conv2D<Float>
+    @_Freezable public var classiferConv: Conv2D<Float>
     public var flatten = Flatten<Float>()
 
     @noDerivative public var lastConvChannel: Int
@@ -363,28 +363,28 @@ public struct MobileNetV3Large: Layer {
 
 public struct MobileNetV3Small: Layer {
     @noDerivative public let zeroPad = ZeroPadding2D<Float>(padding: ((0, 1), (0, 1)))
-    public var inputConv: Conv2D<Float>
+    @_Freezable public var inputConv: Conv2D<Float>
     public var inputConvBatchNorm: BatchNorm<Float>
 
-    public var invertedResidualBlock1: InitialInvertedResidualBlock
-    public var invertedResidualBlock2: InvertedResidualBlock
-    public var invertedResidualBlock3: InvertedResidualBlock
-    public var invertedResidualBlock4: InvertedResidualBlock
-    public var invertedResidualBlock5: InvertedResidualBlock
-    public var invertedResidualBlock6: InvertedResidualBlock
-    public var invertedResidualBlock7: InvertedResidualBlock
-    public var invertedResidualBlock8: InvertedResidualBlock
-    public var invertedResidualBlock9: InvertedResidualBlock
-    public var invertedResidualBlock10: InvertedResidualBlock
-    public var invertedResidualBlock11: InvertedResidualBlock
+    @_Freezable public var invertedResidualBlock1: InitialInvertedResidualBlock
+    @_Freezable public var invertedResidualBlock2: InvertedResidualBlock
+    @_Freezable public var invertedResidualBlock3: InvertedResidualBlock
+    @_Freezable public var invertedResidualBlock4: InvertedResidualBlock
+    @_Freezable public var invertedResidualBlock5: InvertedResidualBlock
+    @_Freezable public var invertedResidualBlock6: InvertedResidualBlock
+    @_Freezable public var invertedResidualBlock7: InvertedResidualBlock
+    @_Freezable public var invertedResidualBlock8: InvertedResidualBlock
+    @_Freezable public var invertedResidualBlock9: InvertedResidualBlock
+    @_Freezable public var invertedResidualBlock10: InvertedResidualBlock
+    @_Freezable public var invertedResidualBlock11: InvertedResidualBlock
 
-    public var outputConv: Conv2D<Float>
+    @_Freezable public var outputConv: Conv2D<Float>
     public var outputConvBatchNorm: BatchNorm<Float>
 
     public var avgPool = GlobalAvgPool2D<Float>()
-    public var finalConv: Conv2D<Float>
+    @_Freezable public var finalConv: Conv2D<Float>
     public var dropoutLayer: Dropout<Float>
-    public var classiferConv: Conv2D<Float>
+    @_Freezable public var classiferConv: Conv2D<Float>
     public var flatten = Flatten<Float>()
 
     @noDerivative public var lastConvChannel: Int

--- a/Models/ImageClassification/ResNet.swift
+++ b/Models/ImageClassification/ResNet.swift
@@ -105,12 +105,12 @@ public struct ResidualBlock: Layer {
 
 /// An implementation of the ResNet v1 and v1.5 architectures, at various depths.
 public struct ResNet: Layer {
-    public var initialLayer: ConvBN
+    @_Freezable public var initialLayer: ConvBN
     public var maxPool: MaxPool2D<Float>
-    public var residualBlocks: [ResidualBlock] = []
+    @_Freezable public var residualBlocks: [ResidualBlock] = []
     public var avgPool = GlobalAvgPool2D<Float>()
     public var flatten = Flatten<Float>()
-    public var classifier: Dense<Float>
+    @_Freezable public var classifier: Dense<Float>
 
     /// Initializes a new ResNet v1 or v1.5 network model.
     ///

--- a/Models/ImageClassification/ResNetV2.swift
+++ b/Models/ImageClassification/ResNetV2.swift
@@ -124,12 +124,12 @@ public struct ResidualBlockV2: Layer {
 
 /// An implementation of the ResNet v2 architectures, at various depths.
 public struct ResNetV2: Layer {
-    public var inputStem: [ConvBNV2]
+    @_Freezable public var inputStem: [ConvBNV2]
     public var maxPool: MaxPool2D<Float>
-    public var residualBlocks: [ResidualBlockV2] = []
+    @_Freezable public var residualBlocks: [ResidualBlockV2] = []
     public var avgPool = GlobalAvgPool2D<Float>()
     public var flatten = Flatten<Float>()
-    public var classifier: Dense<Float>
+    @_Freezable public var classifier: Dense<Float>
 
     /// Initializes a new ResNet v2 network model.
     ///

--- a/Models/ImageClassification/ShuffleNetV2.swift
+++ b/Models/ImageClassification/ShuffleNetV2.swift
@@ -114,15 +114,15 @@ public struct InvertedResidual: Layer {
 public struct ShuffleNetV2: Layer {
     @noDerivative public var zeroPad: ZeroPadding2D<Float> = ZeroPadding2D<Float>(padding: ((1, 1), (1, 1)))
     
-    public var conv1: Conv2D<Float>
+    @_Freezable public var conv1: Conv2D<Float>
     public var batchNorm1: BatchNorm<Float>
     public var maxPool: MaxPool2D<Float>
-    public var invertedResidualBlocksStage1: [InvertedResidual]
-    public var invertedResidualBlocksStage2: [InvertedResidual]
-    public var invertedResidualBlocksStage3: [InvertedResidual]
-    public var conv2: Conv2D<Float>
+    @_Freezable public var invertedResidualBlocksStage1: [InvertedResidual]
+    @_Freezable public var invertedResidualBlocksStage2: [InvertedResidual]
+    @_Freezable public var invertedResidualBlocksStage3: [InvertedResidual]
+    @_Freezable public var conv2: Conv2D<Float>
     public var globalPool: GlobalAvgPool2D<Float> = GlobalAvgPool2D()
-    public var dense: Dense<Float>
+    @_Freezable public var dense: Dense<Float>
     
     public init(stagesRepeat: (Int, Int, Int), stagesOutputChannels: (Int, Int, Int, Int, Int),
                 classCount: Int) {

--- a/Models/ImageClassification/SqueezeNet.swift
+++ b/Models/ImageClassification/SqueezeNet.swift
@@ -53,55 +53,55 @@ public struct Fire: Layer {
 }
 
 public struct SqueezeNetV1_0: Layer {
-    public var conv1 = Conv2D<Float>(
+    @_Freezable public var conv1 = Conv2D<Float>(
         filterShape: (7, 7, 3, 96),
         strides: (2, 2),
         padding: .same,
         activation: relu)
     public var maxPool1 = MaxPool2D<Float>(poolSize: (3, 3), strides: (2, 2))
-    public var fire2 = Fire(
+    @_Freezable public var fire2 = Fire(
         inputFilterCount: 96,
         squeezeFilterCount: 16,
         expand1FilterCount: 64,
         expand3FilterCount: 64)
-    public var fire3 = Fire(
+    @_Freezable public var fire3 = Fire(
         inputFilterCount: 128,
         squeezeFilterCount: 16,
         expand1FilterCount: 64,
         expand3FilterCount: 64)
-    public var fire4 = Fire(
+    @_Freezable public var fire4 = Fire(
         inputFilterCount: 128,
         squeezeFilterCount: 32,
         expand1FilterCount: 128,
         expand3FilterCount: 128)
     public var maxPool4 = MaxPool2D<Float>(poolSize: (3, 3), strides: (2, 2))
-    public var fire5 = Fire(
+    @_Freezable public var fire5 = Fire(
         inputFilterCount: 256,
         squeezeFilterCount: 32,
         expand1FilterCount: 128,
         expand3FilterCount: 128)
-    public var fire6 = Fire(
+    @_Freezable public var fire6 = Fire(
         inputFilterCount: 256,
         squeezeFilterCount: 48,
         expand1FilterCount: 192,
         expand3FilterCount: 192)
-    public var fire7 = Fire(
+    @_Freezable public var fire7 = Fire(
         inputFilterCount: 384,
         squeezeFilterCount: 48,
         expand1FilterCount: 192,
         expand3FilterCount: 192)
-    public var fire8 = Fire(
+    @_Freezable public var fire8 = Fire(
         inputFilterCount: 384,
         squeezeFilterCount: 64,
         expand1FilterCount: 256,
         expand3FilterCount: 256)
     public var maxPool8 = MaxPool2D<Float>(poolSize: (3, 3), strides: (2, 2))
-    public var fire9 = Fire(
+    @_Freezable public var fire9 = Fire(
         inputFilterCount: 512,
         squeezeFilterCount: 64,
         expand1FilterCount: 256,
         expand3FilterCount: 256)
-    public var conv10: Conv2D<Float>
+    @_Freezable public var conv10: Conv2D<Float>
     public var avgPool10 = AvgPool2D<Float>(poolSize: (13, 13), strides: (1, 1))
     public var dropout = Dropout<Float>(probability: 0.5)
 

--- a/Models/ImageClassification/VGG.swift
+++ b/Models/ImageClassification/VGG.swift
@@ -41,16 +41,16 @@ public struct VGGBlock: Layer {
 }
 
 public struct VGG16: Layer {
-    var layer1: VGGBlock
-    var layer2: VGGBlock
-    var layer3: VGGBlock
-    var layer4: VGGBlock
-    var layer5: VGGBlock
+    @_Freezable var layer1: VGGBlock
+    @_Freezable var layer2: VGGBlock
+    @_Freezable var layer3: VGGBlock
+    @_Freezable var layer4: VGGBlock
+    @_Freezable var layer5: VGGBlock
 
     var flatten = Flatten<Float>()
-    var dense1 = Dense<Float>(inputSize: 512 * 7 * 7, outputSize: 4096, activation: relu)
-    var dense2 = Dense<Float>(inputSize: 4096, outputSize: 4096, activation: relu)
-    var output: Dense<Float>
+    @_Freezable var dense1 = Dense<Float>(inputSize: 512 * 7 * 7, outputSize: 4096, activation: relu)
+    @_Freezable var dense2 = Dense<Float>(inputSize: 4096, outputSize: 4096, activation: relu)
+    @_Freezable var output: Dense<Float>
 
     public init(classCount: Int = 1000) {
         layer1 = VGGBlock(featureCounts: (3, 64, 64, 64), blockCount: 2)
@@ -69,16 +69,16 @@ public struct VGG16: Layer {
 }
 
 public struct VGG19: Layer {
-    var layer1: VGGBlock
-    var layer2: VGGBlock
-    var layer3: VGGBlock
-    var layer4: VGGBlock
-    var layer5: VGGBlock
+    @_Freezable var layer1: VGGBlock
+    @_Freezable var layer2: VGGBlock
+    @_Freezable var layer3: VGGBlock
+    @_Freezable var layer4: VGGBlock
+    @_Freezable var layer5: VGGBlock
 
     var flatten = Flatten<Float>()
-    var dense1 = Dense<Float>(inputSize: 512 * 7 * 7, outputSize: 4096, activation: relu)
-    var dense2 = Dense<Float>(inputSize: 4096, outputSize: 4096, activation: relu)
-    var output: Dense<Float>
+    @_Freezable var dense1 = Dense<Float>(inputSize: 512 * 7 * 7, outputSize: 4096, activation: relu)
+    @_Freezable var dense2 = Dense<Float>(inputSize: 4096, outputSize: 4096, activation: relu)
+    @_Freezable var output: Dense<Float>
 
     public init(classCount: Int = 1000) {
         layer1 = VGGBlock(featureCounts: (3, 64, 64, 64), blockCount: 2)

--- a/Models/ImageClassification/WideResNet.swift
+++ b/Models/ImageClassification/WideResNet.swift
@@ -90,16 +90,16 @@ public struct WideResNetBasicBlock: Layer {
 }
 
 public struct WideResNet: Layer {
-    public var l1: Conv2D<Float>
+    @_Freezable public var l1: Conv2D<Float>
 
-    public var l2: WideResNetBasicBlock
-    public var l3: WideResNetBasicBlock
-    public var l4: WideResNetBasicBlock
+    @_Freezable public var l2: WideResNetBasicBlock
+    @_Freezable public var l3: WideResNetBasicBlock
+    @_Freezable public var l4: WideResNetBasicBlock
 
     public var norm: BatchNorm<Float>
     public var avgPool: AvgPool2D<Float>
     public var flatten = Flatten<Float>()
-    public var classifier: Dense<Float>
+    @_Freezable public var classifier: Dense<Float>
 
     public init(depthFactor: Int = 2, widenFactor: Int = 8) {
         self.l1 = Conv2D(filterShape: (3, 3, 3, 16), strides: (1, 1), padding: .same)


### PR DESCRIPTION
This PR proposes to apply `@_Freezable` property wrapper on every property of image classification models that conforms to `Layer` protocol. 

One thing I'd like to point out is that in some models like ResNet, VGG, EfficientNet, and others, the property wrapper is applied on the neural blocks instead of the layers contained in those neural blocks because, according to my best knowledge (please correct me if I'm wrong here), it is rare to freeze specific layers in neural blocks during transfer learning. 

cc @BradLarson