### PR TITLE
Add tensorflow/swift-apis as a SwiftPM dependency.

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -27,25 +27,39 @@ let package = Package(
         .package(url: "https://github.com/apple/swift-protobuf.git", from: "1.10.0"),
         .package(url: "https://github.com/apple/swift-argument-parser", .branch("main")),
         .package(url: "https://github.com/google/swift-benchmark", from: "0.1.0"),
+        .package(url: "https://github.com/tensorflow/swift-apis", .branch("main")),
     ],
     targets: [
         .target(
-            name: "Checkpoints", dependencies: ["SwiftProtobuf", "ModelSupport"],
+            name: "Checkpoints", dependencies: ["TensorFlow", "SwiftProtobuf", "ModelSupport"],
             path: "Checkpoints"),
-        .target(name: "Datasets", dependencies: ["ModelSupport"], path: "Datasets"),
+        .target(name: "Datasets", dependencies: ["TensorFlow", "ModelSupport"], path: "Datasets"),
         .target(name: "STBImage", path: "Support/STBImage"),
         .target(
-            name: "ModelSupport", dependencies: ["STBImage"], path: "Support", exclude: ["STBImage"]),
-        .target(name: "TensorBoard", dependencies: ["SwiftProtobuf", "ModelSupport", "TrainingLoop"], path: "TensorBoard"),
-        .target(name: "ImageClassificationModels", path: "Models/ImageClassification"),
-        .target(name: "VideoClassificationModels", path: "Models/Spatiotemporal"),
-        .target(name: "TextModels",
+            name: "ModelSupport", dependencies: ["TensorFlow", "STBImage"], path: "Support",
+            exclude: ["STBImage"]),
+        .target(
+            name: "TensorBoard",
+            dependencies: ["TensorFlow", "SwiftProtobuf", "ModelSupport", "TrainingLoop"],
+            path: "TensorBoard"),
+        .target(
+            name: "ImageClassificationModels", dependencies: ["TensorFlow"],
+            path: "Models/ImageClassification"),
+        .target(
+            name: "VideoClassificationModels", dependencies: ["TensorFlow"],
+            path: "Models/Spatiotemporal"
+        ),
+        .target(
+            name: "TextModels",
             dependencies: ["Checkpoints", "Datasets", "SwiftProtobuf"],
             path: "Models/Text"),
-        .target(name: "RecommendationModels", path: "Models/Recommendation"),
+        .target(
+            name: "RecommendationModels", dependencies: ["TensorFlow"],
+            path: "Models/Recommendation"),
         .target(name: "TrainingLoop", dependencies: ["ModelSupport"], path: "TrainingLoop"),
         .target(
-            name: "Autoencoder1D", dependencies: ["Datasets", "ModelSupport", "TrainingLoop", "AutoencoderCallback"],
+            name: "Autoencoder1D",
+            dependencies: ["Datasets", "ModelSupport", "TrainingLoop", "AutoencoderCallback"],
             path: "Autoencoder/Autoencoder1D"),
         .target(
             name: "Autoencoder2D", dependencies: ["Datasets", "ModelSupport"],
@@ -56,15 +70,15 @@ let package = Package(
         .target(
             name: "AutoencoderCallback", dependencies: ["ModelSupport", "TrainingLoop"],
             path: "Autoencoder/Callback"),
-        .target(name: "Catch", path: "Catch"),
-        .target(name: "Gym-FrozenLake", path: "Gym/FrozenLake"),
-        .target(name: "Gym-CartPole", path: "Gym/CartPole"),
-        .target(name: "Gym-Blackjack", path: "Gym/Blackjack"),
-        .target(name: "Gym-DQN", path: "Gym/DQN"),
-        .target(name: "Gym-PPO", path: "Gym/PPO"),
+        .target(name: "Catch", dependencies: ["TensorFlow"], path: "Catch"),
+        .target(name: "Gym-FrozenLake", dependencies: ["TensorFlow"], path: "Gym/FrozenLake"),
+        .target(name: "Gym-CartPole", dependencies: ["TensorFlow"], path: "Gym/CartPole"),
+        .target(name: "Gym-Blackjack", dependencies: ["TensorFlow"], path: "Gym/Blackjack"),
+        .target(name: "Gym-DQN", dependencies: ["TensorFlow"], path: "Gym/DQN"),
+        .target(name: "Gym-PPO", dependencies: ["TensorFlow"], path: "Gym/PPO"),
         .target(
             name: "VGG-Imagewoof",
-            dependencies: ["Datasets", "ImageClassificationModels", "TrainingLoop"],
+            dependencies: ["TensorFlow", "Datasets", "ImageClassificationModels", "TrainingLoop"],
             path: "Examples/VGG-Imagewoof"),
         .target(
             name: "Regression-BostonHousing", dependencies: ["Datasets"],
@@ -97,7 +111,11 @@ let package = Package(
             dependencies: ["Datasets", "ImageClassificationModels", "TrainingLoop", "TensorBoard"],
             path: "Examples/ResNet50-ImageNet"),
         .target(
-            name: "PersonLab", dependencies: ["Checkpoints", "ModelSupport", .product(name: "ArgumentParser", package: "swift-argument-parser")],
+            name: "PersonLab",
+            dependencies: [
+                "Checkpoints", "ModelSupport",
+                .product(name: "ArgumentParser", package: "swift-argument-parser"),
+            ],
             path: "PersonLab"),
         .target(
             name: "MiniGo", dependencies: ["Checkpoints"], path: "MiniGo", exclude: ["main.swift"]),
@@ -134,7 +152,7 @@ let package = Package(
             name: "SwiftModelsBenchmarksCore",
             dependencies: [
                 "Datasets", "ModelSupport", "ImageClassificationModels", "ArgumentParser",
-                "TextModels", "Benchmark"
+                "TextModels", "Benchmark",
             ],
             path: "SwiftModelsBenchmarksCore"),
         .target(
@@ -144,7 +162,9 @@ let package = Package(
         ),
         .testTarget(name: "CheckpointTests", dependencies: ["Checkpoints"]),
         .target(
-            name: "BERT-CoLA", dependencies: ["TextModels", "Datasets", "TrainingLoop"], path: "Examples/BERT-CoLA"),
+            name: "BERT-CoLA",
+            dependencies: ["x10_optimizers_optimizer", "TextModels", "Datasets", "TrainingLoop"],
+            path: "Examples/BERT-CoLA"),
         .testTarget(name: "SupportTests", dependencies: ["ModelSupport"]),
         .target(
             name: "CycleGAN",
@@ -161,15 +181,15 @@ let package = Package(
             dependencies: ["ArgumentParser", "Datasets", "ModelSupport", "TextModels"],
             path: "Examples/WordSeg"
         ),
-       .target(
-           name: "Fractals",
-           dependencies: ["ArgumentParser", "ModelSupport"],
-           path: "Examples/Fractals"
-       ),
-       .target(
-           name: "GrowingNeuralCellularAutomata",
-           dependencies: ["ArgumentParser", "ModelSupport"],
-           path: "Examples/GrowingNeuralCellularAutomata"
-       )
+        .target(
+            name: "Fractals",
+            dependencies: ["ArgumentParser", "ModelSupport"],
+            path: "Examples/Fractals"
+        ),
+        .target(
+            name: "GrowingNeuralCellularAutomata",
+            dependencies: ["ArgumentParser", "ModelSupport"],
+            path: "Examples/GrowingNeuralCellularAutomata"
+        ),
     ]
 )


### PR DESCRIPTION
## Context

This enables building `tensorflow/swift-models` using stock toolchains from [swift.org/download](https://swift.org/download/#snapshots).

## Build instructions

It is possible to build `tensorflow/swift-apis` and dependencies like `tensorflow/swift-models` using stock toolchains by installing [pre-built X10 libraries](https://github.com/tensorflow/swift-apis/blob/main/Documentation/Development.md#option-2-use-a-prebuilt-version-of-x10-1) (currently available only for macOS and Windows).

After installing (e.g. to `$HOME/Library` on macOS), build with SwiftPM via the following:

```console
$ swift build -Xcc -I$HOME/Library/tensorflow-2.4.0/usr/include -Xlinker -L$HOME/Library/tensorflow-2.4.0/usr/lib -Xswiftc -DTENSORFLOW_USE_STANDARD_TOOLCHAIN
```

`swift test` is known not to work on macOS for `tensorflow/swift-apis` and dependencies due to SR-14008: `Library not loaded: /usr/lib/swift/libswift_Differentiation.dylib`.


## Testing

Before merging, let's verify that the following command works for [swift.org/download](https://swift.org/download/#snapshots) toolchains across platforms:

- [x] macOS: [swift-DEVELOPMENT-SNAPSHOT-2021-01-04-a-osx.pkg](https://swift.org/builds/development/xcode/swift-DEVELOPMENT-SNAPSHOT-2021-01-04-a/swift-DEVELOPMENT-SNAPSHOT-2021-01-04-a-osx.pkg)
- [ ] Ubuntu 18.04: [swift-DEVELOPMENT-SNAPSHOT-2021-01-04-a-ubuntu18.04.tar.gz](https://swift.org/builds/development/ubuntu1804/swift-DEVELOPMENT-SNAPSHOT-2021-01-04-a/swift-DEVELOPMENT-SNAPSHOT-2021-01-04-a-ubuntu18.04.tar.gz)
- [ ] Windows 10: [swift-DEVELOPMENT-SNAPSHOT-2021-01-04-a-windows10.exe](swift-DEVELOPMENT-SNAPSHOT-2021-01-04-a-windows10.exe)