### PR TITLE
Shallow Water PDE: make build on Windows

### DIFF
--- a/Examples/Shallow-Water-PDE/ArrayLoopSolution.swift
+++ b/Examples/Shallow-Water-PDE/ArrayLoopSolution.swift
@@ -14,6 +14,14 @@
 
 import TensorFlow
 
+#if os(Windows)
+#if canImport(CRT)
+import CRT
+#else
+import MSVCRT
+#endif
+#endif
+
 // MARK: Solution of shallow water equation
 
 /// Differentiable solution of shallow water equation on a unit square.

--- a/Examples/Shallow-Water-PDE/TensorConvSolution.swift
+++ b/Examples/Shallow-Water-PDE/TensorConvSolution.swift
@@ -14,6 +14,14 @@
 
 import TensorFlow
 
+#if os(Windows)
+#if canImport(CRT)
+import CRT
+#else
+import MSVCRT
+#endif
+#endif
+
 // MARK: Solution of shallow water equation
 
 /// Differentiable solution of shallow water equation on a unit square.

--- a/Examples/Shallow-Water-PDE/TensorLoopSolution.swift
+++ b/Examples/Shallow-Water-PDE/TensorLoopSolution.swift
@@ -14,6 +14,14 @@
 
 import TensorFlow
 
+#if os(Windows)
+#if canImport(CRT)
+import CRT
+#else
+import MSVCRT
+#endif
+#endif
+
 // MARK: Solution of shallow water equation
 
 /// Differentiable solution of shallow water equation on a unit square.

--- a/Examples/Shallow-Water-PDE/TensorSliceSolution.swift
+++ b/Examples/Shallow-Water-PDE/TensorSliceSolution.swift
@@ -14,6 +14,14 @@
 
 import TensorFlow
 
+#if os(Windows)
+#if canImport(CRT)
+import CRT
+#else
+import MSVCRT
+#endif
+#endif
+
 // MARK: Solution of shallow water equation
 
 /// Differentiable solution of shallow water equation on a unit square.


### PR DESCRIPTION
We need to import `MSVCRT` (or rather the new name of `CRT`) to get the
type-generic operations as the C library functions which are referenced
here expect double values but the values being used are single precision
(`Float`) which fails to type-check.