### PR TITLE
Make accuracy and loss values available for upstream use-cases

### DIFF
--- a/TrainingLoop/TrainingProgress.swift
+++ b/TrainingLoop/TrainingProgress.swift
@@ -19,8 +19,8 @@ let progressBarLength = 30
 /// A progress bar that displays to the console as a model trains, and as validation is performed.
 /// It hooks into a TrainingLoop via a callback method.
 public class TrainingProgress {
-  public var accuracies: [Float]
-  public var losses: [Float]
+  public var accuracies: [Float] // accessible list of accuracies values
+  public var losses: [Float]     // acceessible list of loss values
   var statistics: TrainingStatistics?
   let metrics: Set<TrainingMetrics>
   let liveStatistics: Bool
@@ -121,13 +121,4 @@ public class TrainingProgress {
     default: break
     }
   }
-}
-public extension TrainingProgress {
-  func trainAcc() -> [Float] {
-      return self.accuracies
-  }
-  func trainLoss() -> [Float] {
-      return self.losses
-  }
-
 }

--- a/TrainingLoop/TrainingProgress.swift
+++ b/TrainingLoop/TrainingProgress.swift
@@ -20,7 +20,7 @@ let progressBarLength = 30
 /// It hooks into a TrainingLoop via a callback method.
 public class TrainingProgress {
   var statistics: TrainingStatistics?
-  let metrics: Set<TrainingMetrics>
+  public let metrics: Set<TrainingMetrics>
   let liveStatistics: Bool
 
   /// Initializes the progress bar with the metrics to be displayed (if any), and whether to


### PR DESCRIPTION
Quite often we need accuracy and loss values in upstream code, e.g. to plot them. This PR address this issue.