### PR TITLE
Stock toolchain cleanup

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -148,27 +148,6 @@ set_target_properties(ArgumentParser PROPERTIES
 add_dependencies(ArgumentParser swift-argument-parser-install)
 add_dependencies(turbojpeg libjpeg-turbo-build)
 
-option(ENABLE_SWIFT_NUMERICS
-  "Enable integrating swift-numerics" YES)
-
-include(CheckSwiftSourceCompiles)
-check_swift_source_compiles("struct S : KeyPathIterable { }" SWIFT_COMPILER_HAS_KEYPATHITERABLE_PROTOCOL)
-if(SWIFT_COMPILER_HAS_KEYPATHITERABLE_PROTOCOL)
-  set(TENSORFLOW_USE_STANDARD_TOOLCHAIN_DEFAULT OFF)
-else()
-  # if(CMAKE_Swift_COMPILER_VERSION VERSION_GREATER 5.3)
-  message(WARNING "Swift compiler does not support KeyPathIterable protocol - assuming stock toolchain")
-  set(TENSORFLOW_USE_STANDARD_TOOLCHAIN_DEFAULT ON)
-  # endif()
-endif()
-
-include(CMakeDependentOption)
-cmake_dependent_option(TENSORFLOW_USE_STANDARD_TOOLCHAIN
-  "Experimental support to use a standard toolchain"
-  ${TENSORFLOW_USE_STANDARD_TOOLCHAIN_DEFAULT}
-  "ENABLE_SWIFT_NUMERICS"
-  NO)
-
 add_subdirectory(Autoencoder)
 add_subdirectory(TensorBoard)
 add_subdirectory(Support)

--- a/Models/Text/CMakeLists.txt
+++ b/Models/Text/CMakeLists.txt
@@ -16,14 +16,11 @@ add_library(TextModels
   WordSeg/SemiRing.swift)
 set_target_properties(TextModels PROPERTIES
   INTERFACE_INCLUDE_DIRECTORIES ${CMAKE_Swift_MODULE_DIRECTORY})
-target_compile_definitions(TextModels PRIVATE
-  $<$<BOOL:${TENSORFLOW_USE_STANDARD_TOOLCHAIN}>:TENSORFLOW_USE_STANDARD_TOOLCHAIN>)
 target_compile_options(TextModels PRIVATE
   $<$<BOOL:${BUILD_TESTING}>:-enable-testing>)
 target_link_libraries(TextModels PUBLIC
   Checkpoints
   Datasets
-  $<$<AND:$<BOOL:${ENABLE_SWIFT_NUMERICS}>,$<BOOL:${TENSORFLOW_USE_STANDARD_TOOLCHAIN}>>:Numerics>
   SwiftProtobuf)
 
 install(TARGETS TextModels

--- a/Models/Text/WordSeg/Model.swift
+++ b/Models/Text/WordSeg/Model.swift
@@ -23,10 +23,6 @@
 import ModelSupport
 import TensorFlow
 
-#if TENSORFLOW_USE_STANDARD_TOOLCHAIN
-import Numerics
-#endif
-
 /// Types that can be optimized by an optimizer.
 ///
 /// TODO: Consider promoting this into a public protocol in swift-apis?

--- a/Package.swift
+++ b/Package.swift
@@ -27,7 +27,6 @@ let package = Package(
         .package(url: "https://github.com/apple/swift-protobuf.git", from: "1.10.0"),
         .package(url: "https://github.com/apple/swift-argument-parser", .branch("main")),
         .package(url: "https://github.com/google/swift-benchmark", from: "0.1.0"),
-        .package(url: "https://github.com/apple/swift-numerics", .branch("main")),
     ],
     targets: [
         .target(
@@ -36,14 +35,12 @@ let package = Package(
         .target(name: "Datasets", dependencies: ["ModelSupport"], path: "Datasets"),
         .target(name: "STBImage", path: "Support/STBImage"),
         .target(
-            name: "ModelSupport",
-            dependencies: ["STBImage", .product(name: "Numerics", package: "swift-numerics"),],
-            path: "Support", exclude: ["STBImage"]),
+            name: "ModelSupport", dependencies: ["STBImage"], path: "Support", exclude: ["STBImage"]),
         .target(name: "TensorBoard", dependencies: ["SwiftProtobuf", "ModelSupport", "TrainingLoop"], path: "TensorBoard"),
         .target(name: "ImageClassificationModels", path: "Models/ImageClassification"),
         .target(name: "VideoClassificationModels", path: "Models/Spatiotemporal"),
         .target(name: "TextModels",
-            dependencies: ["Checkpoints", "Datasets", "SwiftProtobuf", .product(name: "Numerics", package: "swift-numerics")],
+            dependencies: ["Checkpoints", "Datasets", "SwiftProtobuf"],
             path: "Models/Text"),
         .target(name: "RecommendationModels", path: "Models/Recommendation"),
         .target(name: "TrainingLoop", dependencies: ["ModelSupport"], path: "TrainingLoop"),

--- a/Support/AnyLayer.swift
+++ b/Support/AnyLayer.swift
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 // TODO: Re-enable this for the stock toolchain when it can be realigned with VectorProtocol.
-#if !TENSORFLOW_USE_STANDARD_TOOLCHAIN
 import TensorFlow
 import _Differentiation
 
@@ -41,7 +40,7 @@ fileprivate func mustOverride(function: StaticString = #function, file: StaticSt
 ///   - Input: the input type of the underlying layar
 ///   - Output: the output type of the underlying layer
 ///   - Scalar: the scalar type of the underlying tangent vector
-internal class AnyLayerBox<Input: Differentiable, Output: Differentiable, Scalar: FloatingPoint & ElementaryFunctions> {
+internal class AnyLayerBox<Input: Differentiable, Output: Differentiable> {
   /// The underlying layer, type-erased to `Any`.
   var typeErasedBase: Any {
     mustOverride()
@@ -49,19 +48,19 @@ internal class AnyLayerBox<Input: Differentiable, Output: Differentiable, Scalar
 
   /// Returns the underlying layer unboxed to the given type, if possible.
   func unboxed<U: Layer>(to type: U.Type) -> U?
-  where U.TangentVector.VectorSpaceScalar == Scalar {
+  where U.TangentVector.VectorSpaceScalar == Float {
     mustOverride()
   }
   
   // `Differentiable` requirements.
   /// Moves `self` along the given direction. In Riemannian geometry, this is equivalent to exponential map, which moves `self` on the geodesic surface along the given tangent vector.
-  func _move(along direction: AnyLayerTangentVector<Scalar>) {
+  func _move(along direction: AnyLayerTangentVector) {
     mustOverride()
   }
 
   // `EuclideanDifferentiable` requirements.
   /// The differentiable vector component of `self`.
-  var _differentiableVectorView: AnyLayerTangentVector<Scalar> {
+  var _differentiableVectorView: AnyLayerTangentVector {
     mustOverride()
   }
 
@@ -72,7 +71,7 @@ internal class AnyLayerBox<Input: Differentiable, Output: Differentiable, Scalar
   }
 
   func _vjpCallAsFunction(_ input: Input) ->
-    (value: Output, pullback: (Output.TangentVector) -> (AnyLayerTangentVector<Scalar>, Input.TangentVector)) {
+    (value: Output, pullback: (Output.TangentVector) -> (AnyLayerTangentVector, Input.TangentVector)) {
     mustOverride()
   }
 
@@ -84,14 +83,14 @@ internal class AnyLayerBox<Input: Differentiable, Output: Differentiable, Scalar
   }
 
   /// Creates a new box storing a copy of the underlying layer, used to preserve value semantics.
-  func duplicate() -> AnyLayerBox<Input, Output, Scalar> {
+  func duplicate() -> AnyLayerBox<Input, Output> {
     mustOverride()
   }
 }
 
 /// A concrete implementation of the type-erased layer wrapper that forwards to an underlying layer.
-internal class ConcreteLayerBox<Underlying: Layer>: AnyLayerBox<Underlying.Input, Underlying.Output, Underlying.TangentVector.VectorSpaceScalar>
-where Underlying.TangentVector.VectorSpaceScalar: FloatingPoint & ElementaryFunctions {
+internal class ConcreteLayerBox<Underlying: Layer>: AnyLayerBox<Underlying.Input, Underlying.Output> 
+where Underlying.TangentVector.VectorSpaceScalar == Float {
   /// The underlying layer.
   var underlying: Underlying
 
@@ -107,12 +106,12 @@ where Underlying.TangentVector.VectorSpaceScalar: FloatingPoint & ElementaryFunc
 
   /// Returns the underlying layer unboxed to the given type, if possible.
   override func unboxed<U: Layer>(to type: U.Type) -> U?
-  where U.TangentVector.VectorSpaceScalar == Underlying.TangentVector.VectorSpaceScalar {
+  where U.TangentVector.VectorSpaceScalar == Float {
     return (self as? ConcreteLayerBox<U>)?.underlying
   }
 
   // `Differentiable` requirements.
-  override func _move(along direction: AnyLayerTangentVector<Underlying.TangentVector.VectorSpaceScalar>) {
+  override func _move(along direction: AnyLayerTangentVector) {
     if let scalarDirection = direction.box.getOpaqueScalar() {
       underlying.move(along: Underlying.TangentVector.zero.adding(scalarDirection))
     } else {
@@ -125,7 +124,7 @@ where Underlying.TangentVector.VectorSpaceScalar: FloatingPoint & ElementaryFunc
   }
 
   // `EuclideanDifferentiable` requirements.
-  public override var _differentiableVectorView: AnyLayerTangentVector<Underlying.TangentVector.VectorSpaceScalar> {
+  public override var _differentiableVectorView: AnyLayerTangentVector {
     return AnyLayerTangentVector(underlying.differentiableVectorView)
   }
 
@@ -143,7 +142,7 @@ where Underlying.TangentVector.VectorSpaceScalar: FloatingPoint & ElementaryFunc
   override func _vjpCallAsFunction(_ input: Underlying.Input) -> (
     value: Underlying.Output,
     pullback: (Underlying.Output.TangentVector) ->
-      (AnyLayerTangentVector<Underlying.TangentVector.VectorSpaceScalar>, Underlying.Input.TangentVector)
+      (AnyLayerTangentVector, Underlying.Input.TangentVector)
   ) {
     let basePullback = valueWithPullback(
       at: ModelAndInput(model: underlying, input: input),
@@ -155,7 +154,7 @@ where Underlying.TangentVector.VectorSpaceScalar: FloatingPoint & ElementaryFunc
       pullback: { (outTangent) in
         let pairTangent = basePullback.pullback(outTangent)
         return (
-          AnyLayerTangentVector<Underlying.TangentVector.VectorSpaceScalar>(pairTangent.model),
+          AnyLayerTangentVector(pairTangent.model),
           pairTangent.input
         )
       }
@@ -164,12 +163,12 @@ where Underlying.TangentVector.VectorSpaceScalar: FloatingPoint & ElementaryFunc
 
   // `CopyableToDevice` requirements.
   override func _copyToDevice(to device: Device) ->
-    AnyLayerBox<Underlying.Input, Underlying.Output, Underlying.TangentVector.VectorSpaceScalar> {
+    AnyLayerBox<Underlying.Input, Underlying.Output> {
     return ConcreteLayerBox(Underlying(copying: underlying, to: device))
   }
 
   override func duplicate() ->
-    AnyLayerBox<Underlying.Input, Underlying.Output, Underlying.TangentVector.VectorSpaceScalar> {
+    AnyLayerBox<Underlying.Input, Underlying.Output> {
     return ConcreteLayerBox(underlying)
   }
 }
@@ -189,11 +188,10 @@ where Underlying.TangentVector.VectorSpaceScalar: FloatingPoint & ElementaryFunc
 /// Type Parameters:
 ///   - Input: the input type of the underlying layar
 ///   - Output: the output type of the underlying layer
-///   - Scalar: the scalar type of the underlying tangent vector
-public struct AnyLayer<Input: Differentiable, Output: Differentiable, Scalar: FloatingPoint & ElementaryFunctions>: CopyableToDevice {
-  internal var box: AnyLayerBox<Input, Output, Scalar>
+public struct AnyLayer<Input: Differentiable, Output: Differentiable>: CopyableToDevice {
+  internal var box: AnyLayerBox<Input, Output>
 
-  internal init(box: AnyLayerBox<Input, Output, Scalar>) {
+  internal init(box: AnyLayerBox<Input, Output>) {
     self.box = box
   }
 
@@ -205,7 +203,7 @@ public struct AnyLayer<Input: Differentiable, Output: Differentiable, Scalar: Fl
   /// Creates a type-erased derivative from the given layer.
   @differentiable
   public init<Underlying: Layer>(_ layer: Underlying)
-  where Underlying.Input == Input, Underlying.Output == Output, Underlying.TangentVector.VectorSpaceScalar == Scalar {
+  where Underlying.Input == Input, Underlying.Output == Output, Underlying.TangentVector.VectorSpaceScalar == Float {
     self.box = ConcreteLayerBox<Underlying>(layer)
   }
 
@@ -217,10 +215,10 @@ public struct AnyLayer<Input: Differentiable, Output: Differentiable, Scalar: Fl
   @derivative(of: init)
   internal static func _vjpInit<T: Layer>(
     _ base: T
-  ) -> (value: AnyLayer, pullback: (AnyLayerTangentVector<Scalar>) -> T.TangentVector)
-  where T.Input == Input, T.Output == Output, T.TangentVector.VectorSpaceScalar == Scalar
+  ) -> (value: AnyLayer, pullback: (AnyLayerTangentVector) -> T.TangentVector)
+  where T.Input == Input, T.Output == Output, T.TangentVector.VectorSpaceScalar == Float
   {
-    return (AnyLayer<Input, Output, Scalar>(base), { v in v.unboxed(as: T.TangentVector.self)! })
+    return (AnyLayer<Input, Output>(base), { v in v.unboxed(as: T.TangentVector.self)! })
   }
 
   @inlinable
@@ -228,14 +226,14 @@ public struct AnyLayer<Input: Differentiable, Output: Differentiable, Scalar: Fl
   internal static func _jvpInit<T: Layer>(
     _ base: T
   ) -> (
-    value: AnyLayer, differential: (T.TangentVector) -> AnyLayerTangentVector<Scalar>
-  ) where T.Input == Input, T.Output == Output, T.TangentVector.VectorSpaceScalar == Scalar {
-    return (AnyLayer<Input, Output, Scalar>(base), { dbase in AnyLayerTangentVector<Scalar>(dbase) })
+    value: AnyLayer, differential: (T.TangentVector) -> AnyLayerTangentVector
+  ) where T.Input == Input, T.Output == Output, T.TangentVector.VectorSpaceScalar == Float {
+    return (AnyLayer<Input, Output>(base), { dbase in AnyLayerTangentVector(dbase) })
   }
 }
 
 extension AnyLayer: Differentiable {
-  public typealias TangentVector = AnyLayerTangentVector<Scalar>
+  public typealias TangentVector = AnyLayerTangentVector
 
   public mutating func move(along direction: TangentVector) {
     if !isKnownUniquelyReferenced(&box) { // preserve value semantics
@@ -260,7 +258,7 @@ extension AnyLayer: Layer {
 
   @derivative(of: _callAsFunction)
   func _vjpCallAsFunction(_ input: Input) ->
-    (value: Output, pullback: (Output.TangentVector) -> (AnyLayerTangentVector<Scalar>, Input.TangentVector)) {
+    (value: Output, pullback: (Output.TangentVector) -> (AnyLayerTangentVector, Input.TangentVector)) {
     return box._vjpCallAsFunction(input)
   }
 
@@ -269,4 +267,3 @@ extension AnyLayer: Layer {
     return _callAsFunction(input)
   }
 }
-#endif

--- a/Support/AnyLayerTangentVector.swift
+++ b/Support/AnyLayerTangentVector.swift
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// TODO: Re-enable this for the stock toolchain when it can be realigned with VectorProtocol.
-#if !TENSORFLOW_USE_STANDARD_TOOLCHAIN
 import TensorFlow
 import _Differentiation
 
@@ -29,7 +27,7 @@ public typealias TangentVectorConformances = Differentiable & VectorProtocol & E
 /// `EuclideanDifferentiable`, `PointwiseMultiplicative`, and `ElementaryFunctions`.
 /// Type Parameters:
 ///   - Scalar: the scalar type of the underlying tangent vector
-internal class AnyLayerTangentVectorBox<Scalar: FloatingPoint & ElementaryFunctions> {
+internal class AnyLayerTangentVectorBox {
   /// The underlying value, type-erased to `Any`.
   var typeErasedBase: Any {
     mustOverride()
@@ -37,7 +35,7 @@ internal class AnyLayerTangentVectorBox<Scalar: FloatingPoint & ElementaryFuncti
 
   /// Returns the underlying value unboxed to the given type, if possible.
   func unboxed<U: TangentVectorConformances>(as type: U.Type) -> U?
-  where U.TangentVector == U, U.VectorSpaceScalar == Scalar {
+  where U.TangentVector == U, U.VectorSpaceScalar == Float {
     mustOverride()
   }
 
@@ -74,21 +72,21 @@ internal class AnyLayerTangentVectorBox<Scalar: FloatingPoint & ElementaryFuncti
   }
   
   // `VectorProtocol` requirements.
-  func _adding(_ x: Scalar) -> AnyLayerTangentVectorBox {
+  func _adding(_ x: Float) -> AnyLayerTangentVectorBox {
     mustOverride()
   }
-  func _subtracting(_ x: Scalar) -> AnyLayerTangentVectorBox {
+  func _subtracting(_ x: Float) -> AnyLayerTangentVectorBox {
     mustOverride()
   }
 
   /// Returns `self` multiplied by the given scalar.
-  func _scaled(by: Scalar) -> AnyLayerTangentVectorBox {
+  func _scaled(by: Float) -> AnyLayerTangentVectorBox {
     mustOverride()
   }
 
   // `Differentiable` requirements.
   /// Moves `self` along the given direction. In Riemannian geometry, this is equivalent to exponential map, which moves `self` on the geodesic surface along the given tangent vector.
-  func _move(along direction: AnyLayerTangentVector<Scalar>) {
+  func _move(along direction: AnyLayerTangentVector) {
     mustOverride()
   }
 
@@ -190,26 +188,27 @@ internal class AnyLayerTangentVectorBox<Scalar: FloatingPoint & ElementaryFuncti
     mustOverride()
   }
   
-  /// The exp2 function.
-  func _exp2() -> AnyLayerTangentVectorBox {
+  #if TENSORFLOW_USE_STANDARD_TOOLCHAIN
+  /// The expMinusOne function.
+  func _expMinusOne() -> AnyLayerTangentVectorBox {
     mustOverride()
   }
-  
+  #else    
   /// The exp10 function.
   func _exp10() -> AnyLayerTangentVectorBox {
     mustOverride()
   }
-  
+
+  /// The exp2 function.
+  func _exp2() -> AnyLayerTangentVectorBox {
+    mustOverride()
+  }
+
   /// The expm1 function.
   func _expm1() -> AnyLayerTangentVectorBox {
     mustOverride()
   }
-  
-  /// The log function.
-  func _log() -> AnyLayerTangentVectorBox {
-    mustOverride()
-  }
-  
+
   /// The log2 function.
   func _log2() -> AnyLayerTangentVectorBox {
     mustOverride()
@@ -217,6 +216,12 @@ internal class AnyLayerTangentVectorBox<Scalar: FloatingPoint & ElementaryFuncti
   
   /// The log10 function.
   func _log10() -> AnyLayerTangentVectorBox {
+    mustOverride()
+  }
+  #endif
+  
+  /// The log function.
+  func _log() -> AnyLayerTangentVectorBox {
     mustOverride()
   }
   
@@ -245,14 +250,14 @@ internal class AnyLayerTangentVectorBox<Scalar: FloatingPoint & ElementaryFuncti
 
 extension AnyLayerTangentVectorBox {
   /// Optionally returns the underlying scalar if the wrapped value has type `AnyLayerTangentVector.OpaqueScalar`.
-  func getOpaqueScalar() -> Scalar? {
-    return unboxed(as: AnyLayerTangentVector<Scalar>.OpaqueScalar.self)?.value
+  func getOpaqueScalar() -> Float? {
+    return unboxed(as: AnyLayerTangentVector.OpaqueScalar.self)?.value
   }
 }
 
 /// A concrete implementation of the type-erased tangent vector wrapper that forwards to an underlying tangent vector.
-internal class ConcreteAnyLayerTangentVectorBox<Underlying: TangentVectorConformances>: AnyLayerTangentVectorBox<Underlying.VectorSpaceScalar>
-where Underlying.TangentVector == Underlying, Underlying.VectorSpaceScalar: FloatingPoint & ElementaryFunctions {
+internal class ConcreteAnyLayerTangentVectorBox<Underlying: TangentVectorConformances>: AnyLayerTangentVectorBox
+where Underlying.TangentVector == Underlying, Underlying.VectorSpaceScalar == Float {
   /// The underlying tangent vector.
   var underlying: Underlying
 
@@ -270,12 +275,12 @@ where Underlying.TangentVector == Underlying, Underlying.VectorSpaceScalar: Floa
     return (self as? ConcreteAnyLayerTangentVectorBox<U>)?.underlying
   }
 
-  override func duplicate() -> AnyLayerTangentVectorBox<Underlying.VectorSpaceScalar> {
+  override func duplicate() -> AnyLayerTangentVectorBox {
     return ConcreteAnyLayerTangentVectorBox(underlying)
   }
 
   // `Equatable` requirements (implied by `AdditiveArithmetic`).
-  override func _isEqual(to other: AnyLayerTangentVectorBox<Underlying.VectorSpaceScalar>) -> Bool {
+  override func _isEqual(to other: AnyLayerTangentVectorBox) -> Bool {
     if let otherScalar = other.getOpaqueScalar() {
       if let scalar = getOpaqueScalar() {
         return scalar == otherScalar
@@ -289,7 +294,7 @@ where Underlying.TangentVector == Underlying, Underlying.VectorSpaceScalar: Floa
     }
   }
 
-  override func _isNotEqual(to other: AnyLayerTangentVectorBox<Underlying.VectorSpaceScalar>) -> Bool {
+  override func _isNotEqual(to other: AnyLayerTangentVectorBox) -> Bool {
     if let otherScalar = other.getOpaqueScalar() {
       if let scalar = getOpaqueScalar() {
         return scalar != otherScalar
@@ -304,11 +309,11 @@ where Underlying.TangentVector == Underlying, Underlying.VectorSpaceScalar: Floa
   }
 
   // `AdditiveArithmetic` requirements.
-  override class var _zero: AnyLayerTangentVectorBox<Underlying.VectorSpaceScalar> {
+  override class var _zero: AnyLayerTangentVectorBox {
     return ConcreteAnyLayerTangentVectorBox(Underlying.zero)
   }
 
-  override func _add(_ x: AnyLayerTangentVectorBox<Underlying.VectorSpaceScalar>) -> AnyLayerTangentVectorBox<Underlying.VectorSpaceScalar> {
+  override func _add(_ x: AnyLayerTangentVectorBox) -> AnyLayerTangentVectorBox {
     if let scalar = getOpaqueScalar() {
       // use the associative property, self + x = x + self
       return x._adding(scalar)
@@ -325,10 +330,10 @@ where Underlying.TangentVector == Underlying, Underlying.VectorSpaceScalar: Floa
     return ConcreteAnyLayerTangentVectorBox(underlying + xBase)
   }
 
-  override func _subtract(_ x: AnyLayerTangentVectorBox<Underlying.VectorSpaceScalar>) -> AnyLayerTangentVectorBox<Underlying.VectorSpaceScalar> {
+  override func _subtract(_ x: AnyLayerTangentVectorBox) -> AnyLayerTangentVectorBox {
     if let scalar = getOpaqueScalar() {
       // expand by definition of opqaue scalars and perform the original operation
-      return AnyLayerTangentVectorBox<Underlying.VectorSpaceScalar>._one._scaled(by: scalar)._subtract(x)
+      return AnyLayerTangentVectorBox._one._scaled(by: scalar)._subtract(x)
     }
 
     if let scalar = x.getOpaqueScalar() {
@@ -343,105 +348,105 @@ where Underlying.TangentVector == Underlying, Underlying.VectorSpaceScalar: Floa
   }
   
   // `VectorProtocol` requirements.
-  override func _adding(_ x: Underlying.VectorSpaceScalar) -> AnyLayerTangentVectorBox<Underlying.VectorSpaceScalar> {
-    return ConcreteAnyLayerTangentVectorBox<Underlying>(underlying.adding(x))
+  override func _adding(_ x: Underlying.VectorSpaceScalar) -> AnyLayerTangentVectorBox {
+    return ConcreteAnyLayerTangentVectorBox(underlying.adding(x))
   }
-  override func _subtracting(_ x: Underlying.VectorSpaceScalar) -> AnyLayerTangentVectorBox<Underlying.VectorSpaceScalar> {
-    return ConcreteAnyLayerTangentVectorBox<Underlying>(underlying.subtracting(x))
+  override func _subtracting(_ x: Underlying.VectorSpaceScalar) -> AnyLayerTangentVectorBox {
+    return ConcreteAnyLayerTangentVectorBox(underlying.subtracting(x))
   }
-  override func _scaled(by: Underlying.VectorSpaceScalar) -> AnyLayerTangentVectorBox<Underlying.VectorSpaceScalar> {
-    return ConcreteAnyLayerTangentVectorBox<Underlying>(underlying.scaled(by: by))
+  override func _scaled(by: Underlying.VectorSpaceScalar) -> AnyLayerTangentVectorBox {
+    return ConcreteAnyLayerTangentVectorBox(underlying.scaled(by: by))
   }
 
   // `PointwiseMultiplicative` requirements.
-  override class var _one: AnyLayerTangentVectorBox<Underlying.VectorSpaceScalar> {
-    return ConcreteAnyLayerTangentVectorBox<Underlying>(Underlying.one)
+  override class var _one: AnyLayerTangentVectorBox {
+    return ConcreteAnyLayerTangentVectorBox(Underlying.one)
   }
 
-  override func _reciprocal() -> AnyLayerTangentVectorBox<Underlying.VectorSpaceScalar> {
-    return ConcreteAnyLayerTangentVectorBox<Underlying>(underlying.reciprocal)
+  override func _reciprocal() -> AnyLayerTangentVectorBox {
+    return ConcreteAnyLayerTangentVectorBox(underlying.reciprocal)
   }
 
-  override func _pointwiseMultiply(by: AnyLayerTangentVectorBox<Underlying.VectorSpaceScalar>) -> AnyLayerTangentVectorBox<Underlying.VectorSpaceScalar> {
-    return ConcreteAnyLayerTangentVectorBox<Underlying>(underlying .* by.unboxed(as: Underlying.self)!)
+  override func _pointwiseMultiply(by: AnyLayerTangentVectorBox) -> AnyLayerTangentVectorBox {
+    return ConcreteAnyLayerTangentVectorBox(underlying .* by.unboxed(as: Underlying.self)!)
   }
 
   // `ElementaryFunctions` requirements.
-  override func _sqrt() -> AnyLayerTangentVectorBox<Underlying.VectorSpaceScalar> {
-    return ConcreteAnyLayerTangentVectorBox<Underlying>(Underlying.sqrt(underlying));
+  override func _sqrt() -> AnyLayerTangentVectorBox {
+    return ConcreteAnyLayerTangentVectorBox(Underlying.sqrt(underlying));
   }
-  override func _cos() -> AnyLayerTangentVectorBox<Underlying.VectorSpaceScalar> {
-    return ConcreteAnyLayerTangentVectorBox<Underlying>(Underlying.cos(underlying));
+  override func _cos() -> AnyLayerTangentVectorBox {
+    return ConcreteAnyLayerTangentVectorBox(Underlying.cos(underlying));
   }
-  override func _sin() -> AnyLayerTangentVectorBox<Underlying.VectorSpaceScalar> {
-    return ConcreteAnyLayerTangentVectorBox<Underlying>(Underlying.sin(underlying));
+  override func _sin() -> AnyLayerTangentVectorBox {
+    return ConcreteAnyLayerTangentVectorBox(Underlying.sin(underlying));
   }
-  override func _tan() -> AnyLayerTangentVectorBox<Underlying.VectorSpaceScalar> {
-    return ConcreteAnyLayerTangentVectorBox<Underlying>(Underlying.tan(underlying));
+  override func _tan() -> AnyLayerTangentVectorBox {
+    return ConcreteAnyLayerTangentVectorBox(Underlying.tan(underlying));
   }
-  override func _acos() -> AnyLayerTangentVectorBox<Underlying.VectorSpaceScalar> {
-    return ConcreteAnyLayerTangentVectorBox<Underlying>(Underlying.acos(underlying));
+  override func _acos() -> AnyLayerTangentVectorBox {
+    return ConcreteAnyLayerTangentVectorBox(Underlying.acos(underlying));
   }
-  override func _asin() -> AnyLayerTangentVectorBox<Underlying.VectorSpaceScalar> {
-    return ConcreteAnyLayerTangentVectorBox<Underlying>(Underlying.asin(underlying));
+  override func _asin() -> AnyLayerTangentVectorBox {
+    return ConcreteAnyLayerTangentVectorBox(Underlying.asin(underlying));
   }
-  override func _atan() -> AnyLayerTangentVectorBox<Underlying.VectorSpaceScalar> {
-    return ConcreteAnyLayerTangentVectorBox<Underlying>(Underlying.atan(underlying));
+  override func _atan() -> AnyLayerTangentVectorBox {
+    return ConcreteAnyLayerTangentVectorBox(Underlying.atan(underlying));
   }
-  override func _cosh() -> AnyLayerTangentVectorBox<Underlying.VectorSpaceScalar> {
-    return ConcreteAnyLayerTangentVectorBox<Underlying>(Underlying.cosh(underlying));
+  override func _cosh() -> AnyLayerTangentVectorBox {
+    return ConcreteAnyLayerTangentVectorBox(Underlying.cosh(underlying));
   }
-  override func _sinh() -> AnyLayerTangentVectorBox<Underlying.VectorSpaceScalar> {
-    return ConcreteAnyLayerTangentVectorBox<Underlying>(Underlying.sinh(underlying));
+  override func _sinh() -> AnyLayerTangentVectorBox {
+    return ConcreteAnyLayerTangentVectorBox(Underlying.sinh(underlying));
   }
-  override func _tanh() -> AnyLayerTangentVectorBox<Underlying.VectorSpaceScalar> {
-    return ConcreteAnyLayerTangentVectorBox<Underlying>(Underlying.tanh(underlying));
+  override func _tanh() -> AnyLayerTangentVectorBox {
+    return ConcreteAnyLayerTangentVectorBox(Underlying.tanh(underlying));
   }
-  override func _acosh() -> AnyLayerTangentVectorBox<Underlying.VectorSpaceScalar> {
-    return ConcreteAnyLayerTangentVectorBox<Underlying>(Underlying.acosh(underlying));
+  override func _acosh() -> AnyLayerTangentVectorBox {
+    return ConcreteAnyLayerTangentVectorBox(Underlying.acosh(underlying));
   }
-  override func _asinh() -> AnyLayerTangentVectorBox<Underlying.VectorSpaceScalar> {
-    return ConcreteAnyLayerTangentVectorBox<Underlying>(Underlying.asinh(underlying));
+  override func _asinh() -> AnyLayerTangentVectorBox {
+    return ConcreteAnyLayerTangentVectorBox(Underlying.asinh(underlying));
   }
-  override func _atanh() -> AnyLayerTangentVectorBox<Underlying.VectorSpaceScalar> {
-    return ConcreteAnyLayerTangentVectorBox<Underlying>(Underlying.atanh(underlying));
+  override func _atanh() -> AnyLayerTangentVectorBox {
+    return ConcreteAnyLayerTangentVectorBox(Underlying.atanh(underlying));
   }
-  override func _exp() -> AnyLayerTangentVectorBox<Underlying.VectorSpaceScalar> {
-    return ConcreteAnyLayerTangentVectorBox<Underlying>(Underlying.exp(underlying));
+  override func _exp() -> AnyLayerTangentVectorBox {
+    return ConcreteAnyLayerTangentVectorBox(Underlying.exp(underlying));
   }
-  override func _exp2() -> AnyLayerTangentVectorBox<Underlying.VectorSpaceScalar> {
-    return ConcreteAnyLayerTangentVectorBox<Underlying>(Underlying.exp2(underlying));
+  #if TENSORFLOW_USE_STANDARD_TOOLCHAIN
+  override func _expMinusOne() -> AnyLayerTangentVectorBox {
+    return ConcreteAnyLayerTangentVectorBox(Underlying.expMinusOne(underlying));
   }
-  override func _exp10() -> AnyLayerTangentVectorBox<Underlying.VectorSpaceScalar> {
-    return ConcreteAnyLayerTangentVectorBox<Underlying>(Underlying.exp10(underlying));
+  override func _log1p() -> AnyLayerTangentVectorBox {
+    return ConcreteAnyLayerTangentVectorBox(Underlying.log(onePlus: underlying));
   }
-  override func _expm1() -> AnyLayerTangentVectorBox<Underlying.VectorSpaceScalar> {
-    return ConcreteAnyLayerTangentVectorBox<Underlying>(Underlying.expm1(underlying));
+  #else
+  override func _exp2() -> AnyLayerTangentVectorBox {
+    return ConcreteAnyLayerTangentVectorBox(Underlying.exp2(underlying));
   }
-  override func _log() -> AnyLayerTangentVectorBox<Underlying.VectorSpaceScalar> {
-    return ConcreteAnyLayerTangentVectorBox<Underlying>(Underlying.log(underlying));
+  override func _exp10() -> AnyLayerTangentVectorBox {
+    return ConcreteAnyLayerTangentVectorBox(Underlying.exp10(underlying));
   }
-  override func _log2() -> AnyLayerTangentVectorBox<Underlying.VectorSpaceScalar> {
-    return ConcreteAnyLayerTangentVectorBox<Underlying>(Underlying.log2(underlying));
+  override func _log1p() -> AnyLayerTangentVectorBox {
+    return ConcreteAnyLayerTangentVectorBox(Underlying.log1p(underlying));
   }
-  override func _log10() -> AnyLayerTangentVectorBox<Underlying.VectorSpaceScalar> {
-    return ConcreteAnyLayerTangentVectorBox<Underlying>(Underlying.log10(underlying));
+  #endif
+  override func _log() -> AnyLayerTangentVectorBox {
+    return ConcreteAnyLayerTangentVectorBox(Underlying.log(underlying));
   }
-  override func _log1p() -> AnyLayerTangentVectorBox<Underlying.VectorSpaceScalar> {
-    return ConcreteAnyLayerTangentVectorBox<Underlying>(Underlying.log1p(underlying));
+  override func _pow(_ y: AnyLayerTangentVectorBox) -> AnyLayerTangentVectorBox {
+    return ConcreteAnyLayerTangentVectorBox(Underlying.pow(underlying, y.unboxed(as: Underlying.self)!));
   }
-  override func _pow(_ y: AnyLayerTangentVectorBox<Underlying.VectorSpaceScalar>) -> AnyLayerTangentVectorBox<Underlying.VectorSpaceScalar> {
-    return ConcreteAnyLayerTangentVectorBox<Underlying>(Underlying.pow(underlying, y.unboxed(as: Underlying.self)!));
+  override func _pow(_ n: Int) -> AnyLayerTangentVectorBox {
+    return ConcreteAnyLayerTangentVectorBox(Underlying.pow(underlying, n));
   }
-  override func _pow(_ n: Int) -> AnyLayerTangentVectorBox<Underlying.VectorSpaceScalar> {
-    return ConcreteAnyLayerTangentVectorBox<Underlying>(Underlying.pow(underlying, n));
-  }
-  override func _root(_ n: Int) -> AnyLayerTangentVectorBox<Underlying.VectorSpaceScalar> {
-    return ConcreteAnyLayerTangentVectorBox<Underlying>(Underlying.root(underlying, n));
+  override func _root(_ n: Int) -> AnyLayerTangentVectorBox {
+    return ConcreteAnyLayerTangentVectorBox(Underlying.root(underlying, n));
   }
 
   // `Differentiable` requirements.
-  override func _move(along direction: AnyLayerTangentVector<Underlying.VectorSpaceScalar>) {
+  override func _move(along direction: AnyLayerTangentVector) {
     if let scalarDirection = direction.box.getOpaqueScalar() {
       underlying.move(along: Underlying.TangentVector.zero.adding(scalarDirection))
     } else {
@@ -454,7 +459,7 @@ where Underlying.TangentVector == Underlying, Underlying.VectorSpaceScalar: Floa
   }
 
   // `EuclideanDifferentiable` requirements.
-  override var _differentiableVectorView: AnyLayerTangentVectorBox<Underlying.VectorSpaceScalar> {
+  override var _differentiableVectorView: AnyLayerTangentVectorBox {
     return self
   }
 }
@@ -464,16 +469,16 @@ where Underlying.TangentVector == Underlying, Underlying.VectorSpaceScalar: Floa
 /// The `AnyLayerTangentVector` type forwards its operations to an arbitrary underlying
 /// base derivative value conforming to `Differentiable`, `VectorProtocol`,
 /// `ElementaryFunctions`, and `PointwiseMultiplicative`, hiding the specifics of the underlying value.
-public struct AnyLayerTangentVector<F: FloatingPoint & ElementaryFunctions>: KeyPathIterable {
-  internal var box: AnyLayerTangentVectorBox<F>
+public struct AnyLayerTangentVector: KeyPathIterable {
+  internal var box: AnyLayerTangentVectorBox
 
-  internal init(box: AnyLayerTangentVectorBox<F>) {
+  internal init(box: AnyLayerTangentVectorBox) {
     self.box = box
   }
 
   /// Returns the underlying value unboxed to the given type, if possible.
   public func unboxed<U: TangentVectorConformances>(as type: U.Type) -> U?
-    where U.TangentVector == U, U.VectorSpaceScalar == F {
+    where U.TangentVector == U, U.VectorSpaceScalar == Float {
     return box.unboxed(as: type)
   }
 
@@ -491,28 +496,28 @@ public struct AnyLayerTangentVector<F: FloatingPoint & ElementaryFunctions>: Key
   /// Creates a type-erased wrapper from the given tangent vector.
   @differentiable
   public init<Underlying: TangentVectorConformances>(_ underlying: Underlying)
-  where Underlying.TangentVector == Underlying, Underlying.VectorSpaceScalar == F {
-    self.box = ConcreteAnyLayerTangentVectorBox<Underlying>(underlying)
+  where Underlying.TangentVector == Underlying, Underlying.VectorSpaceScalar == Float {
+    self.box = ConcreteAnyLayerTangentVectorBox(underlying)
   }
 
   @derivative(of: init)
   @usableFromInline
   internal static func _vjpInit<Underlying: TangentVectorConformances>(
     _ underlying: Underlying
-  ) -> (value: AnyLayerTangentVector<F>, pullback: (AnyLayerTangentVector<F>) -> Underlying.TangentVector)
-    where Underlying.TangentVector == Underlying, Underlying.VectorSpaceScalar == F
+  ) -> (value: AnyLayerTangentVector, pullback: (AnyLayerTangentVector) -> Underlying.TangentVector)
+    where Underlying.TangentVector == Underlying, Underlying.VectorSpaceScalar == Float
   {
-    return (AnyLayerTangentVector<F>(underlying), { v in v.unboxed(as: Underlying.TangentVector.self)! })
+    return (AnyLayerTangentVector(underlying), { v in v.unboxed(as: Underlying.TangentVector.self)! })
   }
 
   @derivative(of: init)
   @usableFromInline
   internal static func _jvpInit<Underlying: TangentVectorConformances>(
     _ underlying: Underlying
-  ) -> (value: AnyLayerTangentVector<F>, differential: (Underlying.TangentVector) -> AnyLayerTangentVector<F>)
-    where Underlying.TangentVector == Underlying, Underlying.VectorSpaceScalar == F
+  ) -> (value: AnyLayerTangentVector, differential: (Underlying.TangentVector) -> AnyLayerTangentVector)
+    where Underlying.TangentVector == Underlying, Underlying.VectorSpaceScalar == Float
   {
-    return (AnyLayerTangentVector<F>(underlying), { dbase in AnyLayerTangentVector<F>(dbase) })
+    return (AnyLayerTangentVector(underlying), { dbase in AnyLayerTangentVector(dbase) })
   }
 
   public typealias TangentVector = AnyLayerTangentVector
@@ -525,35 +530,35 @@ public struct AnyLayerTangentVector<F: FloatingPoint & ElementaryFunctions>: Key
   @frozen
   @usableFromInline
   internal struct OpaqueScalar: TangentVectorConformances {
-    @usableFromInline typealias VectorSpaceScalar = F
-    let value: F
+    @usableFromInline typealias VectorSpaceScalar = Float
+    let value: Float
 
     @usableFromInline typealias TangentVector = OpaqueScalar
 
-    init(_ value: F) {
+    init(_ value: Float) {
       self.value = value
     }
 
     // `VectorProtocol` requirements.
-    @usableFromInline func adding(_ x: F) -> OpaqueScalar {
+    @usableFromInline func adding(_ x: Float) -> OpaqueScalar {
       return OpaqueScalar(value + x)
     }
 
-    @usableFromInline func subtracting(_ x: F) -> OpaqueScalar {
+    @usableFromInline func subtracting(_ x: Float) -> OpaqueScalar {
       return OpaqueScalar(value - x)
     }
 
-    @usableFromInline func scaled(by: F) -> OpaqueScalar {
+    @usableFromInline func scaled(by: Float) -> OpaqueScalar {
       return OpaqueScalar(value * by)
     }
 
     // `PointwiseMultiplicative` requirements.
     @usableFromInline static var one: OpaqueScalar {
-      return OpaqueScalar(F(1))
+      return OpaqueScalar(Float(1))
     }
 
     @usableFromInline var reciprocal: OpaqueScalar {
-      return OpaqueScalar(F(1) / value)
+      return OpaqueScalar(Float(1) / value)
     }
 
     @usableFromInline static func .* (lhs: OpaqueScalar, rhs: OpaqueScalar) -> OpaqueScalar {
@@ -562,99 +567,86 @@ public struct AnyLayerTangentVector<F: FloatingPoint & ElementaryFunctions>: Key
 
     // `ElementaryFunctions` requirements.
     @usableFromInline static func sqrt(_ x: OpaqueScalar) -> OpaqueScalar {
-      return OpaqueScalar(F.sqrt(x.value))
+      return OpaqueScalar(Float.sqrt(x.value))
     }
 
     @usableFromInline static func cos(_ x: OpaqueScalar) -> OpaqueScalar {
-      return OpaqueScalar(F.cos(x.value))
+      return OpaqueScalar(Float.cos(x.value))
     }
 
     @usableFromInline static func sin(_ x: OpaqueScalar) -> OpaqueScalar {
-      return OpaqueScalar(F.sin(x.value))
+      return OpaqueScalar(Float.sin(x.value))
     }
 
     @usableFromInline static func tan(_ x: OpaqueScalar) -> OpaqueScalar {
-      return OpaqueScalar(F.tan(x.value))
+      return OpaqueScalar(Float.tan(x.value))
     }
 
     @usableFromInline static func acos(_ x: OpaqueScalar) -> OpaqueScalar {
-      return OpaqueScalar(F.acos(x.value))
+      return OpaqueScalar(Float.acos(x.value))
     }
 
     @usableFromInline static func asin(_ x: OpaqueScalar) -> OpaqueScalar {
-      return OpaqueScalar(F.asin(x.value))
+      return OpaqueScalar(Float.asin(x.value))
     }
 
     @usableFromInline static func atan(_ x: OpaqueScalar) -> OpaqueScalar {
-      return OpaqueScalar(F.atan(x.value))
+      return OpaqueScalar(Float.atan(x.value))
     }
 
     @usableFromInline static func cosh(_ x: OpaqueScalar) -> OpaqueScalar {
-      return OpaqueScalar(F.cosh(x.value))
+      return OpaqueScalar(Float.cosh(x.value))
     }
 
     @usableFromInline static func sinh(_ x: OpaqueScalar) -> OpaqueScalar {
-      return OpaqueScalar(F.sinh(x.value))
+      return OpaqueScalar(Float.sinh(x.value))
     }
 
     @usableFromInline static func tanh(_ x: OpaqueScalar) -> OpaqueScalar {
-      return OpaqueScalar(F.tanh(x.value))
+      return OpaqueScalar(Float.tanh(x.value))
     }
 
     @usableFromInline static func acosh(_ x: OpaqueScalar) -> OpaqueScalar {
-      return OpaqueScalar(F.acosh(x.value))
+      return OpaqueScalar(Float.acosh(x.value))
     }
 
     @usableFromInline static func asinh(_ x: OpaqueScalar) -> OpaqueScalar {
-      return OpaqueScalar(F.asinh(x.value))
+      return OpaqueScalar(Float.asinh(x.value))
     }
 
     @usableFromInline static func atanh(_ x: OpaqueScalar) -> OpaqueScalar {
-      return OpaqueScalar(F.atanh(x.value))
+      return OpaqueScalar(Float.atanh(x.value))
     }
 
     @usableFromInline static func exp(_ x: OpaqueScalar) -> OpaqueScalar {
-      return OpaqueScalar(F.exp(x.value))
+      return OpaqueScalar(Float.exp(x.value))
     }
 
-    @usableFromInline static func exp2(_ x: OpaqueScalar) -> OpaqueScalar {
-      return OpaqueScalar(F.exp2(x.value))
+    #if TENSORFLOW_USE_STANDARD_TOOLCHAIN
+    @usableFromInline static func expMinusOne(_ x: OpaqueScalar) -> OpaqueScalar {
+      return OpaqueScalar(Float.expMinusOne(x.value))
     }
 
-    @usableFromInline static func exp10(_ x: OpaqueScalar) -> OpaqueScalar {
-      return OpaqueScalar(F.exp10(x.value))
+    @usableFromInline static func log(onePlus x: OpaqueScalar) -> OpaqueScalar {
+      return OpaqueScalar(Float.log(onePlus: x.value))
     }
-
-    @usableFromInline static func expm1(_ x: OpaqueScalar) -> OpaqueScalar {
-      return OpaqueScalar(F.expm1(x.value))
-    }
+    #else
+    #endif
 
     @usableFromInline static func log(_ x: OpaqueScalar) -> OpaqueScalar {
-      return OpaqueScalar(F.log(x.value))
-    }
-
-    @usableFromInline static func log2(_ x: OpaqueScalar) -> OpaqueScalar {
-      return OpaqueScalar(F.log2(x.value))
-    }
-
-    @usableFromInline static func log10(_ x: OpaqueScalar) -> OpaqueScalar {
-      return OpaqueScalar(F.log10(x.value))
-    }
-
-    @usableFromInline static func log1p(_ x: OpaqueScalar) -> OpaqueScalar {
-      return OpaqueScalar(F.log1p(x.value))
+      return OpaqueScalar(Float.log(x.value))
     }
 
     @usableFromInline static func pow(_ x: OpaqueScalar, _ y: OpaqueScalar) -> OpaqueScalar {
-      return OpaqueScalar(F.pow(x.value, y.value))
+      return OpaqueScalar(Float.pow(x.value, y.value))
     }
 
     @usableFromInline static func pow(_ x: OpaqueScalar, _ n: Int) -> OpaqueScalar {
-      return OpaqueScalar(F.pow(x.value, n))
+      return OpaqueScalar(Float.pow(x.value, n))
     }
 
     @usableFromInline static func root(_ x: OpaqueScalar, _ n: Int) -> OpaqueScalar {
-      return OpaqueScalar(F.root(x.value, n))
+      return OpaqueScalar(Float.root(x.value, n))
     }
   }
 }
@@ -737,7 +729,7 @@ extension AnyLayerTangentVector: AdditiveArithmetic {
 }
 
 extension AnyLayerTangentVector: VectorProtocol {
-  public typealias VectorSpaceScalar = F
+  public typealias VectorSpaceScalar = Float
 
   public func adding(_ x: VectorSpaceScalar) -> Self {
     return .init(box: box._adding(x));
@@ -809,6 +801,14 @@ extension AnyLayerTangentVector: ElementaryFunctions {
   public static func exp(_ x: Self) -> Self {
     return .init(box: x.box._exp())
   }
+  #if TENSORFLOW_USE_STANDARD_TOOLCHAIN
+  public static func expMinusOne(_ x: Self) -> Self {
+    return .init(box: x.box._expMinusOne())
+  }
+  public static func log(onePlus x: Self) -> Self {
+    return .init(box: x.box._log1p())
+  }
+  #else
   public static func exp2(_ x: Self) -> Self {
     return .init(box: x.box._exp2())
   }
@@ -818,9 +818,6 @@ extension AnyLayerTangentVector: ElementaryFunctions {
   public static func expm1(_ x: Self) -> Self {
     return .init(box: x.box._expm1())
   }
-  public static func log(_ x: Self) -> Self {
-    return .init(box: x.box._log())
-  }
   public static func log2(_ x: Self) -> Self {
     return .init(box: x.box._log2())
   }
@@ -829,6 +826,10 @@ extension AnyLayerTangentVector: ElementaryFunctions {
   }
   public static func log1p(_ x: Self) -> Self {
     return .init(box: x.box._log1p())
+  }
+  #endif
+  public static func log(_ x: Self) -> Self {
+    return .init(box: x.box._log())
   }
   public static func pow(_ x: Self, _ y: Self) -> Self {
     return .init(box: x.box._pow(y.box))
@@ -840,4 +841,3 @@ extension AnyLayerTangentVector: ElementaryFunctions {
     return .init(box: x.box._root(n))
   }
 }
-#endif

--- a/Support/AnyLayerTangentVector.swift
+++ b/Support/AnyLayerTangentVector.swift
@@ -188,12 +188,11 @@ internal class AnyLayerTangentVectorBox {
     mustOverride()
   }
   
-  #if TENSORFLOW_USE_STANDARD_TOOLCHAIN
   /// The expMinusOne function.
   func _expMinusOne() -> AnyLayerTangentVectorBox {
     mustOverride()
   }
-  #else    
+
   /// The exp10 function.
   func _exp10() -> AnyLayerTangentVectorBox {
     mustOverride()
@@ -218,7 +217,6 @@ internal class AnyLayerTangentVectorBox {
   func _log10() -> AnyLayerTangentVectorBox {
     mustOverride()
   }
-  #endif
   
   /// The log function.
   func _log() -> AnyLayerTangentVectorBox {
@@ -414,24 +412,27 @@ where Underlying.TangentVector == Underlying, Underlying.VectorSpaceScalar == Fl
   override func _exp() -> AnyLayerTangentVectorBox {
     return ConcreteAnyLayerTangentVectorBox(Underlying.exp(underlying));
   }
-  #if TENSORFLOW_USE_STANDARD_TOOLCHAIN
   override func _expMinusOne() -> AnyLayerTangentVectorBox {
-    return ConcreteAnyLayerTangentVectorBox(Underlying.expMinusOne(underlying));
+    // TODO: Re-enable this once we have settled on a single toolchain.
+    fatalError("expMinusOne() is currently unimplemented for this toolchain.")
+//    return ConcreteAnyLayerTangentVectorBox(Underlying.expMinusOne(underlying));
   }
   override func _log1p() -> AnyLayerTangentVectorBox {
-    return ConcreteAnyLayerTangentVectorBox(Underlying.log(onePlus: underlying));
+    // TODO: Re-enable this once we have settled on a single toolchain.
+    fatalError("log1p() is currently unimplemented for this toolchain.")
+    // return ConcreteAnyLayerTangentVectorBox(Underlying.log(onePlus: underlying));
+    // return ConcreteAnyLayerTangentVectorBox(Underlying.log1p(underlying));
   }
-  #else
   override func _exp2() -> AnyLayerTangentVectorBox {
-    return ConcreteAnyLayerTangentVectorBox(Underlying.exp2(underlying));
+    // TODO: Re-enable this once we have settled on a single toolchain.
+    fatalError("exp2() is currently unimplemented for this toolchain.")
+    // return ConcreteAnyLayerTangentVectorBox(Underlying.exp2(underlying));
   }
   override func _exp10() -> AnyLayerTangentVectorBox {
-    return ConcreteAnyLayerTangentVectorBox(Underlying.exp10(underlying));
+    // TODO: Re-enable this once we have settled on a single toolchain.
+    fatalError("exp10() is currently unimplemented for this toolchain.")
+    // return ConcreteAnyLayerTangentVectorBox(Underlying.exp10(underlying));
   }
-  override func _log1p() -> AnyLayerTangentVectorBox {
-    return ConcreteAnyLayerTangentVectorBox(Underlying.log1p(underlying));
-  }
-  #endif
   override func _log() -> AnyLayerTangentVectorBox {
     return ConcreteAnyLayerTangentVectorBox(Underlying.log(underlying));
   }
@@ -622,16 +623,17 @@ public struct AnyLayerTangentVector: KeyPathIterable {
       return OpaqueScalar(Float.exp(x.value))
     }
 
-    #if TENSORFLOW_USE_STANDARD_TOOLCHAIN
     @usableFromInline static func expMinusOne(_ x: OpaqueScalar) -> OpaqueScalar {
-      return OpaqueScalar(Float.expMinusOne(x.value))
+      // TODO: Re-enable this once we have settled on a single toolchain.
+      fatalError("expMinusOne() is currently unimplemented for this toolchain.")
+      // return OpaqueScalar(Float.expMinusOne(x.value))
     }
 
     @usableFromInline static func log(onePlus x: OpaqueScalar) -> OpaqueScalar {
-      return OpaqueScalar(Float.log(onePlus: x.value))
+      // TODO: Re-enable this once we have settled on a single toolchain.
+      fatalError("log(onePlus:) is currently unimplemented for this toolchain.")
+      // return OpaqueScalar(Float.log(onePlus: x.value))
     }
-    #else
-    #endif
 
     @usableFromInline static func log(_ x: OpaqueScalar) -> OpaqueScalar {
       return OpaqueScalar(Float.log(x.value))
@@ -801,14 +803,12 @@ extension AnyLayerTangentVector: ElementaryFunctions {
   public static func exp(_ x: Self) -> Self {
     return .init(box: x.box._exp())
   }
-  #if TENSORFLOW_USE_STANDARD_TOOLCHAIN
   public static func expMinusOne(_ x: Self) -> Self {
     return .init(box: x.box._expMinusOne())
   }
   public static func log(onePlus x: Self) -> Self {
     return .init(box: x.box._log1p())
   }
-  #else
   public static func exp2(_ x: Self) -> Self {
     return .init(box: x.box._exp2())
   }
@@ -827,7 +827,6 @@ extension AnyLayerTangentVector: ElementaryFunctions {
   public static func log1p(_ x: Self) -> Self {
     return .init(box: x.box._log1p())
   }
-  #endif
   public static func log(_ x: Self) -> Self {
     return .init(box: x.box._log())
   }

--- a/Support/CMakeLists.txt
+++ b/Support/CMakeLists.txt
@@ -20,8 +20,6 @@ add_library(ModelSupport
   Text/WordSeg/Lexicon.swift)
 set_target_properties(ModelSupport PROPERTIES
   INTERFACE_INCLUDE_DIRECTORIES ${CMAKE_Swift_MODULE_DIRECTORY})
-target_compile_definitions(ModelSupport PRIVATE
-  $<$<BOOL:${TENSORFLOW_USE_STANDARD_TOOLCHAIN}>:TENSORFLOW_USE_STANDARD_TOOLCHAIN>)
 target_compile_options(ModelSupport PRIVATE
   $<$<BOOL:${BUILD_TESTING}>:-enable-testing>)
 target_link_libraries(ModelSupport PUBLIC


### PR DESCRIPTION
AnyLayer can now build using both the stock (+swift-apis) and current Swift for TensorFlow toolchains, so the define-based conditionals have been removed. This also removes the need for explicit Numerics imports, due to Numerics now being exported from swift-apis.

Due to slight differences in ElementaryFunctions, I've temporarily disabled a handful of exponential and logarithm variants within AnyLayer (which weren't being used for anything currently, anyways).

With these changes, swift-models can now build without any extra compiler flags for both the current Swift for TensorFlow toolchains and the new stock (+swift-apis) toolchains.