### PR TITLE
WordSeg: repair build on Windows

### DIFF
--- a/BenchmarksCore/Models/WordSeg.swift
+++ b/BenchmarksCore/Models/WordSeg.swift
@@ -18,6 +18,14 @@ import ModelSupport
 import TensorFlow
 import TextModels
 
+#if os(Windows)
+#if canImport(CRT)
+import CRT
+#else
+import MSVCRT
+#endif
+#endif
+
 let WordSegScore = wordSegSuite(
   name: "WordSegScore",
   operation: score)

--- a/Examples/WordSeg/main.swift
+++ b/Examples/WordSeg/main.swift
@@ -17,6 +17,14 @@ import ModelSupport
 import TensorFlow
 import TextModels
 
+#if os(Windows)
+#if canImport(CRT)
+import CRT
+#else
+import MSVCRT
+#endif
+#endif
+
 internal func runTraining(settings: WordSegSettings) throws {
   var trainingLossHistory = [Float]()  // Keep track of loss.
   var validationLossHistory = [Float]()  // Keep track of loss.

--- a/Models/Text/WordSeg/SemiRing.swift
+++ b/Models/Text/WordSeg/SemiRing.swift
@@ -15,7 +15,11 @@
 #if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
   import Darwin
 #elseif os(Windows)
-  import ucrt
+  #if canImport(CRT)
+    import CRT
+  #else
+    import MSVCRT
+  #endif
 #else
   import Glibc
 #endif


### PR DESCRIPTION
Importing `ucrt` is insufficient since we rely on the type-generic
operation to convert the `Float` to what would be operations on
`Double` otherwise.