### PR TITLE
Moving GPT-2 checkpoint location to its new host

### DIFF
--- a/Models/Text/GPT2/GPT2.swift
+++ b/Models/Text/GPT2/GPT2.swift
@@ -19,7 +19,7 @@ import TensorFlow
 
 public class GPT2 {
     public static let remoteCheckpoint: URL =
-        URL(string: "https://storage.googleapis.com/gpt-2/models/117M/model.ckpt")!
+        URL(string: "https://openaipublic.blob.core.windows.net/gpt-2/models/117M/model.ckpt")!
 
     public enum GPT2Error: Error {
         case invalidEncoding(id: Int32)


### PR DESCRIPTION
OpenAI migrated their hosting to Azure, so this updates the default GPT-2 checkpoint location to where it now resides. This fixes the few failing tests we are experiencing as a result of this move.