### PR TITLE
Adding Catalina-compatible FileHandle operations

### DIFF
--- a/Support/FoundationFileSystem.swift
+++ b/Support/FoundationFileSystem.swift
@@ -64,8 +64,16 @@ public struct FoundationFile: File {
   /// Parameter value: data to be appended at the end.
   public func append(_ value: Data) throws {
     let fileHandler = try FileHandle(forUpdating: location)
+    #if os(macOS)
+    // The following are needed in order to build on macOS 10.15 (Catalina). They can be removed
+    // once macOS 10.16 (Big Sur) is prevalent enough as a build environment.
+    fileHandler.seekToEndOfFile()
+    fileHandler.write(value)
+    fileHandler.closeFile()
+    #else
     try fileHandler.seekToEnd()
     try fileHandler.write(contentsOf: value)
     try fileHandler.close()
+    #endif
   }
 }


### PR DESCRIPTION
PR #668 added an `append()` method to the FileSystem protocol and an implementation in FoundationFileSystem. This implementation used FileHandle and several methods which have had their signatures change between macOS 10.15 (Catalina) and 10.16 (Big Sur). The current implementation uses the new interface, which will build with the latest Linux toolchain but will not build on the current macOS 10.15 (Catalina).

This provides the older interface for use when building on macOS, and the newer one for other OS versions. Once Big Sur is the dominant build environment for macOS, we can remove this fallback.