### PR TITLE
Repairing CMakeLists for pix2pix

### DIFF
--- a/pix2pix/CMakeLists.txt
+++ b/pix2pix/CMakeLists.txt
@@ -1,12 +1,12 @@
 add_library(pix2pix
-  pix2pix/CheckpointWriter.swift
-  pix2pix/CLI.swift
-  pix2pix/Dataset.swift
-  pix2pix/Discriminator.swift
-  pix2pix/Generator.swift
-  pix2pix/Layers.swift
-  pix2pix/Utils.swift
-  pix2pix/CheckpointReader.swift)
+  CheckpointReader.swift
+  CheckpointWriter.swift
+  CLI.swift
+  Dataset.swift
+  Discriminator.swift
+  Generator.swift
+  Layers.swift
+  Utils.swift)
   
 set_target_properties(pix2pix PROPERTIES
   INTERFACE_INCLUDE_DIRECTORIES ${CMAKE_Swift_MODULE_DIRECTORY})
@@ -15,7 +15,10 @@ target_compile_options(pix2pix PRIVATE
   $<$<BOOL:${BUILD_TESTING}>:-enable-testing>)
   
 target_link_libraries(pix2pix PRIVATE
-  pix2pix)
+  ArgumentParser
+  Checkpoints
+  Datasets
+  ModelSupport)
 
 add_executable(pix2pixDemo
   main.swift)
@@ -30,7 +33,7 @@ install(TARGETS pix2pixDemo
   DESTINATION bin)
 get_swift_host_arch(swift_arch)
 install(FILES
-  $<TARGET_PROPERTY:pix2ix,Swift_MODULE_DIRECTORY>/pix2pix.swiftdoc
+  $<TARGET_PROPERTY:pix2pix,Swift_MODULE_DIRECTORY>/pix2pix.swiftdoc
   $<TARGET_PROPERTY:pix2pix,Swift_MODULE_DIRECTORY>/pix2pix.swiftmodule
   DESTINATION lib/swift$<$<NOT:$<BOOL:${BUILD_SHARED_LIBS}>>:_static>/$<LOWER_CASE:${CMAKE_SYSTEM_NAME}>/${swift_arch})
 


### PR DESCRIPTION
This is a quick fix to get the pix2pix CMake target building again.