### PR TITLE
Initial compatibility with stock toolchain

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -148,6 +148,27 @@ set_target_properties(ArgumentParser PROPERTIES
 add_dependencies(ArgumentParser swift-argument-parser-install)
 add_dependencies(turbojpeg libjpeg-turbo-build)
 
+option(ENABLE_SWIFT_NUMERICS
+  "Enable integrating swift-numerics" YES)
+
+include(CheckSwiftSourceCompiles)
+check_swift_source_compiles("struct S : KeyPathIterable { }" SWIFT_COMPILER_HAS_KEYPATHITERABLE_PROTOCOL)
+if(SWIFT_COMPILER_HAS_KEYPATHITERABLE_PROTOCOL)
+  set(TENSORFLOW_USE_STANDARD_TOOLCHAIN_DEFAULT OFF)
+else()
+  # if(CMAKE_Swift_COMPILER_VERSION VERSION_GREATER 5.3)
+  message(WARNING "Swift compiler does not support KeyPathIterable protocol - assuming stock toolchain")
+  set(TENSORFLOW_USE_STANDARD_TOOLCHAIN_DEFAULT ON)
+  # endif()
+endif()
+
+include(CMakeDependentOption)
+cmake_dependent_option(TENSORFLOW_USE_STANDARD_TOOLCHAIN
+  "Experimental support to use a standard toolchain"
+  ${TENSORFLOW_USE_STANDARD_TOOLCHAIN_DEFAULT}
+  "ENABLE_SWIFT_NUMERICS"
+  NO)
+
 add_subdirectory(Autoencoder)
 add_subdirectory(TensorBoard)
 add_subdirectory(Support)

--- a/Models/Text/CMakeLists.txt
+++ b/Models/Text/CMakeLists.txt
@@ -16,11 +16,14 @@ add_library(TextModels
   WordSeg/SemiRing.swift)
 set_target_properties(TextModels PROPERTIES
   INTERFACE_INCLUDE_DIRECTORIES ${CMAKE_Swift_MODULE_DIRECTORY})
+target_compile_definitions(TextModels PRIVATE
+  $<$<BOOL:${TENSORFLOW_USE_STANDARD_TOOLCHAIN}>:TENSORFLOW_USE_STANDARD_TOOLCHAIN>)
 target_compile_options(TextModels PRIVATE
   $<$<BOOL:${BUILD_TESTING}>:-enable-testing>)
 target_link_libraries(TextModels PUBLIC
   Checkpoints
   Datasets
+#  $<$<AND:$<BOOL:${ENABLE_SWIFT_NUMERICS}>,$<BOOL:${TENSORFLOW_USE_STANDARD_TOOLCHAIN}>>:Numerics>
   SwiftProtobuf)
 
 install(TARGETS TextModels

--- a/Models/Text/CMakeLists.txt
+++ b/Models/Text/CMakeLists.txt
@@ -23,7 +23,7 @@ target_compile_options(TextModels PRIVATE
 target_link_libraries(TextModels PUBLIC
   Checkpoints
   Datasets
-#  $<$<AND:$<BOOL:${ENABLE_SWIFT_NUMERICS}>,$<BOOL:${TENSORFLOW_USE_STANDARD_TOOLCHAIN}>>:Numerics>
+  $<$<AND:$<BOOL:${ENABLE_SWIFT_NUMERICS}>,$<BOOL:${TENSORFLOW_USE_STANDARD_TOOLCHAIN}>>:Numerics>
   SwiftProtobuf)
 
 install(TARGETS TextModels

--- a/Models/Text/WordSeg/Lattice.swift
+++ b/Models/Text/WordSeg/Lattice.swift
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import _Differentiation
 import ModelSupport
 import TensorFlow
 

--- a/Models/Text/WordSeg/Model.swift
+++ b/Models/Text/WordSeg/Model.swift
@@ -23,6 +23,10 @@
 import ModelSupport
 import TensorFlow
 
+#if TENSORFLOW_USE_STANDARD_TOOLCHAIN
+import Numerics
+#endif
+
 /// Types that can be optimized by an optimizer.
 ///
 /// TODO: Consider promoting this into a public protocol in swift-apis?

--- a/Models/Text/WordSeg/SemiRing.swift
+++ b/Models/Text/WordSeg/SemiRing.swift
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import _Differentiation
+
 #if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
   import Darwin
 #elseif os(Windows)

--- a/Package.swift
+++ b/Package.swift
@@ -27,6 +27,7 @@ let package = Package(
         .package(url: "https://github.com/apple/swift-protobuf.git", from: "1.10.0"),
         .package(url: "https://github.com/apple/swift-argument-parser", .branch("main")),
         .package(url: "https://github.com/google/swift-benchmark", from: "0.1.0"),
+        .package(url: "https://github.com/apple/swift-numerics", .branch("main")),
     ],
     targets: [
         .target(
@@ -35,12 +36,15 @@ let package = Package(
         .target(name: "Datasets", dependencies: ["ModelSupport"], path: "Datasets"),
         .target(name: "STBImage", path: "Support/STBImage"),
         .target(
-            name: "ModelSupport", dependencies: ["STBImage"], path: "Support",
-            exclude: ["STBImage"]),
+            name: "ModelSupport",
+            dependencies: ["STBImage", .product(name: "Numerics", package: "swift-numerics"),],
+            path: "Support", exclude: ["STBImage"]),
         .target(name: "TensorBoard", dependencies: ["SwiftProtobuf", "ModelSupport", "TrainingLoop"], path: "TensorBoard"),
         .target(name: "ImageClassificationModels", path: "Models/ImageClassification"),
         .target(name: "VideoClassificationModels", path: "Models/Spatiotemporal"),
-        .target(name: "TextModels", dependencies: ["Checkpoints", "Datasets", "SwiftProtobuf"], path: "Models/Text"),
+        .target(name: "TextModels",
+            dependencies: ["Checkpoints", "Datasets", "SwiftProtobuf", .product(name: "Numerics", package: "swift-numerics")],
+            path: "Models/Text"),
         .target(name: "RecommendationModels", path: "Models/Recommendation"),
         .target(name: "TrainingLoop", dependencies: ["ModelSupport"], path: "TrainingLoop"),
         .target(

--- a/Support/AnyLayer.swift
+++ b/Support/AnyLayer.swift
@@ -1,3 +1,19 @@
+// Copyright 2020 The TensorFlow Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// TODO: Re-enable this for the stock toolchain when it can be realigned with VectorProtocol.
+#if !TENSORFLOW_USE_STANDARD_TOOLCHAIN
 import TensorFlow
 import _Differentiation
 
@@ -253,3 +269,4 @@ extension AnyLayer: Layer {
     return _callAsFunction(input)
   }
 }
+#endif

--- a/Support/AnyLayerTangentVector.swift
+++ b/Support/AnyLayerTangentVector.swift
@@ -1,3 +1,19 @@
+// Copyright 2020 The TensorFlow Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// TODO: Re-enable this for the stock toolchain when it can be realigned with VectorProtocol.
+#if !TENSORFLOW_USE_STANDARD_TOOLCHAIN
 import TensorFlow
 import _Differentiation
 
@@ -824,3 +840,4 @@ extension AnyLayerTangentVector: ElementaryFunctions {
     return .init(box: x.box._root(n))
   }
 }
+#endif

--- a/Support/CMakeLists.txt
+++ b/Support/CMakeLists.txt
@@ -20,6 +20,8 @@ add_library(ModelSupport
   Text/WordSeg/Lexicon.swift)
 set_target_properties(ModelSupport PROPERTIES
   INTERFACE_INCLUDE_DIRECTORIES ${CMAKE_Swift_MODULE_DIRECTORY})
+target_compile_definitions(ModelSupport PRIVATE
+  $<$<BOOL:${TENSORFLOW_USE_STANDARD_TOOLCHAIN}>:TENSORFLOW_USE_STANDARD_TOOLCHAIN>)
 target_compile_options(ModelSupport PRIVATE
   $<$<BOOL:${BUILD_TESTING}>:-enable-testing>)
 target_link_libraries(ModelSupport PUBLIC

--- a/Tests/SupportTests/AnyLayerTests.swift
+++ b/Tests/SupportTests/AnyLayerTests.swift
@@ -16,6 +16,13 @@ import XCTest
 import ModelSupport
 import TensorFlow
 
+// TODO: Re-enable these once AnyLayer can be aligned with the new VectorProtocol.
+#if TENSORFLOW_USE_STANDARD_TOOLCHAIN
+final class AnyLayerTests: XCTestCase {
+    static var allTests = [(String, (XCTestCase) -> () -> Void)]()
+}
+#else
+
 struct ElementaryFunctionsTests<WrapperTestType: XCTestCase, Reference: ElementaryFunctions, Test: ElementaryFunctions> {
     let createReference: ([Float]) -> Reference
     let referenceToTest: (Reference) -> Test
@@ -167,3 +174,4 @@ final class AnyLayerTests: XCTestCase {
         ("testTangentVectorElementaryFunctions", testTangentVectorElementaryFunctions),
     ]
 }
+#endif

--- a/cmake/modules/CheckSwiftSourceCompiles.cmake
+++ b/cmake/modules/CheckSwiftSourceCompiles.cmake
@@ -1,0 +1,145 @@
+# Distributed under the OSI-approved BSD 3-Clause License.  See accompanying
+# file Copyright.txt or https://cmake.org/licensing for details.
+
+#[=======================================================================[.rst:
+CheckSwiftSourceCompiles
+----------------------
+
+Check if given Swift source compiles and links into an executable.
+
+.. command:: check_swift_source_compiles
+
+  .. code-block:: cmake
+
+    check_swift_source_compiles(<code> <resultVar>
+                                [FAIL_REGEX <regex1> [<regex2>...]])
+
+  Check that the source supplied in ``<code>`` can be compiled as a Swift source
+  file and linked as an executable. The result will be stored in the internal
+  cache variable specified by ``<resultVar>``, with a boolean true value for
+  success and boolean false for failure. If ``FAIL_REGEX`` is provided, then
+  failure is determined by checking if anything in the output matches any of the
+  specified regular expressions.
+
+  The underlying check is performed by the :command:`try_compile` command. The
+  compile and link commands can be influenced by setting any of the following
+  variables prior to calling ``check_swift_source_compiles()``:
+
+  ``CMAKE_REQUIRED_FLAGS``
+    Additional flags to pass to the compiler. Note that the contents of
+    :variable:`CMAKE_Swift_FLAGS <CMAKE_<LANG>_FLAGS>` and its associated
+    configuration-specific variable are automatically added to the compiler
+    command before the contents of ``CMAKE_REQUIRED_FLAGS``.
+
+  ``CMAKE_REQUIRED_DEFINITIONS``
+    A :ref:`;-list <CMake Language Lists>` of compiler definitions of the form
+    ``-DFOO`` or ``-DFOO=bar``. A definition for the name specified by
+    ``<resultVar>`` will also be added automatically.
+
+  ``CMAKE_REQUIRED_INCLUDES``
+    A :ref:`;-list <CMake Language Lists>` of header search paths to pass to
+    the compiler. These will be the only header search paths used by
+    ``try_compile()``, i.e. the contents of the :prop_dir:`INCLUDE_DIRECTORIES`
+    directory property will be ignored.
+
+  ``CMAKE_REQUIRED_LINK_OPTIONS``
+    A :ref:`;-list <CMake Language Lists>` of options to add to the link
+    command (see :command:`try_compile` for further details).
+
+  ``CMAKE_REQUIRED_LIBRARIES``
+    A :ref:`;-list <CMake Language Lists>` of libraries to add to the link
+    command. These can be the name of system libraries or they can be
+    :ref:`Imported Targets <Imported Targets>` (see :command:`try_compile` for
+    further details).
+
+  ``CMAKE_REQUIRED_QUIET``
+    If this variable evaluates to a boolean true value, all status messages
+    associated with the check will be suppressed.
+
+  The check is only performed once, with the result cached in the variable
+  named by ``<resultVar>``. Every subsequent CMake run will re-use this cached
+  value rather than performing the check again, even if the ``<code>`` changes.
+  In order to force the check to be re-evaluated, the variable named by
+  ``<resultVar>`` must be manually removed from the cache.
+
+#]=======================================================================]
+
+include_guard(GLOBAL)
+
+macro(CHECK_Swift_SOURCE_COMPILES SOURCE VAR)
+  if(NOT DEFINED "${VAR}")
+    set(_FAIL_REGEX)
+    set(_key)
+    foreach(arg ${ARGN})
+      if("${arg}" MATCHES "^(FAIL_REGEX)$")
+        set(_key "${arg}")
+      elseif(_key)
+        list(APPEND _${_key} "${arg}")
+      else()
+        message(FATAL_ERROR "Unknown argument:\n  ${arg}\n")
+      endif()
+    endforeach()
+
+    set(MACRO_CHECK_FUNCTION_DEFINITIONS
+      "-D${VAR} ${CMAKE_REQUIRED_FLAGS}")
+    if(CMAKE_REQUIRED_LINK_OPTIONS)
+      set(CHECK_Swift_SOURCE_COMPILES_ADD_LINK_OPTIONS
+        LINK_OPTIONS ${CMAKE_REQUIRED_LINK_OPTIONS})
+    else()
+      set(CHECK_Swift_SOURCE_COMPILES_ADD_LINK_OPTIONS)
+    endif()
+    if(CMAKE_REQUIRED_LIBRARIES)
+      set(CHECK_Swift_SOURCE_COMPILES_ADD_LIBRARIES
+        LINK_LIBRARIES ${CMAKE_REQUIRED_LIBRARIES})
+    else()
+      set(CHECK_Swift_SOURCE_COMPILES_ADD_LIBRARIES)
+    endif()
+    if(CMAKE_REQUIRED_INCLUDES)
+      set(CHECK_Swift_SOURCE_COMPILES_ADD_INCLUDES
+        "-DINCLUDE_DIRECTORIES:STRING=${CMAKE_REQUIRED_INCLUDES}")
+    else()
+      set(CHECK_Swift_SOURCE_COMPILES_ADD_INCLUDES)
+    endif()
+    file(WRITE "${CMAKE_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/CMakeTmp/src.swift"
+      "${SOURCE}\n")
+
+    if(NOT CMAKE_REQUIRED_QUIET)
+      message(CHECK_START "Performing Test ${VAR}")
+    endif()
+    try_compile(${VAR}
+      ${CMAKE_BINARY_DIR}
+      ${CMAKE_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/CMakeTmp/src.swift
+      COMPILE_DEFINITIONS ${CMAKE_REQUIRED_DEFINITIONS}
+      ${CHECK_Swift_SOURCE_COMPILES_ADD_LINK_OPTIONS}
+      ${CHECK_Swift_SOURCE_COMPILES_ADD_LIBRARIES}
+      CMAKE_FLAGS -DCOMPILE_DEFINITIONS:STRING=${MACRO_CHECK_FUNCTION_DEFINITIONS}
+      "${CHECK_Swift_SOURCE_COMPILES_ADD_INCLUDES}"
+      OUTPUT_VARIABLE OUTPUT)
+
+    foreach(_regex ${_FAIL_REGEX})
+      if("${OUTPUT}" MATCHES "${_regex}")
+        set(${VAR} 0)
+      endif()
+    endforeach()
+
+    if(${VAR})
+      set(${VAR} 1 CACHE INTERNAL "Test ${VAR}")
+      if(NOT CMAKE_REQUIRED_QUIET)
+        message(CHECK_PASS "Success")
+      endif()
+      file(APPEND ${CMAKE_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/CMakeOutput.log
+        "Performing Swift SOURCE FILE Test ${VAR} succeeded with the following output:\n"
+        "${OUTPUT}\n"
+        "Source file was:\n${SOURCE}\n")
+    else()
+      if(NOT CMAKE_REQUIRED_QUIET)
+        message(CHECK_FAIL "Failed")
+      endif()
+      set(${VAR} "" CACHE INTERNAL "Test ${VAR}")
+      file(APPEND ${CMAKE_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/CMakeError.log
+        "Performing Swift SOURCE FILE Test ${VAR} failed with the following output:\n"
+        "${OUTPUT}\n"
+        "Source file was:\n${SOURCE}\n")
+    endif()
+  endif()
+endmacro()


### PR DESCRIPTION
This provides the needed Numerics dependency, as well as missing _Differentiation imports, to support building while using a stock toolchain with swift-apis. For now, the AnyLayer type has been gated off from the stock toolchain until it can be reworked to support the new VectorProtocol.

To build this successfully under Swift Package Manager with the stock toolchain, you'll need to provide the `TENSORFLOW_USE_STANDARD_TOOLCHAIN` flag:

```sh
swift build -Xswiftc -D TENSORFLOW_USE_STANDARD_TOOLCHAIN
```

This is needed to avoid a conflict caused by the use of Numerics in the stock toolchain. CMake should detect this automatically, and does not require any additional command-line options.
