### PR TITLE
ArgumentParser migration from master->main

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -118,7 +118,7 @@ if(CMAKE_SYSTEM_NAME STREQUAL Windows)
 endif()
 ExternalProject_Add(swift-argument-parser
   GIT_REPOSITORY git://github.com/apple/swift-argument-parser.git
-  GIT_TAG master
+  GIT_TAG main
   CMAKE_ARGS
     -DBUILD_SHARED_LIBS=YES
     -DCMAKE_MAKE_PROGRAM=${CMAKE_MAKE_PROGRAM}


### PR DESCRIPTION
The `master` branch of ArgumentParser has been renamed to `main`, so we need to update the one dependency on this in our CMakeLists.