### PR TITLE
Update CMakeLists for SwiftProtobuf's main migration

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -59,7 +59,7 @@ if(CMAKE_SYSTEM_NAME STREQUAL Windows)
 endif()
 ExternalProject_Add(swift-protobuf
   GIT_REPOSITORY git://github.com/apple/swift-protobuf.git
-  GIT_TAG main
+  GIT_TAG 1.10.0
   CMAKE_ARGS
     -DBUILD_SHARED_LIBS=YES
     -DCMAKE_MAKE_PROGRAM=${CMAKE_MAKE_PROGRAM}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -59,7 +59,7 @@ if(CMAKE_SYSTEM_NAME STREQUAL Windows)
 endif()
 ExternalProject_Add(swift-protobuf
   GIT_REPOSITORY git://github.com/apple/swift-protobuf.git
-  GIT_TAG master
+  GIT_TAG main
   CMAKE_ARGS
     -DBUILD_SHARED_LIBS=YES
     -DCMAKE_MAKE_PROGRAM=${CMAKE_MAKE_PROGRAM}


### PR DESCRIPTION
SwiftProtobuf just moved over to main as the default branch, so this updates the reference in CMake to allow it to build again.