### PR TITLE
make swift-benchmark dependency use version

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -25,7 +25,7 @@ let package = Package(
     dependencies: [
         .package(url: "https://github.com/apple/swift-protobuf.git", from: "1.10.0"),
         .package(url: "https://github.com/apple/swift-argument-parser", .branch("main")),
-        .package(url: "https://github.com/google/swift-benchmark", .revision("f70bf472b00aeaa05e2374373568c2fe459c11c7")),
+        .package(url: "https://github.com/google/swift-benchmark", from: "0.1.0"),
     ],
     targets: [
         .target(


### PR DESCRIPTION
This should make it possible to build packages that depend on multiple packages that depend on different version ranges of swift-benchmark (as long as there is at least one compatible version).