### PR TITLE
build: correct missing dependency for `Models`

### DIFF
--- a/Models/Text/CMakeLists.txt
+++ b/Models/Text/CMakeLists.txt
@@ -19,6 +19,7 @@ set_target_properties(TextModels PROPERTIES
 target_compile_options(TextModels PRIVATE
   $<$<BOOL:${BUILD_TESTING}>:-enable-testing>)
 target_link_libraries(TextModels PUBLIC
+  Checkpoints
   Datasets
   SwiftProtobuf)
 


### PR DESCRIPTION
Repair the CMake based build which was under-specifying dependencies.