### PR TITLE
Remove explicit `CoLA.init` trailing closure signature.

### DIFF
--- a/Examples/BERT-CoLA/main.swift
+++ b/Examples/BERT-CoLA/main.swift
@@ -66,7 +66,7 @@ var cola = try CoLA(
   batchSize: batchSize,
   entropy: SystemRandomNumberGenerator(),
   on: device
-) { (example: CoLAExample) -> CoLA.LabeledTextBatch in
+) { example in
   // In this closure, both the input and output text batches must be eager
   // since the text is not padded and x10 requires stable shapes.
   let textBatch = bertClassifier.bert.preprocess(


### PR DESCRIPTION
Fixes type checking error after the [`swift-DEVELOPMENT-SNAPSHOT-2020-08-31-a -> tensorflow` merge](https://github.com/apple/swift/pull/33755).

```
$ swift build
/swift-models/Examples/BERT-CoLA/main.swift:69:3: error: generic parameter 'Entropy' could not be inferred
) { (example: CoLAExample) -> CoLA.LabeledTextBatch in
  ^
```

An alternative fix is explicitly specifying `CoLA<SystemRandomNumberGenerator>.LabeledTextBatch` as the closure result type.

The underlying issue is probably related to closure result type inference changes.