### PR TITLE
Repairing two text-based tests on macOS

### DIFF
--- a/Datasets/WordSeg/WordSegDataset.swift
+++ b/Datasets/WordSeg/WordSegDataset.swift
@@ -147,13 +147,19 @@ public struct WordSegDataset {
       contentsOf: URL(fileURLWithPath: trainingFile),
       options: .alwaysMapped)
 
-    let validationData = try Data(
-      contentsOf: URL(fileURLWithPath: validationFile ?? "/dev/null"),
-      options: .alwaysMapped)
+    let validationData: Data
+    if let file = validationFile {
+      validationData = try Data(contentsOf: URL(fileURLWithPath: file), options: .alwaysMapped)
+    } else {
+      validationData = Data()
+    }
 
-    let testingData = try Data(
-      contentsOf: URL(fileURLWithPath: testingFile ?? "/dev/null"),
-      options: .alwaysMapped)
+    let testingData: Data
+    if let file = testingFile {
+      testingData = try Data(contentsOf: URL(fileURLWithPath: file), options: .alwaysMapped)
+    } else {
+      testingData = Data()
+    }
 
     self.init(
       training: trainingData, validation: validationData, testing: testingData)

--- a/Tests/DatasetsTests/TextUnsupervised/TextUnsupervisedTests.swift
+++ b/Tests/DatasetsTests/TextUnsupervised/TextUnsupervisedTests.swift
@@ -41,23 +41,6 @@ final class TextUnsupervisedTests: XCTestCase {
         }
     }
 
-    func testCreateWikiText103WithoutBpe() {
-        let dataset = TextUnsupervised(variant: .wikiText103)
-
-        var totalCount = 0
-        for example in dataset.trainingDataset {
-            XCTAssertEqual(example.first.shape[0], 1024)
-            XCTAssertEqual(example.second.shape[0], 1024)
-            totalCount += 1
-        }
-        for example in dataset.validationDataset {
-            XCTAssertEqual(example.first.shape[0], 1024)
-            XCTAssertEqual(example.second.shape[0], 1024)
-            totalCount += 1
-        }
-        XCTAssertEqual(totalCount, 24)
-    }
-
     func testCreateWikiText2WithBpe() {
         do {
             let gpt2 = try GPT2()

--- a/Tests/DatasetsTests/WordSeg/WordSegDatasetTests.swift
+++ b/Tests/DatasetsTests/WordSeg/WordSegDatasetTests.swift
@@ -49,7 +49,7 @@ class WordSegDatasetTests: XCTestCase {
     do {
       let localStorageDirectory: URL = DatasetUtilities.defaultDirectory
         .appendingPathComponent("WordSeg", isDirectory: true)
-      let trainingFile = localStorageDirectory.appendingPathComponent("/seg/br/br-text/tr.txt")
+      let trainingFile = localStorageDirectory.appendingPathComponent("seg/br/br-text/tr.txt")
       let dataset = try WordSegDataset(training: trainingFile.path)
       XCTAssertEqual(dataset.trainingPhrases.count, 7832)
       XCTAssertEqual(dataset.validationPhrases.count, 0)


### PR DESCRIPTION
The `testCreateWikiText103WithoutBpe` test will always fail [a precondition](https://github.com/tensorflow/swift-models/blob/main/Datasets/TextUnsupervised/TextUnsupervised.swift#L212) because it sets bpe to nil, while `encodedFileName` is also nil for that dataset. This test case is not active on Linux, but will run on macOS, where it crashes tests. As a result, I've removed this test case.

Additionally, the WordSegDataset used a hardcoded path to /dev/null when no filename is specified for two components. Direct access to /dev/null is blocked on macOS, and is problematic for Windows. I've replaced this with creation of an empty Data instance if the file name is missing.

With these changes, all tests now pass on macOS.