### PR TITLE
Updating parameters to match current ArgumentParser version

### DIFF
--- a/CycleGAN/CLI.swift
+++ b/CycleGAN/CLI.swift
@@ -18,9 +18,9 @@ struct Options: ParsableArguments {
     @Option(help: ArgumentHelp("Path to the dataset folder", valueName: "dataset-path"))
     var datasetPath: String?
 
-    @Option(default: 50, help: ArgumentHelp("Number of epochs", valueName: "epochs"))
-    var epochs: Int
+    @Option(help: ArgumentHelp("Number of epochs", valueName: "epochs"))
+    var epochs: Int = 50
 
-    @Option(default: 20, help: ArgumentHelp("Number of steps to log a sample image into tensorboard", valueName: "sampleLogPeriod"))
-    var sampleLogPeriod: Int
+    @Option(help: ArgumentHelp("Number of steps to log a sample image into tensorboard", valueName: "sampleLogPeriod"))
+    var sampleLogPeriod: Int = 20
 }

--- a/Examples/Fractals/main.swift
+++ b/Examples/Fractals/main.swift
@@ -30,10 +30,10 @@ struct FractalCommand: ParsableCommand {
 extension FractalCommand {
   struct Parameters: ParsableArguments {
     @Flag(help: "Use eager backend.")
-    var eager: Bool
+    var eager: Bool = false
 
     @Flag(help: "Use X10 backend.")
-    var x10: Bool
+    var x10: Bool = false
 
     @Option(help: "Number of iterations to run.")
     var iterations: Int?

--- a/pix2pix/CLI.swift
+++ b/pix2pix/CLI.swift
@@ -18,9 +18,9 @@ struct Options: ParsableArguments {
     @Option(help: ArgumentHelp("Path to the dataset folder", valueName: "dataset-path"))
     var datasetPath: String?
 
-    @Option(default: 1, help: ArgumentHelp("Number of epochs", valueName: "epochs"))
-    var epochs: Int
+    @Option(help: ArgumentHelp("Number of epochs", valueName: "epochs"))
+    var epochs: Int = 1
 
-    @Option(default: 20, help: ArgumentHelp("Number of steps to log a sample image into tensorboard", valueName: "sampleLogPeriod"))
-    var sampleLogPeriod: Int
+    @Option(help: ArgumentHelp("Number of steps to log a sample image into tensorboard", valueName: "sampleLogPeriod"))
+    var sampleLogPeriod: Int = 20
 }


### PR DESCRIPTION
In order to silence a few deprecation warnings, this updates default arguments for ArgumentParser to the new syntax used in recent versions of that module.