### PR TITLE
Fixed links to Colab and GitHub

### DIFF
--- a/Examples/GrowingNeuralCellularAutomata/GrowingNeuralCellularAutomata.ipynb
+++ b/Examples/GrowingNeuralCellularAutomata/GrowingNeuralCellularAutomata.ipynb
@@ -74,10 +74,10 @@
       "source": [
         "<table class=\"tfo-notebook-buttons\" align=\"left\">\n",
         " <td>\n",
-        "  <a target=\"_blank\" href=\"https://colab.research.google.com/github/BradLarson/swift-models/blob/CellularAutomata/Examples/GrowingNeuralCellularAutomata/ notebook/GrowingNeuralCellularAutomata.ipynb\"><img src=\"https://www.tensorflow.org/images/colab_logo_32px.png\" />Run in Google Colab</a>\n",
+        "  <a target=\"_blank\" href=\"https://colab.research.google.com/github/tensorflow/swift-models/blob/master/Examples/GrowingNeuralCellularAutomata/GrowingNeuralCellularAutomata.ipynb\"><img src=\"https://www.tensorflow.org/images/colab_logo_32px.png\" />Run in Google Colab</a>\n",
         " </td>\n",
         " <td>\n",
-        "  <a target=\"_blank\" href=\"https://github.com/BradLarson/swift-models/blob/CellularAutomata/Examples/GrowingNeuralCellularAutomata/ notebook/GrowingNeuralCellularAutomata.ipynb\"><img src=\"https://www.tensorflow.org/images/GitHub-Mark-32px.png\" />View source on GitHub</a>\n",
+        "  <a target=\"_blank\" href=\"https://github.com/tensorflow/swift-models/blob/master/Examples/GrowingNeuralCellularAutomata/GrowingNeuralCellularAutomata.ipynb\"><img src=\"https://www.tensorflow.org/images/GitHub-Mark-32px.png\" />View source on GitHub</a>\n",
         " </td>\n",
         "</table>"
       ]


### PR DESCRIPTION
The links did't point the master branch of tensorflow/swift-model.