### PR TITLE
Refactor LearningRateScheduler

### DIFF
--- a/Examples/BERT-CoLA/main.swift
+++ b/Examples/BERT-CoLA/main.swift
@@ -133,10 +133,11 @@ var trainingLoop: TrainingLoop = TrainingLoop(
     clipGradByGlobalNorm,
     learningRateScheduler(
       makeSchedule(
-        DecaySchedule(
+        decaySchedule: DecaySchedule(
           shape: .linear,
           warmupSchedule: WarmupSchedule(
             shape: .linear, endLearningRate: peakLearningRate, endStep: 10),
+          endLearningRate: 0
         ),
         biasCorrectionBeta: (beta1, beta2))),
   ])

--- a/Examples/BERT-CoLA/main.swift
+++ b/Examples/BERT-CoLA/main.swift
@@ -123,19 +123,6 @@ func clipGradByGlobalNorm<L: TrainingLoopProtocol>(_ loop: inout L, event: Train
   }
 }
 
-/// A function that returns a LinearlyDecayedParameter but with first 10 steps linearly warmed up;
-/// for remaining steps it decays at slope of -(peakLearningRate / `totalStepCount`).
-let scheduledParameterGetter = { (_ totalStepCount: Float) -> LinearlyDecayedParameter in
-  LinearlyDecayedParameter(
-    baseParameter: LinearlyWarmedUpParameter(
-      baseParameter: FixedParameter<Float>(peakLearningRate),
-      warmUpStepCount: 10,
-      warmUpOffset: 0),
-    slope: -(peakLearningRate / totalStepCount),  // The LR decays linearly to zero.
-    startStep: 10
-  )
-}
-
 var trainingLoop: TrainingLoop = TrainingLoop(
   training: cola.trainingEpochs,
   validation: cola.validationBatches,
@@ -144,10 +131,14 @@ var trainingLoop: TrainingLoop = TrainingLoop(
   metrics: [.matthewsCorrelationCoefficient],
   callbacks: [
     clipGradByGlobalNorm,
-    LearningRateScheduler(
-      scheduledParameterGetter: scheduledParameterGetter,
-      biasCorrectionBeta1: beta1,
-      biasCorrectionBeta2: beta2).schedule
+    learningRateScheduler(
+      makeSchedule(
+        DecaySchedule(
+          shape: .linear,
+          warmupSchedule: WarmupSchedule(
+            shape: .linear, endLearningRate: peakLearningRate, endStep: 10),
+        ),
+        biasCorrectionBeta: (beta1, beta2))),
   ])
 
 print("Training \(bertPretrained.name) for the CoLA task!")

--- a/Examples/BERT-CoLA/main.swift
+++ b/Examples/BERT-CoLA/main.swift
@@ -136,7 +136,7 @@ var trainingLoop: TrainingLoop = TrainingLoop(
         decaySchedule: DecaySchedule(
           shape: .linear,
           warmupSchedule: WarmupSchedule(
-            shape: .linear, endLearningRate: peakLearningRate, endStep: 10),
+            shape: .linear, endLearningRate: peakLearningRate, steps: 10),
           endLearningRate: 0
         ),
         biasCorrectionBeta: (beta1, beta2))),


### PR DESCRIPTION
This [line](https://github.com/tensorflow/swift-models/blob/master/TrainingLoop/Callbacks/LearningRateScheduler.swift#L55) of code and below were taken into that file from another earlier existing file. It implemented the fundamental learning rate scheduling algorithms and two of them were used by BERT model. 

It was a good starting point to build our TrainingLoop LearningRateScheduler Callback so I took it as it is in https://github.com/tensorflow/swift-models/pull/679. However this is not the right interface for user to use, so this followup PR comes out to implement a higher level interface.

