### PR TITLE
Update FileHandler value -> suffix to match the changes to the Linux side

### DIFF
--- a/Support/FoundationFileSystem.swift
+++ b/Support/FoundationFileSystem.swift
@@ -66,7 +66,7 @@ public struct FoundationFile: File {
     // The following are needed in order to build on macOS 10.15 (Catalina). They can be removed
     // once macOS 10.16 (Big Sur) is prevalent enough as a build environment.
     fileHandler.seekToEndOfFile()
-    fileHandler.write(value)
+    fileHandler.write(suffix)
     fileHandler.closeFile()
     #else
     try fileHandler.seekToEnd()


### PR DESCRIPTION
In PR #670, the parameter to FoundationFileSystem's append() method was changed from `value` to `suffix` on the Linux side, but not for macOS. This causes model compilation to fail on macOS.

This quick fix updates the macOS side to re-enable building models there.