### PR TITLE
docs: update build docs for Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ swift build -Xswiftc -use-ld=lld -c release
 #### Test
 
 ```cmd
-swift test -Xswiftc -use-ld=lld -c release
+swift test -Xswiftc -use-ld=lld -c debug
 ```
 
 ### Using CMake for Development

--- a/README.md
+++ b/README.md
@@ -29,13 +29,25 @@ swift test
 
 ### Windows
 
+#### Build
+
+```cmd
+swift build -Xswiftc -use-ld=lld -c release
+```
+
+#### Test
+
+```cmd
+swift test -Xswiftc -use-ld=lld -c release
+```
+
+### Using CMake for Development
+
 Use CMake to develop Swift for TensorFlow models.
 
 ### *Experimental* CMake Support
 
-There is experimental support for building with CMake.  This is required to build the models on Windows, and can also be used to cross-compile the models and the demo programs.
-
-**NOTE**: tests are currently not supported with the CMake based build.
+There is experimental support for building with CMake.  This can be used to cross-compile the models and the demo programs.
 
 It is highly recommended that you use CMake 3.16 or newer to ensure that `-B`
 and parallel builds function properly in the example commands below. To install
@@ -81,21 +93,20 @@ cmake --build /BinaryCache/tensorflow-swift-models
 Windows:
 
 ```
-set SDKROOT=%SystemDrive%/Library/Developer/Platforms/Windows.platform/Developer/SDKs/Windows.sdk
 set DEVELOPER_LIBRARY_DIR=%SystemDrive%/Library/Developer/Platforms/Windows.platform/Developer/Library
-: Configure
-"%ProgramFiles%\CMake\bin\cmake.exe"                                                                                                                                                                                                                  ^
-  -B %SystemDrive%/BinaryCache/tensorflow-swift-models                                                                                                                                                                                                ^
-  -D BUILD_SHARED_LIBS=YES                                                                                                                                                                                                                            ^
-  -D BUILD_TESTING=YES                                                                                                                                                                                                                                ^
-  -D CMAKE_BUILD_TYPE=Release                                                                                                                                                                                                                         ^
-  -D CMAKE_Swift_COMPILER=%SystemDrive%/Library/Developer/Toolchains/unknown-Asserts-development.xctoolchain/usr/bin/swiftc.exe                                                                                                                       ^
-  -D CMAKE_Swift_FLAGS="-sdk %SDKROOT% -I %SDKROOT%/usr/lib/swift -L %SDKROOT%/usr/lib/swift/windows -I %DEVELOPER_LIBRARY_DIR%/XCTest-development/usr/lib/swift/windows/x86_64 -L %DEVELOPER_LIBRARY_DIR%/XCTest-development/usr/lib/swift/windows " ^
-  -G Ninja                                                                                                                                                                                                                                            ^
+:: Configure
+"%ProgramFiles%\CMake\bin\cmake.exe"                                                                                                                                                   ^
+  -B %SystemDrive%/BinaryCache/tensorflow-swift-models                                                                                                                                 ^
+  -D BUILD_SHARED_LIBS=YES                                                                                                                                                             ^
+  -D BUILD_TESTING=YES                                                                                                                                                                 ^
+  -D CMAKE_BUILD_TYPE=Release                                                                                                                                                          ^
+  -D CMAKE_Swift_COMPILER=%SystemDrive%/Library/Developer/Toolchains/unknown-Asserts-development.xctoolchain/usr/bin/swiftc.exe                                                        ^
+  -D CMAKE_Swift_FLAGS="-sdk %SDKROOT% -I %DEVELOPER_LIBRARY_DIR%/XCTest-development/usr/lib/swift/windows/x86_64 -L %DEVELOPER_LIBRARY_DIR%/XCTest-development/usr/lib/swift/windows" ^
+  -G Ninja                                                                                                                                                                             ^
   -S %SystemDrive%/SourceCache/tensorflow-swift-models
-: Build
+:: Build
 "%ProgramFiles%\CMake\bin\cmake.exe" --build %SystemDrive%/BinaryCache/tensorflow-swift-models
-: Test
+:: Test
 "%ProgramFiles%\CMake\bin\cmake.exe" --build %SystemDrive%/BinaryCache/tensorflow-swift-models --target test
 ```
 


### PR DESCRIPTION
Windows snapshots as of 10/28 have SwiftPM in the snapshots and works
to build the models.  Update the docs for build instructions.