### PR TITLE
CycleGAN: use `Int32.random` instead of `__C.random`

### DIFF
--- a/CycleGAN/main.swift
+++ b/CycleGAN/main.swift
@@ -61,7 +61,7 @@ for (epoch, epochBatches) in dataset.training.prefix(epochCount).enumerated() {
         let scaledImages = resize(images: concatanatedImages,
                                   size: (286, 286),
                                   method: .nearest)
-        var croppedImages = scaledImages.slice(lowerBounds: Tensor<Int32>([0, Int32(random() % 30), Int32(random() % 30), 0]),
+        var croppedImages = scaledImages.slice(lowerBounds: Tensor<Int32>([0, Int32.random(in: 0...29), Int32.random(in: 0...29), 0]),
                                                sizes: [2, 256, 256, 3])
         if Bool.random() {
             croppedImages = croppedImages.reversed(inAxes: 2)


### PR DESCRIPTION
Use the Swift provided random number generation rather than the C
function which is not portable.  This enables building CycleGAN on
Windows.