### PR TITLE
Work around intermittent toolchain download failures

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -5,8 +5,8 @@ ARG swift_tf_url=https://storage.googleapis.com/swift-tensorflow-artifacts/night
 
 # Download and extract S4TF
 WORKDIR /swift-tensorflow-toolchain
-RUN if ! curl -fSsL --retry 5 $swift_tf_url -o swift.tar.gz; \
-    then sleep 30 && curl -fSsL --retry 5 $swift_tf_url -o swift.tar.gz; \
+RUN if ! curl -fSsL --http1.1 --retry 5 $swift_tf_url -o swift.tar.gz; \
+    then sleep 30 && curl -fSsL --http1.1 --retry 5 $swift_tf_url -o swift.tar.gz; \
     fi;
 
 RUN mkdir usr \


### PR DESCRIPTION
HTTP2 curl downloads are intermittently failing on GCS buckets, so this forces HTTP 1.1 usage with the toolchain downloads to unblock CI.